### PR TITLE
Documentation Generation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,6 +22,27 @@ test_interaction:
     - cd testfiles/tb
     - ./run.sh
 
+documentation:
+  stage: build
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+      changes:
+      - doc/**/*
+  cache:
+    - key:
+        files:
+          - doc/Gemfile.lock
+      paths:
+        - doc/vendor/bundle
+  artifacts:
+    paths:
+      - doc/*.pdf
+  script:
+    - cd doc
+    - bundle config set --local path 'vendor/bundle'
+    - bundle install
+    - make all
+
 deploy:
   stage: deploy
   only:

--- a/doc/.gitignore
+++ b/doc/.gitignore
@@ -1,0 +1,7 @@
+vendor/bundle/
+srcs/*.h
+srcs/*.md
+srcs/*.vhdl
+
+# Do not enforce a specific version for asciidoctor-pdf
+Gemfile.lock

--- a/doc/Gemfile
+++ b/doc/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'asciidoctor-pdf'

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,7 +1,6 @@
 NAME=cheby-ug
 CHEBY=../proto/cheby.py
-
-all: $(NAME).pdf
+BUNDLER=bundle
 
 srcs/counter.vhdl: srcs/counter.cheby
 	$(CHEBY) --gen-hdl=$@ -i $<
@@ -18,13 +17,14 @@ srcs/counter.md: srcs/counter.cheby
 srcs/counter-reindent.md: srcs/counter.md
 	sed -e '/^=/s/^=/==/' < $< > $@
 
-$(NAME).xml: $(NAME).txt srcs/counter.cheby srcs/counter_entity.vhdl srcs/counter.h srcs/counter-reindent.md
-	asciidoctor -v -d book -b docbook $<
+$(NAME).pdf: $(NAME).txt srcs/counter.cheby srcs/counter_entity.vhdl srcs/counter.h srcs/counter-reindent.md
+	$(BUNDLER) exec asciidoctor-pdf -d book $<
 
-$(NAME).pdf: $(NAME).xml
-	a2x -f pdf $<
+install:
+	$(BUNDLER) install
+
+all: $(NAME).pdf
 
 clean:
-	$(RM) $(NAME).xml $(NAME).pdf
-	$(RM) srcs/counter.vhdl srcs/counter_entity.vhdl srcs/counter.h
-	$(RM) srcs/counter.md srcs/counter-reindent.md
+	$(RM) srcs/*.vhdl srcs/*.h srcs/*.md
+	$(RM) $(NAME).pdf


### PR DESCRIPTION
As discussed in https://github.com/tgingold-cern/cheby/issues/14#issuecomment-1691284264, here a more complete setup of the documentation generation using [Asciidoctor PDF](https://docs.asciidoctor.org/pdf-converter/latest/). Right now, the PDF is simply added as an artifact. It might make sense to remove the PDF altogether from the repository or extend the CI to add it once it was built.