### PR TITLE
Latex

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Output comments for 'repeat' when iogroup is true (issue#130)
 
 Fix crash in doc generation for nested repeat (github issue#4)
 
+Add support for Latex generation
+
 ## Version 1.5
 
 Fix a crash when address lines are not used by cernbus (issue#95)

--- a/doc/cheby-ug.txt
+++ b/doc/cheby-ug.txt
@@ -58,7 +58,7 @@ generate:
 * C headers
 * Device drivers
 * HDL code
-* HTML documentation
+* HTML, markdown, and Latex documentation
 
 The automatic generation of these files avoid a tedious work and ensure
 coherency between them.
@@ -747,14 +747,17 @@ as the layout seen by Cheby.  This can be used as a consistency check.
 
 === Generating documentation
 
-Documentation can be generated either in HTML or in markdown (tested with
+Documentation can be generated either in HTML, Latex, or in markdown (tested with
 asciidoctor).  The format is specified by the `--doc=FORMAT` flag and the
-format is either `html` or `md`.
+format is either `html`, `latex`, or `md`.
 
 [source]
 ----
   $ cheby --doc=md --gen-doc=OUTPUT.md -i INPUT.cheby
 ----
+
+The generated Latex file is meant to be included from a main file. An example
+for such a file is provided at `doc/srcs/main.tex`.
 
 === Generating constants file
 

--- a/doc/srcs/main.tex
+++ b/doc/srcs/main.tex
@@ -1,0 +1,85 @@
+% Template for a document containing a cheby register file description
+%
+% This file is meant to contain the style definition, which can be changed
+% without modifying the automatically generated .tex file. Tabularray is used
+% to achieve dynamic compatibility with different page layouts.
+
+% Document set up (up to user preference)
+\documentclass{article}
+\usepackage[margin=25mm]{geometry}
+\usepackage[english]{babel}
+
+% Use sans serif font
+\usepackage{helvet}
+\renewcommand{\familydefault}{\sfdefault}
+
+% Required packages
+\usepackage{tabularray}
+\usepackage[colorlinks=true,linkcolor=blue]{hyperref}
+\usepackage{xcolor}
+
+% Memory Map
+\newenvironment{memmap}{
+  \vspace{5mm}
+  \centering
+  \begin{longtblr}{
+    width    = \textwidth,
+    hline{1} = {1pt},
+    hline{2} = {0.5pt},
+    hline{Z} = {1pt},
+    colspec  = {X[1.5] X[1] X[3] X[3]},
+  }
+  HW address & Type & Name & HDL name \\
+}{
+  \end{longtblr}
+}
+
+% Register Summary
+\newenvironment{regsummary}{
+  \centering
+  \begin{tblr}{
+    width    = \textwidth,
+    colspec  = {X[1] X[4]},
+  }
+}{
+  \end{tblr}
+}
+
+% Register Drawing
+\newenvironment{regdraw}{
+  \vspace{5mm}
+  \begin{center}
+  \begin{tblr}{
+    width    = \textwidth,
+    hlines,
+    vlines,
+    colspec  = {X[1,c] X[1,c] X[1,c] X[1,c] X[1,c] X[1,c] X[1,c] X[1,c]},
+    row{odd} = {font=\footnotesize}
+  }
+}{
+  \end{tblr}
+  \end{center}
+}
+
+% Register Description
+\newenvironment{regdesc}{
+  \vspace{5mm}
+  \centering
+  \begin{tblr}{
+    width    = \textwidth,
+    hline{1} = {1pt},
+    hline{2} = {0.5pt},
+    hline{Z} = {1pt},
+    colspec  = {X[1] X[1] X[2] X[7]},
+  }
+  Bits & R/W & Name & Description \\
+}{
+  \end{tblr}
+}
+
+\begin{document}
+
+% Include the automatically generated .tex file here
+\input{reg.tex}
+
+\end{document}

--- a/proto/cheby/main.py
+++ b/proto/cheby/main.py
@@ -26,6 +26,7 @@ import cheby.gen_wbgen_hdl as gen_wbgen_hdl
 import cheby.print_html as print_html
 import cheby.print_markdown as print_markdown
 import cheby.print_rest as print_rest
+import cheby.print_latex as print_latex
 import cheby.print_consts as print_consts
 import cheby.gen_devicetree as gen_devicetree
 import cheby.gen_device_script as gen_device_script
@@ -102,12 +103,14 @@ def decode_args():
     # default doesn't work - conflict with store_const of --no-header ?
     aparser.add_argument('--header', choices=['none', 'full', 'commit'],
                          help='set comment header generation')
-    aparser.add_argument('--doc', choices=['html', 'md', 'rest'], default='html',
+    aparser.add_argument('--doc', choices=['html', 'md', 'rest', 'latex'], default='html',
                          help='select language for doc generation')
     aparser.add_argument('--gen-doc', nargs='?', const='-',
                          help='generate documentation')
     aparser.add_argument('--rest-headers', default='#=-',
                          help='Ordered set of characters to be used for ReST heading levels')
+    aparser.add_argument('--doc-no-reg-drawing', help='Disable generation of register drawings in documentation', 
+                         action='store_true')
     aparser.add_argument('--input', '-i',
                          help='input file')
     aparser.add_argument('--ff-reset', choices=['sync', 'async'], default='sync',
@@ -288,6 +291,8 @@ def handle_file(args, filename):
                 print_markdown.print_markdown(f, t)
             elif args.doc == 'rest':
                 print_rest.print_rest(f, t, args.rest_headers)
+            elif args.doc == 'latex':
+                print_latex.print_latex(f, t, not args.doc_no_reg_drawing)
             else:
                 raise AssertionError('unknown doc format {}'.format(args.doc))
     if args.gen_consts is not None:

--- a/proto/cheby/print_latex.py
+++ b/proto/cheby/print_latex.py
@@ -1,0 +1,132 @@
+import cheby.tree as tree
+import cheby.gen_doc as gen_doc
+from cheby.wrutils import w, wln
+
+# Generate Latex Documentation
+#
+# Note: Python requires that '\' be escaped as '\\' and
+# curly brackes need to be repeated when using format(). 
+
+
+def escape_printable(field):
+    field = field.replace('_', '\\textunderscore\\allowbreak{}')
+    return field.replace('.', '.\\allowbreak{}')
+
+
+def print_reg(fd, r, raw, print_reg_drawing):
+
+    # Register Summary
+    wln(fd, "\\begin{regsummary}")
+    wln(fd, "HW Prefix & {}\\\\".format(escape_printable(r.c_name)))
+    wln(fd, "HW Address & 0x{:x}\\\\".format(raw.abs_addr))
+    wln(fd, "C Prefix & {}\\\\".format(escape_printable(raw.name)))
+    wln(fd, "C Block Offset & 0x{:x}\\\\".format(r.c_address))
+    wln(fd, "\\end{regsummary}\n")
+
+    # Drawing of contents
+    if print_reg_drawing:
+        descr = gen_doc.build_regdescr_table(r)
+        wln(fd, "\\begin{regdraw}")
+        for desc_raw in descr:
+            for i, col in enumerate(desc_raw):
+                style = ''
+                if col.style == 'field':
+                    style = 'bg=lightgray'
+                    
+                if col.colspan > 1:
+                    w(fd, "\\SetCell[c={}]{{c, {}}} ".format(col.colspan, style))
+                elif style != '':
+                    w(fd, "\\SetCell{{{}}} ".format(style))
+    
+                w(fd, "{} ".format(escape_printable(col.content)))
+                if i < len(desc_raw) - 1:
+                    w(fd, "& ")
+            wln(fd, '\\\\')
+        wln(fd, "\\end{regdraw}\n")
+
+    # Description of individual registers
+    wln(fd, "\\begin{regdesc}")
+    
+    for f in r.children:        
+        if r.has_fields():
+            desc_src = f
+        else:
+            desc_src = r
+        
+        # Bit range
+        if f.hi is not None:
+            w(fd, '{}:{} & '.format(f.hi, f.lo))
+        else:
+            w(fd, '{} & '.format(f.lo))
+            
+        # Access
+        w(fd, '{} & '.format(r.access or ''))
+        
+        # Name
+        w(fd, '{} & '.format(escape_printable(desc_src.name)))
+        
+        # Description + comment
+        desc_comment = desc_src.description or ''
+        if desc_src.comment is not None:
+            desc_comment = desc_comment + '' + desc_src.comment
+
+        w(fd, '{}'.format(escape_printable(desc_comment)))
+        wln(fd, '\\\\')
+    wln(fd, "\\end{regdesc}\n\n")
+
+
+def print_map_summary(fd, summary):
+    wln(fd, "\\begin{memmap}")
+    for r in summary.raws:
+        w(fd, "{} & ".format(r.address))
+        w(fd, "{} & ".format(r.typ))
+        if isinstance(r.node, tree.Reg):
+            w(fd, "\hyperref[sec:{}]{{{}}} & ".format(r.name, escape_printable(r.name)))
+        else:
+            w(fd, "{} & ".format(escape_printable(r.name)))
+        w(fd, "{}".format(escape_printable(r.node.c_name)))
+        wln(fd, '\\\\')
+    wln(fd, "\\end{memmap}")
+    wln(fd)
+
+
+def print_reg_description(fd, summary, print_reg_drawing):
+    for ra in summary.raws:
+        r = ra.node
+        if isinstance(r, tree.Reg):
+            wln(fd, "\\subsubsection{{{}}}".format(escape_printable(ra.name)))
+            wln(fd, '\\label{{sec:{}}}'.format(ra.name))
+            print_reg(fd, r, ra, print_reg_drawing)
+
+
+def print_root(fd, root, print_reg_drawing):
+    wln(fd, "\\section{Memory Map Summary}")
+    wln(fd, root.description or '(no description)')
+    wln(fd)
+    if root.version is not None:
+        wln(fd, "Version: {}".format(root.version))
+        wln(fd)
+
+    if root.c_address_spaces_map is None:
+        summary = gen_doc.MemmapSummary(root)
+        print_map_summary(fd, summary)
+        wln(fd, "\\section{Register Description}")
+        print_reg_description(fd, summary, print_reg_drawing)
+    else:
+        summaries = [(gen_doc.MemmapSummary(space), space) for space in root.children]
+        for summary, space in summaries:
+            wln(fd, "\\subsection{{For Space {}}}".format(escape_printable(space.name)))
+            print_map_summary(fd, summary)
+        for summary, space in summaries:
+            wln(fd, "\\subsection{{Register Description for Space {}}}".format(escape_printable(space.name)))
+            wln(fd)
+            print_reg_description(fd, summary, print_reg_drawing)
+
+
+def print_latex(fd, n, print_reg_drawing=True):
+    # Print latex documentation of root n to file descriptor fd
+    
+    if isinstance(n, tree.Root):
+        print_root(fd, n, print_reg_drawing)
+    else:
+        raise AssertionError

--- a/proto/tests.py
+++ b/proto/tests.py
@@ -23,6 +23,7 @@ import cheby.gen_wbgen_hdl as gen_wbgen_hdl
 import cheby.print_consts as print_consts
 import cheby.print_html as print_html
 import cheby.print_markdown as print_markdown
+import cheby.print_latex as print_latex
 import cheby.print_rest as print_rest
 import cheby.gen_custom as gen_custom
 
@@ -781,6 +782,7 @@ def test_doc():
         html_file = srcdir + f + '.html'
         md_file = srcdir + f + '.md'
         rst_file = srcdir + f + '.rst'
+        latex_file = srcdir + f + '.tex'
         t = parse_ok(cheby_file)
         layout_ok(t)
         expand_hdl.expand_hdl(t)
@@ -790,7 +792,8 @@ def test_doc():
         for file, pprint, style in [
                 (html_file, print_html.pprint, 'html'),
                 (md_file, print_markdown.print_markdown, 'md'),
-                (rst_file, print_rest.print_rest, 'rst')]:
+                (rst_file, print_rest.print_rest, 'rst'),
+                (latex_file, print_latex.print_latex, 'latex')]:
             buf = write_buffer()
             pprint(buf, t)
             if not compare_buffer_and_file(buf, file):

--- a/testfiles/features/semver1.tex
+++ b/testfiles/features/semver1.tex
@@ -1,0 +1,35 @@
+\section{Memory Map Summary}
+a single register
+
+Version: 1.0.0
+
+\begin{memmap}
+0x0 & REG & \hyperref[sec:r1]{r1} & r1\\
+\end{memmap}
+
+\section{Register Description}
+\subsubsection{r1}
+\label{sec:r1}
+\begin{regsummary}
+HW Prefix & r1\\
+HW Address & 0x0\\
+C Prefix & r1\\
+C Block Offset & 0x0\\
+\end{regsummary}
+
+\begin{regdraw}
+31 & 30 & 29 & 28 & 27 & 26 & 25 & 24 \\
+\SetCell[c=8]{c, bg=lightgray} r1[31:24] \\
+23 & 22 & 21 & 20 & 19 & 18 & 17 & 16 \\
+\SetCell[c=8]{c, bg=lightgray} r1[23:16] \\
+15 & 14 & 13 & 12 & 11 & 10 & 9 & 8 \\
+\SetCell[c=8]{c, bg=lightgray} r1[15:8] \\
+7 & 6 & 5 & 4 & 3 & 2 & 1 & 0 \\
+\SetCell[c=8]{c, bg=lightgray} r1[7:0] \\
+\end{regdraw}
+
+\begin{regdesc}
+31:0 & rw & r1 & \\
+\end{regdesc}
+
+

--- a/testfiles/issue67/repeatInRepeat.tex
+++ b/testfiles/issue67/repeatInRepeat.tex
@@ -1,0 +1,188 @@
+\section{Memory Map Summary}
+(no description)
+
+\begin{memmap}
+0x00-0x1f & BLOCK & repA & repA\\
+0x00-0x07 & BLOCK & repA.\allowbreak{}0 & repA\textunderscore\allowbreak{}0\\
+0x00-0x07 & BLOCK & repA.\allowbreak{}0.\allowbreak{}block1 & repA\textunderscore\allowbreak{}0\textunderscore\allowbreak{}block1\\
+0x00-0x07 & BLOCK & repA.\allowbreak{}0.\allowbreak{}block1.\allowbreak{}repB & repA\textunderscore\allowbreak{}0\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\\
+0x00-0x03 & BLOCK & repA.\allowbreak{}0.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}0 & repA\textunderscore\allowbreak{}0\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}0\\
+0x00 & REG & \hyperref[sec:repA.0.block1.repB.0.reg1]{repA.\allowbreak{}0.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}0.\allowbreak{}reg1} & repA\textunderscore\allowbreak{}0\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}0\textunderscore\allowbreak{}reg1\\
+0x04-0x07 & BLOCK & repA.\allowbreak{}0.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}1 & repA\textunderscore\allowbreak{}0\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}1\\
+0x04 & REG & \hyperref[sec:repA.0.block1.repB.1.reg1]{repA.\allowbreak{}0.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}1.\allowbreak{}reg1} & repA\textunderscore\allowbreak{}0\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}1\textunderscore\allowbreak{}reg1\\
+0x08-0x0f & BLOCK & repA.\allowbreak{}1 & repA\textunderscore\allowbreak{}1\\
+0x08-0x0f & BLOCK & repA.\allowbreak{}1.\allowbreak{}block1 & repA\textunderscore\allowbreak{}1\textunderscore\allowbreak{}block1\\
+0x08-0x0f & BLOCK & repA.\allowbreak{}1.\allowbreak{}block1.\allowbreak{}repB & repA\textunderscore\allowbreak{}1\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\\
+0x08-0x0b & BLOCK & repA.\allowbreak{}1.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}0 & repA\textunderscore\allowbreak{}1\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}0\\
+0x08 & REG & \hyperref[sec:repA.1.block1.repB.0.reg1]{repA.\allowbreak{}1.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}0.\allowbreak{}reg1} & repA\textunderscore\allowbreak{}1\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}0\textunderscore\allowbreak{}reg1\\
+0x0c-0x0f & BLOCK & repA.\allowbreak{}1.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}1 & repA\textunderscore\allowbreak{}1\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}1\\
+0x0c & REG & \hyperref[sec:repA.1.block1.repB.1.reg1]{repA.\allowbreak{}1.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}1.\allowbreak{}reg1} & repA\textunderscore\allowbreak{}1\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}1\textunderscore\allowbreak{}reg1\\
+0x10-0x17 & BLOCK & repA.\allowbreak{}2 & repA\textunderscore\allowbreak{}2\\
+0x10-0x17 & BLOCK & repA.\allowbreak{}2.\allowbreak{}block1 & repA\textunderscore\allowbreak{}2\textunderscore\allowbreak{}block1\\
+0x10-0x17 & BLOCK & repA.\allowbreak{}2.\allowbreak{}block1.\allowbreak{}repB & repA\textunderscore\allowbreak{}2\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\\
+0x10-0x13 & BLOCK & repA.\allowbreak{}2.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}0 & repA\textunderscore\allowbreak{}2\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}0\\
+0x10 & REG & \hyperref[sec:repA.2.block1.repB.0.reg1]{repA.\allowbreak{}2.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}0.\allowbreak{}reg1} & repA\textunderscore\allowbreak{}2\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}0\textunderscore\allowbreak{}reg1\\
+0x14-0x17 & BLOCK & repA.\allowbreak{}2.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}1 & repA\textunderscore\allowbreak{}2\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}1\\
+0x14 & REG & \hyperref[sec:repA.2.block1.repB.1.reg1]{repA.\allowbreak{}2.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}1.\allowbreak{}reg1} & repA\textunderscore\allowbreak{}2\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}1\textunderscore\allowbreak{}reg1\\
+0x18-0x1f & BLOCK & repA.\allowbreak{}3 & repA\textunderscore\allowbreak{}3\\
+0x18-0x1f & BLOCK & repA.\allowbreak{}3.\allowbreak{}block1 & repA\textunderscore\allowbreak{}3\textunderscore\allowbreak{}block1\\
+0x18-0x1f & BLOCK & repA.\allowbreak{}3.\allowbreak{}block1.\allowbreak{}repB & repA\textunderscore\allowbreak{}3\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\\
+0x18-0x1b & BLOCK & repA.\allowbreak{}3.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}0 & repA\textunderscore\allowbreak{}3\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}0\\
+0x18 & REG & \hyperref[sec:repA.3.block1.repB.0.reg1]{repA.\allowbreak{}3.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}0.\allowbreak{}reg1} & repA\textunderscore\allowbreak{}3\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}0\textunderscore\allowbreak{}reg1\\
+0x1c-0x1f & BLOCK & repA.\allowbreak{}3.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}1 & repA\textunderscore\allowbreak{}3\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}1\\
+0x1c & REG & \hyperref[sec:repA.3.block1.repB.1.reg1]{repA.\allowbreak{}3.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}1.\allowbreak{}reg1} & repA\textunderscore\allowbreak{}3\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}1\textunderscore\allowbreak{}reg1\\
+\end{memmap}
+
+\section{Register Description}
+\subsubsection{repA.\allowbreak{}0.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}0.\allowbreak{}reg1}
+\label{sec:repA.0.block1.repB.0.reg1}
+\begin{regsummary}
+HW Prefix & repA\textunderscore\allowbreak{}0\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}0\textunderscore\allowbreak{}reg1\\
+HW Address & 0x0\\
+C Prefix & repA.\allowbreak{}0.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}0.\allowbreak{}reg1\\
+C Block Offset & 0x0\\
+\end{regsummary}
+
+\begin{regdraw}
+7 & 6 & 5 & 4 & 3 & 2 & 1 & 0 \\
+\SetCell[c=8]{c, bg=lightgray} reg1[7:0] \\
+\end{regdraw}
+
+\begin{regdesc}
+7:0 & rw & reg1 & \\
+\end{regdesc}
+
+
+\subsubsection{repA.\allowbreak{}0.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}1.\allowbreak{}reg1}
+\label{sec:repA.0.block1.repB.1.reg1}
+\begin{regsummary}
+HW Prefix & repA\textunderscore\allowbreak{}0\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}1\textunderscore\allowbreak{}reg1\\
+HW Address & 0x4\\
+C Prefix & repA.\allowbreak{}0.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}1.\allowbreak{}reg1\\
+C Block Offset & 0x0\\
+\end{regsummary}
+
+\begin{regdraw}
+7 & 6 & 5 & 4 & 3 & 2 & 1 & 0 \\
+\SetCell[c=8]{c, bg=lightgray} reg1[7:0] \\
+\end{regdraw}
+
+\begin{regdesc}
+7:0 & rw & reg1 & \\
+\end{regdesc}
+
+
+\subsubsection{repA.\allowbreak{}1.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}0.\allowbreak{}reg1}
+\label{sec:repA.1.block1.repB.0.reg1}
+\begin{regsummary}
+HW Prefix & repA\textunderscore\allowbreak{}1\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}0\textunderscore\allowbreak{}reg1\\
+HW Address & 0x8\\
+C Prefix & repA.\allowbreak{}1.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}0.\allowbreak{}reg1\\
+C Block Offset & 0x0\\
+\end{regsummary}
+
+\begin{regdraw}
+7 & 6 & 5 & 4 & 3 & 2 & 1 & 0 \\
+\SetCell[c=8]{c, bg=lightgray} reg1[7:0] \\
+\end{regdraw}
+
+\begin{regdesc}
+7:0 & rw & reg1 & \\
+\end{regdesc}
+
+
+\subsubsection{repA.\allowbreak{}1.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}1.\allowbreak{}reg1}
+\label{sec:repA.1.block1.repB.1.reg1}
+\begin{regsummary}
+HW Prefix & repA\textunderscore\allowbreak{}1\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}1\textunderscore\allowbreak{}reg1\\
+HW Address & 0xc\\
+C Prefix & repA.\allowbreak{}1.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}1.\allowbreak{}reg1\\
+C Block Offset & 0x0\\
+\end{regsummary}
+
+\begin{regdraw}
+7 & 6 & 5 & 4 & 3 & 2 & 1 & 0 \\
+\SetCell[c=8]{c, bg=lightgray} reg1[7:0] \\
+\end{regdraw}
+
+\begin{regdesc}
+7:0 & rw & reg1 & \\
+\end{regdesc}
+
+
+\subsubsection{repA.\allowbreak{}2.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}0.\allowbreak{}reg1}
+\label{sec:repA.2.block1.repB.0.reg1}
+\begin{regsummary}
+HW Prefix & repA\textunderscore\allowbreak{}2\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}0\textunderscore\allowbreak{}reg1\\
+HW Address & 0x10\\
+C Prefix & repA.\allowbreak{}2.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}0.\allowbreak{}reg1\\
+C Block Offset & 0x0\\
+\end{regsummary}
+
+\begin{regdraw}
+7 & 6 & 5 & 4 & 3 & 2 & 1 & 0 \\
+\SetCell[c=8]{c, bg=lightgray} reg1[7:0] \\
+\end{regdraw}
+
+\begin{regdesc}
+7:0 & rw & reg1 & \\
+\end{regdesc}
+
+
+\subsubsection{repA.\allowbreak{}2.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}1.\allowbreak{}reg1}
+\label{sec:repA.2.block1.repB.1.reg1}
+\begin{regsummary}
+HW Prefix & repA\textunderscore\allowbreak{}2\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}1\textunderscore\allowbreak{}reg1\\
+HW Address & 0x14\\
+C Prefix & repA.\allowbreak{}2.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}1.\allowbreak{}reg1\\
+C Block Offset & 0x0\\
+\end{regsummary}
+
+\begin{regdraw}
+7 & 6 & 5 & 4 & 3 & 2 & 1 & 0 \\
+\SetCell[c=8]{c, bg=lightgray} reg1[7:0] \\
+\end{regdraw}
+
+\begin{regdesc}
+7:0 & rw & reg1 & \\
+\end{regdesc}
+
+
+\subsubsection{repA.\allowbreak{}3.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}0.\allowbreak{}reg1}
+\label{sec:repA.3.block1.repB.0.reg1}
+\begin{regsummary}
+HW Prefix & repA\textunderscore\allowbreak{}3\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}0\textunderscore\allowbreak{}reg1\\
+HW Address & 0x18\\
+C Prefix & repA.\allowbreak{}3.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}0.\allowbreak{}reg1\\
+C Block Offset & 0x0\\
+\end{regsummary}
+
+\begin{regdraw}
+7 & 6 & 5 & 4 & 3 & 2 & 1 & 0 \\
+\SetCell[c=8]{c, bg=lightgray} reg1[7:0] \\
+\end{regdraw}
+
+\begin{regdesc}
+7:0 & rw & reg1 & \\
+\end{regdesc}
+
+
+\subsubsection{repA.\allowbreak{}3.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}1.\allowbreak{}reg1}
+\label{sec:repA.3.block1.repB.1.reg1}
+\begin{regsummary}
+HW Prefix & repA\textunderscore\allowbreak{}3\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}1\textunderscore\allowbreak{}reg1\\
+HW Address & 0x1c\\
+C Prefix & repA.\allowbreak{}3.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}1.\allowbreak{}reg1\\
+C Block Offset & 0x0\\
+\end{regsummary}
+
+\begin{regdraw}
+7 & 6 & 5 & 4 & 3 & 2 & 1 & 0 \\
+\SetCell[c=8]{c, bg=lightgray} reg1[7:0] \\
+\end{regdraw}
+
+\begin{regdesc}
+7:0 & rw & reg1 & \\
+\end{regdesc}
+
+

--- a/testfiles/issue84/sps200CavityControl_as.tex
+++ b/testfiles/issue84/sps200CavityControl_as.tex
@@ -1,0 +1,692 @@
+\section{Memory Map Summary}
+Memory Map for SPS TWC200 Cavity Control
+
+\subsection{For Space bar0}
+\begin{memmap}
+0x000000-0x00001f & SUBMAP & hwInfo & hwInfo\\
+0x000000 & REG & \hyperref[sec:hwInfo.stdVersion]{hwInfo.\allowbreak{}stdVersion} & hwInfo\textunderscore\allowbreak{}stdVersion\\
+0x000008 & REG & \hyperref[sec:hwInfo.serialNumber]{hwInfo.\allowbreak{}serialNumber} & hwInfo\textunderscore\allowbreak{}serialNumber\\
+0x000010 & REG & \hyperref[sec:hwInfo.firmwareVersion]{hwInfo.\allowbreak{}firmwareVersion} & hwInfo\textunderscore\allowbreak{}firmwareVersion\\
+0x000014 & REG & \hyperref[sec:hwInfo.memMapVersion]{hwInfo.\allowbreak{}memMapVersion} & hwInfo\textunderscore\allowbreak{}memMapVersion\\
+0x000018 & REG & \hyperref[sec:hwInfo.echo]{hwInfo.\allowbreak{}echo} & hwInfo\textunderscore\allowbreak{}echo\\
+0x100000-0x17ffff & SUBMAP & app & app\\
+0x100000-0x1003ff & SUBMAP & app.\allowbreak{}modulation & app\textunderscore\allowbreak{}modulation\\
+0x100000-0x10001f & SUBMAP & app.\allowbreak{}modulation.\allowbreak{}ipInfo & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}ipInfo\\
+0x100000 & REG & \hyperref[sec:app.modulation.ipInfo.stdVersion]{app.\allowbreak{}modulation.\allowbreak{}ipInfo.\allowbreak{}stdVersion} & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}ipInfo\textunderscore\allowbreak{}stdVersion\\
+0x100004 & REG & \hyperref[sec:app.modulation.ipInfo.ident]{app.\allowbreak{}modulation.\allowbreak{}ipInfo.\allowbreak{}ident} & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}ipInfo\textunderscore\allowbreak{}ident\\
+0x100008 & REG & \hyperref[sec:app.modulation.ipInfo.firmwareVersion]{app.\allowbreak{}modulation.\allowbreak{}ipInfo.\allowbreak{}firmwareVersion} & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}ipInfo\textunderscore\allowbreak{}firmwareVersion\\
+0x10000c & REG & \hyperref[sec:app.modulation.ipInfo.memMapVersion]{app.\allowbreak{}modulation.\allowbreak{}ipInfo.\allowbreak{}memMapVersion} & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}ipInfo\textunderscore\allowbreak{}memMapVersion\\
+0x100010 & REG & \hyperref[sec:app.modulation.ipInfo.echo]{app.\allowbreak{}modulation.\allowbreak{}ipInfo.\allowbreak{}echo} & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}ipInfo\textunderscore\allowbreak{}echo\\
+0x100020 & REG & \hyperref[sec:app.modulation.control]{app.\allowbreak{}modulation.\allowbreak{}control} & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}control\\
+0x100030-0x10003f & BLOCK & app.\allowbreak{}modulation.\allowbreak{}testSignal & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}testSignal\\
+0x100030 & REG & \hyperref[sec:app.modulation.testSignal.amplitude]{app.\allowbreak{}modulation.\allowbreak{}testSignal.\allowbreak{}amplitude} & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}testSignal\textunderscore\allowbreak{}amplitude\\
+0x100038 & REG & \hyperref[sec:app.modulation.testSignal.ftw]{app.\allowbreak{}modulation.\allowbreak{}testSignal.\allowbreak{}ftw} & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}testSignal\textunderscore\allowbreak{}ftw\\
+0x100040-0x10004f & BLOCK & app.\allowbreak{}modulation.\allowbreak{}staticSignal & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}staticSignal\\
+0x100040 & REG & \hyperref[sec:app.modulation.staticSignal.i]{app.\allowbreak{}modulation.\allowbreak{}staticSignal.\allowbreak{}i} & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}staticSignal\textunderscore\allowbreak{}i\\
+0x100044 & REG & \hyperref[sec:app.modulation.staticSignal.q]{app.\allowbreak{}modulation.\allowbreak{}staticSignal.\allowbreak{}q} & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}staticSignal\textunderscore\allowbreak{}q\\
+0x100050 & REG & \hyperref[sec:app.modulation.ftwH1main]{app.\allowbreak{}modulation.\allowbreak{}ftwH1main} & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}ftwH1main\\
+0x100058 & REG & \hyperref[sec:app.modulation.ftwH1on]{app.\allowbreak{}modulation.\allowbreak{}ftwH1on} & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}ftwH1on\\
+0x100060 & REG & \hyperref[sec:app.modulation.dftwH1slip0]{app.\allowbreak{}modulation.\allowbreak{}dftwH1slip0} & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}dftwH1slip0\\
+0x100064 & REG & \hyperref[sec:app.modulation.dftwH1slip1]{app.\allowbreak{}modulation.\allowbreak{}dftwH1slip1} & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}dftwH1slip1\\
+0x100068 & REG & \hyperref[sec:app.modulation.latches]{app.\allowbreak{}modulation.\allowbreak{}latches} & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}latches\\
+\end{memmap}
+
+\subsection{For Space bar4}
+\begin{memmap}
+0x00000000-0x000fffff & SUBMAP & fgc\textunderscore\allowbreak{}ddr & fgc\textunderscore\allowbreak{}ddr\\
+0x00000000-0x000fffff & MEMORY & fgc\textunderscore\allowbreak{}ddr.\allowbreak{}data64 & fgc\textunderscore\allowbreak{}ddr\textunderscore\allowbreak{}data64\\
+ +0x00000000 & REG & \hyperref[sec:fgc_ddr.data64.data64]{fgc\textunderscore\allowbreak{}ddr.\allowbreak{}data64.\allowbreak{}data64} & fgc\textunderscore\allowbreak{}ddr\textunderscore\allowbreak{}data64\textunderscore\allowbreak{}data64\\
+0x20000000-0x3fffffff & SUBMAP & acq\textunderscore\allowbreak{}ddr & acq\textunderscore\allowbreak{}ddr\\
+0x20000000-0x3fffffff & MEMORY & acq\textunderscore\allowbreak{}ddr.\allowbreak{}data32 & acq\textunderscore\allowbreak{}ddr\textunderscore\allowbreak{}data32\\
+ +0x20000000 & REG & \hyperref[sec:acq_ddr.data32.data32]{acq\textunderscore\allowbreak{}ddr.\allowbreak{}data32.\allowbreak{}data32} & acq\textunderscore\allowbreak{}ddr\textunderscore\allowbreak{}data32\textunderscore\allowbreak{}data32\\
+0x80000000-0x8001ffff & SUBMAP & acq\textunderscore\allowbreak{}ram & acq\textunderscore\allowbreak{}ram\\
+0x80000000-0x8001ffff & MEMORY & acq\textunderscore\allowbreak{}ram.\allowbreak{}data32 & acq\textunderscore\allowbreak{}ram\textunderscore\allowbreak{}data32\\
+ +0x80000000 & REG & \hyperref[sec:acq_ram.data32.data32]{acq\textunderscore\allowbreak{}ram.\allowbreak{}data32.\allowbreak{}data32} & acq\textunderscore\allowbreak{}ram\textunderscore\allowbreak{}data32\textunderscore\allowbreak{}data32\\
+\end{memmap}
+
+\subsection{Register Description for Space bar0}
+
+\subsubsection{hwInfo.\allowbreak{}stdVersion}
+\label{sec:hwInfo.stdVersion}
+\begin{regsummary}
+HW Prefix & hwInfo\textunderscore\allowbreak{}stdVersion\\
+HW Address & 0x0\\
+C Prefix & hwInfo.\allowbreak{}stdVersion\\
+C Block Offset & 0x0\\
+\end{regsummary}
+
+\begin{regdraw}
+31 & 30 & 29 & 28 & 27 & 26 & 25 & 24 \\
+\SetCell[c=8]{c, bg=lightgray} platform[7:0] \\
+23 & 22 & 21 & 20 & 19 & 18 & 17 & 16 \\
+\SetCell[c=8]{c, bg=lightgray} major[7:0] \\
+15 & 14 & 13 & 12 & 11 & 10 & 9 & 8 \\
+\SetCell[c=8]{c, bg=lightgray} minor[7:0] \\
+7 & 6 & 5 & 4 & 3 & 2 & 1 & 0 \\
+\SetCell[c=8]{c, bg=lightgray} patch[7:0] \\
+\end{regdraw}
+
+\begin{regdesc}
+31:24 & ro & platform & Identifying which platform the version belongs to (i.\allowbreak{}e.\allowbreak{} pci, lhc\textunderscore\allowbreak{}vme, vme64, .\allowbreak{}.\allowbreak{}.\allowbreak{})\\
+23:16 & ro & major & Major version indicating incompatible changes\\
+15:8 & ro & minor & Minor version indicating feature enhancements\\
+7:0 & ro & patch & Patch indicating bug fixes\\
+\end{regdesc}
+
+
+\subsubsection{hwInfo.\allowbreak{}serialNumber}
+\label{sec:hwInfo.serialNumber}
+\begin{regsummary}
+HW Prefix & hwInfo\textunderscore\allowbreak{}serialNumber\\
+HW Address & 0x8\\
+C Prefix & hwInfo.\allowbreak{}serialNumber\\
+C Block Offset & 0x8\\
+\end{regsummary}
+
+\begin{regdraw}
+63 & 62 & 61 & 60 & 59 & 58 & 57 & 56 \\
+\SetCell[c=8]{c, bg=lightgray} serialNumber[63:56] \\
+55 & 54 & 53 & 52 & 51 & 50 & 49 & 48 \\
+\SetCell[c=8]{c, bg=lightgray} serialNumber[55:48] \\
+47 & 46 & 45 & 44 & 43 & 42 & 41 & 40 \\
+\SetCell[c=8]{c, bg=lightgray} serialNumber[47:40] \\
+39 & 38 & 37 & 36 & 35 & 34 & 33 & 32 \\
+\SetCell[c=8]{c, bg=lightgray} serialNumber[39:32] \\
+31 & 30 & 29 & 28 & 27 & 26 & 25 & 24 \\
+\SetCell[c=8]{c, bg=lightgray} serialNumber[31:24] \\
+23 & 22 & 21 & 20 & 19 & 18 & 17 & 16 \\
+\SetCell[c=8]{c, bg=lightgray} serialNumber[23:16] \\
+15 & 14 & 13 & 12 & 11 & 10 & 9 & 8 \\
+\SetCell[c=8]{c, bg=lightgray} serialNumber[15:8] \\
+7 & 6 & 5 & 4 & 3 & 2 & 1 & 0 \\
+\SetCell[c=8]{c, bg=lightgray} serialNumber[7:0] \\
+\end{regdraw}
+
+\begin{regdesc}
+63:0 & ro & serialNumber & HW serial number\\
+\end{regdesc}
+
+
+\subsubsection{hwInfo.\allowbreak{}firmwareVersion}
+\label{sec:hwInfo.firmwareVersion}
+\begin{regsummary}
+HW Prefix & hwInfo\textunderscore\allowbreak{}firmwareVersion\\
+HW Address & 0x10\\
+C Prefix & hwInfo.\allowbreak{}firmwareVersion\\
+C Block Offset & 0x10\\
+\end{regsummary}
+
+\begin{regdraw}
+31 & 30 & 29 & 28 & 27 & 26 & 25 & 24 \\
+- & - & - & - & - & - & - & - \\
+23 & 22 & 21 & 20 & 19 & 18 & 17 & 16 \\
+\SetCell[c=8]{c, bg=lightgray} major[7:0] \\
+15 & 14 & 13 & 12 & 11 & 10 & 9 & 8 \\
+\SetCell[c=8]{c, bg=lightgray} minor[7:0] \\
+7 & 6 & 5 & 4 & 3 & 2 & 1 & 0 \\
+\SetCell[c=8]{c, bg=lightgray} patch[7:0] \\
+\end{regdraw}
+
+\begin{regdesc}
+23:16 & ro & major & Major version indicating incompatible changes\\
+15:8 & ro & minor & Minor version indicating feature enhancements\\
+7:0 & ro & patch & Patch indicating bug fixes\\
+\end{regdesc}
+
+
+\subsubsection{hwInfo.\allowbreak{}memMapVersion}
+\label{sec:hwInfo.memMapVersion}
+\begin{regsummary}
+HW Prefix & hwInfo\textunderscore\allowbreak{}memMapVersion\\
+HW Address & 0x14\\
+C Prefix & hwInfo.\allowbreak{}memMapVersion\\
+C Block Offset & 0x14\\
+\end{regsummary}
+
+\begin{regdraw}
+31 & 30 & 29 & 28 & 27 & 26 & 25 & 24 \\
+- & - & - & - & - & - & - & - \\
+23 & 22 & 21 & 20 & 19 & 18 & 17 & 16 \\
+\SetCell[c=8]{c, bg=lightgray} major[7:0] \\
+15 & 14 & 13 & 12 & 11 & 10 & 9 & 8 \\
+\SetCell[c=8]{c, bg=lightgray} minor[7:0] \\
+7 & 6 & 5 & 4 & 3 & 2 & 1 & 0 \\
+\SetCell[c=8]{c, bg=lightgray} patch[7:0] \\
+\end{regdraw}
+
+\begin{regdesc}
+23:16 & ro & major & \\
+15:8 & ro & minor & \\
+7:0 & ro & patch & \\
+\end{regdesc}
+
+
+\subsubsection{hwInfo.\allowbreak{}echo}
+\label{sec:hwInfo.echo}
+\begin{regsummary}
+HW Prefix & hwInfo\textunderscore\allowbreak{}echo\\
+HW Address & 0x18\\
+C Prefix & hwInfo.\allowbreak{}echo\\
+C Block Offset & 0x18\\
+\end{regsummary}
+
+\begin{regdraw}
+31 & 30 & 29 & 28 & 27 & 26 & 25 & 24 \\
+\SetCell[c=8]{c, bg=lightgray} echo[31:24] \\
+23 & 22 & 21 & 20 & 19 & 18 & 17 & 16 \\
+\SetCell[c=8]{c, bg=lightgray} echo[23:16] \\
+15 & 14 & 13 & 12 & 11 & 10 & 9 & 8 \\
+\SetCell[c=8]{c, bg=lightgray} echo[15:8] \\
+7 & 6 & 5 & 4 & 3 & 2 & 1 & 0 \\
+\SetCell[c=8]{c, bg=lightgray} echo[7:0] \\
+\end{regdraw}
+
+\begin{regdesc}
+31:0 & rw & echo & Echo register.\allowbreak{} This version of the standard foresees only 8bits linked to real memoryRegister used solely by software.\allowbreak{} No interaction with the firmware foreseen.\allowbreak{}
+The idea is to use this register as "flag" in the hardware to remember your actions from the software side.\allowbreak{}
+
+Reading 0xFF often happens when the board is not even reachable (i.\allowbreak{}e.\allowbreak{} bus problems on VME)
+
+On the other hand if the board is reachable the usual state of flipflops are 0x00.\allowbreak{} Thus this would indicate that no initialization has been attempted yet.\allowbreak{}
+
+At start of your software (FESA class) you should set the value 0x40 indicating that initialization is in progress.\allowbreak{} 
+This is important for you to later one check if you can read this value back before finally setting it to 0x80 (the value previously used with Cheburashka).\allowbreak{}
+
+If your initialization failed but you want to continue anyway you should set the register to 0xC0 to indicate this error 
+
+This register is in particular useful if you have several entities interacting with the hardware.\allowbreak{} In this case several bits could be assigned to this entities (bits 5.\allowbreak{}.\allowbreak{}0) to signalize that they have done there part successful and a main entity checks all the expected bits.\allowbreak{}\\
+\end{regdesc}
+
+
+\subsubsection{app.\allowbreak{}modulation.\allowbreak{}ipInfo.\allowbreak{}stdVersion}
+\label{sec:app.modulation.ipInfo.stdVersion}
+\begin{regsummary}
+HW Prefix & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}ipInfo\textunderscore\allowbreak{}stdVersion\\
+HW Address & 0x100000\\
+C Prefix & app.\allowbreak{}modulation.\allowbreak{}ipInfo.\allowbreak{}stdVersion\\
+C Block Offset & 0x0\\
+\end{regsummary}
+
+\begin{regdraw}
+31 & 30 & 29 & 28 & 27 & 26 & 25 & 24 \\
+- & - & - & - & - & - & - & - \\
+23 & 22 & 21 & 20 & 19 & 18 & 17 & 16 \\
+\SetCell[c=8]{c, bg=lightgray} major[7:0] \\
+15 & 14 & 13 & 12 & 11 & 10 & 9 & 8 \\
+\SetCell[c=8]{c, bg=lightgray} minor[7:0] \\
+7 & 6 & 5 & 4 & 3 & 2 & 1 & 0 \\
+\SetCell[c=8]{c, bg=lightgray} patch[7:0] \\
+\end{regdraw}
+
+\begin{regdesc}
+23:16 & ro & major & Major version indicating incompatible changes\\
+15:8 & ro & minor & Minor version indicating feature enhancements\\
+7:0 & ro & patch & Patch indicating bug fixes\\
+\end{regdesc}
+
+
+\subsubsection{app.\allowbreak{}modulation.\allowbreak{}ipInfo.\allowbreak{}ident}
+\label{sec:app.modulation.ipInfo.ident}
+\begin{regsummary}
+HW Prefix & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}ipInfo\textunderscore\allowbreak{}ident\\
+HW Address & 0x100004\\
+C Prefix & app.\allowbreak{}modulation.\allowbreak{}ipInfo.\allowbreak{}ident\\
+C Block Offset & 0x4\\
+\end{regsummary}
+
+\begin{regdraw}
+31 & 30 & 29 & 28 & 27 & 26 & 25 & 24 \\
+\SetCell[c=8]{c, bg=lightgray} ident[31:24] \\
+23 & 22 & 21 & 20 & 19 & 18 & 17 & 16 \\
+\SetCell[c=8]{c, bg=lightgray} ident[23:16] \\
+15 & 14 & 13 & 12 & 11 & 10 & 9 & 8 \\
+\SetCell[c=8]{c, bg=lightgray} ident[15:8] \\
+7 & 6 & 5 & 4 & 3 & 2 & 1 & 0 \\
+\SetCell[c=8]{c, bg=lightgray} ident[7:0] \\
+\end{regdraw}
+
+\begin{regdesc}
+31:0 & ro & ident & IP Ident code\\
+\end{regdesc}
+
+
+\subsubsection{app.\allowbreak{}modulation.\allowbreak{}ipInfo.\allowbreak{}firmwareVersion}
+\label{sec:app.modulation.ipInfo.firmwareVersion}
+\begin{regsummary}
+HW Prefix & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}ipInfo\textunderscore\allowbreak{}firmwareVersion\\
+HW Address & 0x100008\\
+C Prefix & app.\allowbreak{}modulation.\allowbreak{}ipInfo.\allowbreak{}firmwareVersion\\
+C Block Offset & 0x8\\
+\end{regsummary}
+
+\begin{regdraw}
+31 & 30 & 29 & 28 & 27 & 26 & 25 & 24 \\
+- & - & - & - & - & - & - & - \\
+23 & 22 & 21 & 20 & 19 & 18 & 17 & 16 \\
+\SetCell[c=8]{c, bg=lightgray} major[7:0] \\
+15 & 14 & 13 & 12 & 11 & 10 & 9 & 8 \\
+\SetCell[c=8]{c, bg=lightgray} minor[7:0] \\
+7 & 6 & 5 & 4 & 3 & 2 & 1 & 0 \\
+\SetCell[c=8]{c, bg=lightgray} patch[7:0] \\
+\end{regdraw}
+
+\begin{regdesc}
+23:16 & ro & major & Major version indicating incompatible changes\\
+15:8 & ro & minor & Minor version indicating feature enhancements\\
+7:0 & ro & patch & Patch indicating bug fixes\\
+\end{regdesc}
+
+
+\subsubsection{app.\allowbreak{}modulation.\allowbreak{}ipInfo.\allowbreak{}memMapVersion}
+\label{sec:app.modulation.ipInfo.memMapVersion}
+\begin{regsummary}
+HW Prefix & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}ipInfo\textunderscore\allowbreak{}memMapVersion\\
+HW Address & 0x10000c\\
+C Prefix & app.\allowbreak{}modulation.\allowbreak{}ipInfo.\allowbreak{}memMapVersion\\
+C Block Offset & 0xc\\
+\end{regsummary}
+
+\begin{regdraw}
+31 & 30 & 29 & 28 & 27 & 26 & 25 & 24 \\
+- & - & - & - & - & - & - & - \\
+23 & 22 & 21 & 20 & 19 & 18 & 17 & 16 \\
+\SetCell[c=8]{c, bg=lightgray} major[7:0] \\
+15 & 14 & 13 & 12 & 11 & 10 & 9 & 8 \\
+\SetCell[c=8]{c, bg=lightgray} minor[7:0] \\
+7 & 6 & 5 & 4 & 3 & 2 & 1 & 0 \\
+\SetCell[c=8]{c, bg=lightgray} patch[7:0] \\
+\end{regdraw}
+
+\begin{regdesc}
+23:16 & ro & major & Major version indicating incompatible changes\\
+15:8 & ro & minor & Minor version indicating feature enhancements\\
+7:0 & ro & patch & Patch indicating bug fixes\\
+\end{regdesc}
+
+
+\subsubsection{app.\allowbreak{}modulation.\allowbreak{}ipInfo.\allowbreak{}echo}
+\label{sec:app.modulation.ipInfo.echo}
+\begin{regsummary}
+HW Prefix & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}ipInfo\textunderscore\allowbreak{}echo\\
+HW Address & 0x100010\\
+C Prefix & app.\allowbreak{}modulation.\allowbreak{}ipInfo.\allowbreak{}echo\\
+C Block Offset & 0x10\\
+\end{regsummary}
+
+\begin{regdraw}
+31 & 30 & 29 & 28 & 27 & 26 & 25 & 24 \\
+- & - & - & - & - & - & - & - \\
+23 & 22 & 21 & 20 & 19 & 18 & 17 & 16 \\
+- & - & - & - & - & - & - & - \\
+15 & 14 & 13 & 12 & 11 & 10 & 9 & 8 \\
+- & - & - & - & - & - & - & - \\
+7 & 6 & 5 & 4 & 3 & 2 & 1 & 0 \\
+\SetCell[c=8]{c, bg=lightgray} echo[7:0] \\
+\end{regdraw}
+
+\begin{regdesc}
+7:0 & rw & echo & This version of the standard foresees only 8bits linked to real memory\\
+\end{regdesc}
+
+
+\subsubsection{app.\allowbreak{}modulation.\allowbreak{}control}
+\label{sec:app.modulation.control}
+\begin{regsummary}
+HW Prefix & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}control\\
+HW Address & 0x100020\\
+C Prefix & app.\allowbreak{}modulation.\allowbreak{}control\\
+C Block Offset & 0x20\\
+\end{regsummary}
+
+\begin{regdraw}
+31 & 30 & 29 & 28 & 27 & 26 & 25 & 24 \\
+- & - & - & - & - & - & - & - \\
+23 & 22 & 21 & 20 & 19 & 18 & 17 & 16 \\
+- & - & - & - & - & - & - & - \\
+15 & 14 & 13 & 12 & 11 & 10 & 9 & 8 \\
+\SetCell{bg=lightgray} clearBPLatches & \SetCell[c=3]{c, bg=lightgray} rate[2:0] & \SetCell{bg=lightgray} wrInputsValidLatch & \SetCell{bg=lightgray} wrRresetFSK & \SetCell{bg=lightgray} wrResetSlip & \SetCell{bg=lightgray} wrResetNCO \\
+7 & 6 & 5 & 4 & 3 & 2 & 1 & 0 \\
+\SetCell{bg=lightgray} wrInputsValid & \SetCell{bg=lightgray} bypassMod & \SetCell{bg=lightgray} bypassDemod & - & - & \SetCell{bg=lightgray} useStaticSignal & \SetCell{bg=lightgray} useImpulse & \SetCell{bg=lightgray} useTestSignal \\
+\end{regdraw}
+
+\begin{regdesc}
+0 & rw & useTestSignal & Use DDS generated test signal instead of ADC input as demodulation inputTest signal is synthezied with additional internal DDS, test signals frequency given by ftw\textunderscore\allowbreak{}RF.\allowbreak{}\\
+1 & rw & useImpulse & Use impulse instead of demodulation output\\
+2 & rw & useStaticSignal & Use static signal from register instead of demodulation output\\
+5 & rw & bypassDemod & Bypass demodulator\\
+6 & rw & bypassMod & Bypass modulator\\
+7 & rw & wrInputsValid & transmit WR frame\\
+11 & rw & wrInputsValidLatch & transmit WR no autoclear\\
+8 & rw & wrResetNCO & activate WR frame control bit\\
+9 & rw & wrResetSlip & activate WR frame control bit\\
+10 & rw & wrRresetFSK & activate WR frame control bit\\
+14:12 & rw & rate & \\
+15 & rw & clearBPLatches & \\
+\end{regdesc}
+
+
+\subsubsection{app.\allowbreak{}modulation.\allowbreak{}testSignal.\allowbreak{}amplitude}
+\label{sec:app.modulation.testSignal.amplitude}
+\begin{regsummary}
+HW Prefix & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}testSignal\textunderscore\allowbreak{}amplitude\\
+HW Address & 0x100030\\
+C Prefix & app.\allowbreak{}modulation.\allowbreak{}testSignal.\allowbreak{}amplitude\\
+C Block Offset & 0x0\\
+\end{regsummary}
+
+\begin{regdraw}
+15 & 14 & 13 & 12 & 11 & 10 & 9 & 8 \\
+\SetCell[c=8]{c, bg=lightgray} amplitude[15:8] \\
+7 & 6 & 5 & 4 & 3 & 2 & 1 & 0 \\
+\SetCell[c=8]{c, bg=lightgray} amplitude[7:0] \\
+\end{regdraw}
+
+\begin{regdesc}
+15:0 & rw & amplitude & Amplitude for the test signal\\
+\end{regdesc}
+
+
+\subsubsection{app.\allowbreak{}modulation.\allowbreak{}testSignal.\allowbreak{}ftw}
+\label{sec:app.modulation.testSignal.ftw}
+\begin{regsummary}
+HW Prefix & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}testSignal\textunderscore\allowbreak{}ftw\\
+HW Address & 0x100038\\
+C Prefix & app.\allowbreak{}modulation.\allowbreak{}testSignal.\allowbreak{}ftw\\
+C Block Offset & 0x8\\
+\end{regsummary}
+
+\begin{regdraw}
+63 & 62 & 61 & 60 & 59 & 58 & 57 & 56 \\
+\SetCell[c=8]{c, bg=lightgray} ftw[63:56] \\
+55 & 54 & 53 & 52 & 51 & 50 & 49 & 48 \\
+\SetCell[c=8]{c, bg=lightgray} ftw[55:48] \\
+47 & 46 & 45 & 44 & 43 & 42 & 41 & 40 \\
+\SetCell[c=8]{c, bg=lightgray} ftw[47:40] \\
+39 & 38 & 37 & 36 & 35 & 34 & 33 & 32 \\
+\SetCell[c=8]{c, bg=lightgray} ftw[39:32] \\
+31 & 30 & 29 & 28 & 27 & 26 & 25 & 24 \\
+\SetCell[c=8]{c, bg=lightgray} ftw[31:24] \\
+23 & 22 & 21 & 20 & 19 & 18 & 17 & 16 \\
+\SetCell[c=8]{c, bg=lightgray} ftw[23:16] \\
+15 & 14 & 13 & 12 & 11 & 10 & 9 & 8 \\
+\SetCell[c=8]{c, bg=lightgray} ftw[15:8] \\
+7 & 6 & 5 & 4 & 3 & 2 & 1 & 0 \\
+\SetCell[c=8]{c, bg=lightgray} ftw[7:0] \\
+\end{regdraw}
+
+\begin{regdesc}
+63:0 & rw & ftw & FTW of the test signal (frequency relative to fs)\\
+\end{regdesc}
+
+
+\subsubsection{app.\allowbreak{}modulation.\allowbreak{}staticSignal.\allowbreak{}i}
+\label{sec:app.modulation.staticSignal.i}
+\begin{regsummary}
+HW Prefix & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}staticSignal\textunderscore\allowbreak{}i\\
+HW Address & 0x100040\\
+C Prefix & app.\allowbreak{}modulation.\allowbreak{}staticSignal.\allowbreak{}i\\
+C Block Offset & 0x0\\
+\end{regsummary}
+
+\begin{regdraw}
+15 & 14 & 13 & 12 & 11 & 10 & 9 & 8 \\
+\SetCell[c=8]{c, bg=lightgray} i[15:8] \\
+7 & 6 & 5 & 4 & 3 & 2 & 1 & 0 \\
+\SetCell[c=8]{c, bg=lightgray} i[7:0] \\
+\end{regdraw}
+
+\begin{regdesc}
+15:0 & rw & i & Constant to be used as OTF input for channel I\\
+\end{regdesc}
+
+
+\subsubsection{app.\allowbreak{}modulation.\allowbreak{}staticSignal.\allowbreak{}q}
+\label{sec:app.modulation.staticSignal.q}
+\begin{regsummary}
+HW Prefix & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}staticSignal\textunderscore\allowbreak{}q\\
+HW Address & 0x100044\\
+C Prefix & app.\allowbreak{}modulation.\allowbreak{}staticSignal.\allowbreak{}q\\
+C Block Offset & 0x4\\
+\end{regsummary}
+
+\begin{regdraw}
+15 & 14 & 13 & 12 & 11 & 10 & 9 & 8 \\
+\SetCell[c=8]{c, bg=lightgray} q[15:8] \\
+7 & 6 & 5 & 4 & 3 & 2 & 1 & 0 \\
+\SetCell[c=8]{c, bg=lightgray} q[7:0] \\
+\end{regdraw}
+
+\begin{regdesc}
+15:0 & rw & q & Constant to be used as OTF input for channel Q\\
+\end{regdesc}
+
+
+\subsubsection{app.\allowbreak{}modulation.\allowbreak{}ftwH1main}
+\label{sec:app.modulation.ftwH1main}
+\begin{regsummary}
+HW Prefix & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}ftwH1main\\
+HW Address & 0x100050\\
+C Prefix & app.\allowbreak{}modulation.\allowbreak{}ftwH1main\\
+C Block Offset & 0x50\\
+\end{regsummary}
+
+\begin{regdraw}
+63 & 62 & 61 & 60 & 59 & 58 & 57 & 56 \\
+\SetCell[c=8]{c, bg=lightgray} ftwH1main[63:56] \\
+55 & 54 & 53 & 52 & 51 & 50 & 49 & 48 \\
+\SetCell[c=8]{c, bg=lightgray} ftwH1main[55:48] \\
+47 & 46 & 45 & 44 & 43 & 42 & 41 & 40 \\
+\SetCell[c=8]{c, bg=lightgray} ftwH1main[47:40] \\
+39 & 38 & 37 & 36 & 35 & 34 & 33 & 32 \\
+\SetCell[c=8]{c, bg=lightgray} ftwH1main[39:32] \\
+31 & 30 & 29 & 28 & 27 & 26 & 25 & 24 \\
+\SetCell[c=8]{c, bg=lightgray} ftwH1main[31:24] \\
+23 & 22 & 21 & 20 & 19 & 18 & 17 & 16 \\
+\SetCell[c=8]{c, bg=lightgray} ftwH1main[23:16] \\
+15 & 14 & 13 & 12 & 11 & 10 & 9 & 8 \\
+\SetCell[c=8]{c, bg=lightgray} ftwH1main[15:8] \\
+7 & 6 & 5 & 4 & 3 & 2 & 1 & 0 \\
+\SetCell[c=8]{c, bg=lightgray} ftwH1main[7:0] \\
+\end{regdraw}
+
+\begin{regdesc}
+63:0 & rw & ftwH1main & \\
+\end{regdesc}
+
+
+\subsubsection{app.\allowbreak{}modulation.\allowbreak{}ftwH1on}
+\label{sec:app.modulation.ftwH1on}
+\begin{regsummary}
+HW Prefix & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}ftwH1on\\
+HW Address & 0x100058\\
+C Prefix & app.\allowbreak{}modulation.\allowbreak{}ftwH1on\\
+C Block Offset & 0x58\\
+\end{regsummary}
+
+\begin{regdraw}
+63 & 62 & 61 & 60 & 59 & 58 & 57 & 56 \\
+\SetCell[c=8]{c, bg=lightgray} ftwH1on[63:56] \\
+55 & 54 & 53 & 52 & 51 & 50 & 49 & 48 \\
+\SetCell[c=8]{c, bg=lightgray} ftwH1on[55:48] \\
+47 & 46 & 45 & 44 & 43 & 42 & 41 & 40 \\
+\SetCell[c=8]{c, bg=lightgray} ftwH1on[47:40] \\
+39 & 38 & 37 & 36 & 35 & 34 & 33 & 32 \\
+\SetCell[c=8]{c, bg=lightgray} ftwH1on[39:32] \\
+31 & 30 & 29 & 28 & 27 & 26 & 25 & 24 \\
+\SetCell[c=8]{c, bg=lightgray} ftwH1on[31:24] \\
+23 & 22 & 21 & 20 & 19 & 18 & 17 & 16 \\
+\SetCell[c=8]{c, bg=lightgray} ftwH1on[23:16] \\
+15 & 14 & 13 & 12 & 11 & 10 & 9 & 8 \\
+\SetCell[c=8]{c, bg=lightgray} ftwH1on[15:8] \\
+7 & 6 & 5 & 4 & 3 & 2 & 1 & 0 \\
+\SetCell[c=8]{c, bg=lightgray} ftwH1on[7:0] \\
+\end{regdraw}
+
+\begin{regdesc}
+63:0 & rw & ftwH1on & \\
+\end{regdesc}
+
+
+\subsubsection{app.\allowbreak{}modulation.\allowbreak{}dftwH1slip0}
+\label{sec:app.modulation.dftwH1slip0}
+\begin{regsummary}
+HW Prefix & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}dftwH1slip0\\
+HW Address & 0x100060\\
+C Prefix & app.\allowbreak{}modulation.\allowbreak{}dftwH1slip0\\
+C Block Offset & 0x60\\
+\end{regsummary}
+
+\begin{regdraw}
+31 & 30 & 29 & 28 & 27 & 26 & 25 & 24 \\
+\SetCell[c=8]{c, bg=lightgray} dftwH1slip0[31:24] \\
+23 & 22 & 21 & 20 & 19 & 18 & 17 & 16 \\
+\SetCell[c=8]{c, bg=lightgray} dftwH1slip0[23:16] \\
+15 & 14 & 13 & 12 & 11 & 10 & 9 & 8 \\
+\SetCell[c=8]{c, bg=lightgray} dftwH1slip0[15:8] \\
+7 & 6 & 5 & 4 & 3 & 2 & 1 & 0 \\
+\SetCell[c=8]{c, bg=lightgray} dftwH1slip0[7:0] \\
+\end{regdraw}
+
+\begin{regdesc}
+31:0 & rw & dftwH1slip0 & \\
+\end{regdesc}
+
+
+\subsubsection{app.\allowbreak{}modulation.\allowbreak{}dftwH1slip1}
+\label{sec:app.modulation.dftwH1slip1}
+\begin{regsummary}
+HW Prefix & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}dftwH1slip1\\
+HW Address & 0x100064\\
+C Prefix & app.\allowbreak{}modulation.\allowbreak{}dftwH1slip1\\
+C Block Offset & 0x64\\
+\end{regsummary}
+
+\begin{regdraw}
+31 & 30 & 29 & 28 & 27 & 26 & 25 & 24 \\
+\SetCell[c=8]{c, bg=lightgray} dftwH1slip1[31:24] \\
+23 & 22 & 21 & 20 & 19 & 18 & 17 & 16 \\
+\SetCell[c=8]{c, bg=lightgray} dftwH1slip1[23:16] \\
+15 & 14 & 13 & 12 & 11 & 10 & 9 & 8 \\
+\SetCell[c=8]{c, bg=lightgray} dftwH1slip1[15:8] \\
+7 & 6 & 5 & 4 & 3 & 2 & 1 & 0 \\
+\SetCell[c=8]{c, bg=lightgray} dftwH1slip1[7:0] \\
+\end{regdraw}
+
+\begin{regdesc}
+31:0 & rw & dftwH1slip1 & \\
+\end{regdesc}
+
+
+\subsubsection{app.\allowbreak{}modulation.\allowbreak{}latches}
+\label{sec:app.modulation.latches}
+\begin{regsummary}
+HW Prefix & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}latches\\
+HW Address & 0x100068\\
+C Prefix & app.\allowbreak{}modulation.\allowbreak{}latches\\
+C Block Offset & 0x68\\
+\end{regsummary}
+
+\begin{regdraw}
+31 & 30 & 29 & 28 & 27 & 26 & 25 & 24 \\
+- & - & - & - & - & - & - & - \\
+23 & 22 & 21 & 20 & 19 & 18 & 17 & 16 \\
+- & - & - & - & - & - & - & - \\
+15 & 14 & 13 & 12 & 11 & 10 & 9 & 8 \\
+- & - & - & - & - & - & - & - \\
+7 & 6 & 5 & 4 & 3 & 2 & 1 & 0 \\
+\SetCell[c=8]{c, bg=lightgray} backplane[7:0] \\
+\end{regdraw}
+
+\begin{regdesc}
+7:0 & rw & backplane & \\
+\end{regdesc}
+
+
+\subsection{Register Description for Space bar4}
+
+\subsubsection{fgc\textunderscore\allowbreak{}ddr.\allowbreak{}data64.\allowbreak{}data64}
+\label{sec:fgc_ddr.data64.data64}
+\begin{regsummary}
+HW Prefix & fgc\textunderscore\allowbreak{}ddr\textunderscore\allowbreak{}data64\textunderscore\allowbreak{}data64\\
+HW Address & 0x0\\
+C Prefix & fgc\textunderscore\allowbreak{}ddr.\allowbreak{}data64.\allowbreak{}data64\\
+C Block Offset & 0x0\\
+\end{regsummary}
+
+\begin{regdraw}
+63 & 62 & 61 & 60 & 59 & 58 & 57 & 56 \\
+\SetCell[c=8]{c, bg=lightgray} upper[31:24] \\
+55 & 54 & 53 & 52 & 51 & 50 & 49 & 48 \\
+\SetCell[c=8]{c, bg=lightgray} upper[23:16] \\
+47 & 46 & 45 & 44 & 43 & 42 & 41 & 40 \\
+\SetCell[c=8]{c, bg=lightgray} upper[15:8] \\
+39 & 38 & 37 & 36 & 35 & 34 & 33 & 32 \\
+\SetCell[c=8]{c, bg=lightgray} upper[7:0] \\
+31 & 30 & 29 & 28 & 27 & 26 & 25 & 24 \\
+\SetCell[c=8]{c, bg=lightgray} lower[31:24] \\
+23 & 22 & 21 & 20 & 19 & 18 & 17 & 16 \\
+\SetCell[c=8]{c, bg=lightgray} lower[23:16] \\
+15 & 14 & 13 & 12 & 11 & 10 & 9 & 8 \\
+\SetCell[c=8]{c, bg=lightgray} lower[15:8] \\
+7 & 6 & 5 & 4 & 3 & 2 & 1 & 0 \\
+\SetCell[c=8]{c, bg=lightgray} lower[7:0] \\
+\end{regdraw}
+
+\begin{regdesc}
+63:32 & rw & upper & \\
+31:0 & rw & lower & \\
+\end{regdesc}
+
+
+\subsubsection{acq\textunderscore\allowbreak{}ddr.\allowbreak{}data32.\allowbreak{}data32}
+\label{sec:acq_ddr.data32.data32}
+\begin{regsummary}
+HW Prefix & acq\textunderscore\allowbreak{}ddr\textunderscore\allowbreak{}data32\textunderscore\allowbreak{}data32\\
+HW Address & 0x20000000\\
+C Prefix & acq\textunderscore\allowbreak{}ddr.\allowbreak{}data32.\allowbreak{}data32\\
+C Block Offset & 0x0\\
+\end{regsummary}
+
+\begin{regdraw}
+31 & 30 & 29 & 28 & 27 & 26 & 25 & 24 \\
+\SetCell[c=8]{c, bg=lightgray} upper[15:8] \\
+23 & 22 & 21 & 20 & 19 & 18 & 17 & 16 \\
+\SetCell[c=8]{c, bg=lightgray} upper[7:0] \\
+15 & 14 & 13 & 12 & 11 & 10 & 9 & 8 \\
+\SetCell[c=8]{c, bg=lightgray} lower[15:8] \\
+7 & 6 & 5 & 4 & 3 & 2 & 1 & 0 \\
+\SetCell[c=8]{c, bg=lightgray} lower[7:0] \\
+\end{regdraw}
+
+\begin{regdesc}
+31:16 & rw & upper & \\
+15:0 & rw & lower & \\
+\end{regdesc}
+
+
+\subsubsection{acq\textunderscore\allowbreak{}ram.\allowbreak{}data32.\allowbreak{}data32}
+\label{sec:acq_ram.data32.data32}
+\begin{regsummary}
+HW Prefix & acq\textunderscore\allowbreak{}ram\textunderscore\allowbreak{}data32\textunderscore\allowbreak{}data32\\
+HW Address & 0x80000000\\
+C Prefix & acq\textunderscore\allowbreak{}ram.\allowbreak{}data32.\allowbreak{}data32\\
+C Block Offset & 0x0\\
+\end{regsummary}
+
+\begin{regdraw}
+31 & 30 & 29 & 28 & 27 & 26 & 25 & 24 \\
+\SetCell[c=8]{c, bg=lightgray} upper[15:8] \\
+23 & 22 & 21 & 20 & 19 & 18 & 17 & 16 \\
+\SetCell[c=8]{c, bg=lightgray} upper[7:0] \\
+15 & 14 & 13 & 12 & 11 & 10 & 9 & 8 \\
+\SetCell[c=8]{c, bg=lightgray} lower[15:8] \\
+7 & 6 & 5 & 4 & 3 & 2 & 1 & 0 \\
+\SetCell[c=8]{c, bg=lightgray} lower[7:0] \\
+\end{regdraw}
+
+\begin{regdesc}
+31:16 & rw & upper & \\
+15:0 & rw & lower & \\
+\end{regdesc}
+
+

--- a/testfiles/issue9/main.tex
+++ b/testfiles/issue9/main.tex
@@ -1,0 +1,79 @@
+% Document set up (up to user preference)
+\documentclass{article}
+\usepackage[margin=25mm]{geometry}
+\usepackage[english]{babel}
+
+% Use sans serif font
+\usepackage{helvet}
+\renewcommand{\familydefault}{\sfdefault}
+
+% Required packages
+\usepackage{tabularray}
+\usepackage{hyperref}
+\usepackage{xcolor}
+\usepackage{ifdraft}
+
+% Memory Map
+\newenvironment{memmap}{
+  \vspace{5mm}
+  \centering
+  \begin{longtblr}{
+    width    = \textwidth,
+    hline{1} = {1pt},
+    hline{2} = {0.5pt},
+    hline{Z} = {1pt},
+    colspec  = {X[1.5] X[1] X[3] X[3]},
+  }
+  HW address & Type & Name & HDL name \\
+}{
+  \end{longtblr}
+}
+
+% Register Summary
+\newenvironment{regsummary}{
+  \centering
+  \begin{tblr}{
+    width    = \textwidth,
+    colspec  = {X[1] X[4]},
+  }
+}{
+  \end{tblr}
+}
+
+% Register Drawing
+\newenvironment{regdraw}{
+  \vspace{5mm}
+  \begin{center}
+  \begin{tblr}{
+    width    = \textwidth,
+    hlines,
+    vlines,
+    colspec  = {X[1,c] X[1,c] X[1,c] X[1,c] X[1,c] X[1,c] X[1,c] X[1,c]},
+    row{odd} = {font=\footnotesize}
+  }
+}{
+  \end{tblr}
+  \end{center}
+}
+
+% Register Description
+\newenvironment{regdesc}{
+  \vspace{5mm}
+  \centering
+  \begin{tblr}{
+    width    = \textwidth,
+    hline{1} = {1pt},
+    hline{2} = {0.5pt},
+    hline{Z} = {1pt},
+    colspec  = {X[1] X[1] X[3] X[6]},
+  }
+  Bits & R/W & Name & Description \\
+}{
+  \end{tblr}
+}
+
+\begin{document}
+
+\input{test.tex}
+
+\end{document}

--- a/testfiles/issue9/test.tex
+++ b/testfiles/issue9/test.tex
@@ -1,0 +1,115 @@
+\section{Memory Map Summary}
+Test AXI4-Lite interface
+
+\begin{memmap}
+0x00 & REG & \hyperref[sec:register1]{register1} & register1\\
+0x10-0x1f & BLOCK & block1 & block1\\
+0x10 & REG & \hyperref[sec:block1.register2]{block1.\allowbreak{}register2} & block1\textunderscore\allowbreak{}register2\\
+0x14 & REG & \hyperref[sec:block1.register3]{block1.\allowbreak{}register3} & block1\textunderscore\allowbreak{}register3\\
+0x18-0x1b & BLOCK & block1.\allowbreak{}block2 & block1\textunderscore\allowbreak{}block2\\
+0x18 & REG & \hyperref[sec:block1.block2.register4]{block1.\allowbreak{}block2.\allowbreak{}register4} & block1\textunderscore\allowbreak{}block2\textunderscore\allowbreak{}register4\\
+\end{memmap}
+
+\section{Register Description}
+\subsubsection{register1}
+\label{sec:register1}
+\begin{regsummary}
+HW Prefix & register1\\
+HW Address & 0x0\\
+C Prefix & register1\\
+C Block Offset & 0x0\\
+\end{regsummary}
+
+\begin{regdraw}
+31 & 30 & 29 & 28 & 27 & 26 & 25 & 24 \\
+\SetCell[c=8]{c, bg=lightgray} register1[31:24] \\
+23 & 22 & 21 & 20 & 19 & 18 & 17 & 16 \\
+\SetCell[c=8]{c, bg=lightgray} register1[23:16] \\
+15 & 14 & 13 & 12 & 11 & 10 & 9 & 8 \\
+\SetCell[c=8]{c, bg=lightgray} register1[15:8] \\
+7 & 6 & 5 & 4 & 3 & 2 & 1 & 0 \\
+\SetCell[c=8]{c, bg=lightgray} register1[7:0] \\
+\end{regdraw}
+
+\begin{regdesc}
+31:0 & wo & register1 & Test register 1\\
+\end{regdesc}
+
+
+\subsubsection{block1.\allowbreak{}register2}
+\label{sec:block1.register2}
+\begin{regsummary}
+HW Prefix & block1\textunderscore\allowbreak{}register2\\
+HW Address & 0x10\\
+C Prefix & block1.\allowbreak{}register2\\
+C Block Offset & 0x0\\
+\end{regsummary}
+
+\begin{regdraw}
+31 & 30 & 29 & 28 & 27 & 26 & 25 & 24 \\
+- & - & - & - & - & - & - & - \\
+23 & 22 & 21 & 20 & 19 & 18 & 17 & 16 \\
+- & - & - & - & - & - & - & - \\
+15 & 14 & 13 & 12 & 11 & 10 & 9 & 8 \\
+- & - & - & - & - & - & - & - \\
+7 & 6 & 5 & 4 & 3 & 2 & 1 & 0 \\
+- & - & - & - & \SetCell[c=3]{c, bg=lightgray} field2[2:0] & \SetCell{bg=lightgray} field1 \\
+\end{regdraw}
+
+\begin{regdesc}
+0 & ro & field1 & Test field 1\\
+3:1 & ro & field2 & Test field 2\\
+\end{regdesc}
+
+
+\subsubsection{block1.\allowbreak{}register3}
+\label{sec:block1.register3}
+\begin{regsummary}
+HW Prefix & block1\textunderscore\allowbreak{}register3\\
+HW Address & 0x14\\
+C Prefix & block1.\allowbreak{}register3\\
+C Block Offset & 0x4\\
+\end{regsummary}
+
+\begin{regdraw}
+31 & 30 & 29 & 28 & 27 & 26 & 25 & 24 \\
+\SetCell[c=8]{c, bg=lightgray} register3[31:24] \\
+23 & 22 & 21 & 20 & 19 & 18 & 17 & 16 \\
+\SetCell[c=8]{c, bg=lightgray} register3[23:16] \\
+15 & 14 & 13 & 12 & 11 & 10 & 9 & 8 \\
+\SetCell[c=8]{c, bg=lightgray} register3[15:8] \\
+7 & 6 & 5 & 4 & 3 & 2 & 1 & 0 \\
+\SetCell[c=8]{c, bg=lightgray} register3[7:0] \\
+\end{regdraw}
+
+\begin{regdesc}
+31:0 & rw & register3 & Test register 3\\
+\end{regdesc}
+
+
+\subsubsection{block1.\allowbreak{}block2.\allowbreak{}register4}
+\label{sec:block1.block2.register4}
+\begin{regsummary}
+HW Prefix & block1\textunderscore\allowbreak{}block2\textunderscore\allowbreak{}register4\\
+HW Address & 0x18\\
+C Prefix & block1.\allowbreak{}block2.\allowbreak{}register4\\
+C Block Offset & 0x0\\
+\end{regsummary}
+
+\begin{regdraw}
+31 & 30 & 29 & 28 & 27 & 26 & 25 & 24 \\
+- & - & - & - & - & - & - & - \\
+23 & 22 & 21 & 20 & 19 & 18 & 17 & 16 \\
+- & - & - & - & - & - & - & - \\
+15 & 14 & 13 & 12 & 11 & 10 & 9 & 8 \\
+- & - & - & - & - & - & - & - \\
+7 & 6 & 5 & 4 & 3 & 2 & 1 & 0 \\
+- & - & - & - & \SetCell[c=3]{c, bg=lightgray} field4[2:0] & \SetCell{bg=lightgray} field3 \\
+\end{regdraw}
+
+\begin{regdesc}
+0 & ro & field3 & Test field 3\\
+3:1 & ro & field4 & Test field 4\\
+\end{regdesc}
+
+


### PR DESCRIPTION
#### Description

This MR introduces support for generation of Latex documentation. Included changes:
 - Add `proto/cheby/print_latex.py` file which contains the python code to generate the Latex register description.
 - Add `doc/srcs/main.tex` file as a template for a main file that includes the automatically generated register description. The idea is that this file contains the user-configurable style definition, while the automatically generated file does not need to be changed manually.
 - Add baseline-comparison tests for Latex generation (based on existing tests for documentation).
 - Update documentation to include Latex.

Example for generated files: [issue84.zip](https://github.com/tgingold-cern/cheby/files/11945594/issue84.zip)

#### Discussion

I was honestly not sure where to put the template file (main.tex). Is the location `docs/srcs` ok?

I chose the tabularray package for the tables because it has multiple features that are useful here:
 1. Support for dynamic column widths (required to support different page sizes).
 2. Support for multi-page tables (e.g. memory map summary)
 3. Good options to achieve a similar style as the HTML version.

Unfortunately, it seems that PDF generation is quite slow. Thus, I've added an option to disable the nice register drawings to speed it up.

It would have been nice to group the registers somehow (e.g. in the PDF table of contents), but I did not find an easy way to add that.

What do you think?