### PR TITLE
Update user guide (or-clr-out) and readme (APB addition)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,11 @@ Add support for any construct in an address-space (issue#129)
 
 Output comments for 'repeat' when iogroup is true (issue#130)
 
-Fix crash in doc generation for nested repeat (github issue#4)
+Fix crash in doc generation for nested repeat (issue#67, github PR #4)
 
-Add support for Latex generation
+Add support for Latex generation (github PR #5)
+
+Add support for the APB bus (github PR #11)
 
 ## Version 1.5
 

--- a/doc/cheby-ug.txt
+++ b/doc/cheby-ug.txt
@@ -413,11 +413,12 @@ attribute.
 `autoclear`:: Only for outputs.  In case of a write from the bus, the value
 is set on the output ports for only one clock cycle and then cleared.
 
-`or-clr`:: A register is created, and the current value is or-ed with the
-input port.  The register is cleared on a write (when bits are 1).  This
-allows to capture events.  Software developers should be careful when using
-these registers: they should only clear bits that were read as 1; otherwise
-they could miss events.
+`or-clr`, `or-clr-out`:: A register is created, and the current value is or-ed
+with the input port. The register is cleared on a write (when bits are 1).
+This allows to capture events. The `or-clr-out` also outputs the resulting
+signal. This can be particularly useful to implement  level-based interrupts.
+Software developers should be careful when using these registers: they should
+only clear bits that were read as 1; otherwise they could miss events.
 
 Example of a register with two fields:
 


### PR DESCRIPTION
A small update to the documentation and readme:
 - Add documentation for `or-clr-out` (previously undocumented, but quite useful)
 - Update readme for 1.6 additions (mainly add note on APB)