### PR TITLE
Write mask

### DIFF
--- a/proto/cheby/hdl/apbbus.py
+++ b/proto/cheby/hdl/apbbus.py
@@ -49,9 +49,7 @@ class APBBus(BusGen):
             "wr_addr", root.c_addr_bits, lo_idx=root.c_addr_word_bits
         )
         ibus.wr_dat = module.new_HDLSignal("wr_data", root.c_word_bits)
-        ibus.wr_sel = module.new_HDLSignal(
-            "wr_strb", root.c_word_bits // tree.BYTE_SIZE
-        )
+        ibus.wr_sel = module.new_HDLSignal("wr_sel", root.c_word_bits)
 
         module.stmts.append(HDLComment("Write Channel"))
         # A write transfer consists of two phases, a setup and an access phase. The
@@ -87,7 +85,22 @@ class APBBus(BusGen):
         )
         module.stmts.append(HDLAssign(ibus.wr_adr, root.h_bus["paddr"]))
         module.stmts.append(HDLAssign(ibus.wr_dat, root.h_bus["pwdata"]))
-        module.stmts.append(HDLAssign(ibus.wr_sel, root.h_bus["pstrb"]))
+
+        # Translate Byte-wise write mask of APB bus to bit-wise write mask of ibus
+        proc = HDLComb()
+        proc.sensitivity.extend([root.h_bus["pstrb"]])
+        for idx in range(root.c_word_bits // tree.BYTE_SIZE):
+            proc.stmts.append(
+                HDLAssign(
+                    HDLSlice(ibus.wr_sel, idx * tree.BYTE_SIZE, tree.BYTE_SIZE),
+                    HDLReplicate(
+                        HDLSlice(root.h_bus["pstrb"], idx, None),
+                        tree.BYTE_SIZE,
+                        True,
+                    ),
+                )
+            )
+        module.stmts.append(proc)
 
     def expand_bus_r(self, root, module, ibus, opts):
         """Generate internal read bus and connect it with APB signals"""
@@ -316,7 +329,39 @@ class APBBus(BusGen):
             stmts.append(proc)
 
         stmts.append(HDLAssign(n.h_bus["pwdata"], ibus.wr_dat))
-        stmts.append(HDLAssign(n.h_bus["pstrb"], ibus.wr_sel or HDLReplicate(bit_1, 4)))
+
+        if ibus.wr_sel is not None:
+            # Translate bit-wise write mask of ibus to Byte-wise write mask of APB bus
+            proc = HDLComb()
+            proc.sensitivity.extend([ibus.wr_sel])
+            proc.stmts.append(
+                HDLAssign(
+                    n.h_bus["pstrb"],
+                    HDLReplicate(bit_0, root.c_word_bits // tree.BYTE_SIZE),
+                )
+            )
+            for idx in range(root.c_word_bits // tree.BYTE_SIZE):
+                proc_if = HDLIfElse(
+                    HDLNot(
+                        HDLEq(
+                            HDLSlice(ibus.wr_sel, idx * tree.BYTE_SIZE, tree.BYTE_SIZE),
+                            HDLReplicate(bit_0, tree.BYTE_SIZE, False),
+                        )
+                    )
+                )
+                proc_if.then_stmts.append(
+                    HDLAssign(HDLSlice(n.h_bus["pstrb"], idx, None), bit_1)
+                )
+                proc_if.else_stmts = None
+                proc.stmts.append(proc_if)
+            stmts.append(proc)
+        else:
+            stmts.append(
+                HDLAssign(
+                    n.h_bus["pstrb"],
+                    HDLReplicate(bit_1, root.c_word_bits // tree.BYTE_SIZE),
+                )
+            )
 
     def write_bus_slave(self, root, stmts, n, proc, ibus):
         proc.stmts.append(HDLAssign(n.i_wr_req, bit_0))

--- a/proto/cheby/hdl/genmemory.py
+++ b/proto/cheby/hdl/genmemory.py
@@ -136,12 +136,44 @@ class GenMemory(ElGen):
             # Use byte select on port A if available.
             bwsel = HDLReplicate(bit_1, wd // tree.BYTE_SIZE)
             if ibus.wr_sel is not None:
+                # Translate bit-wise write mask of internal bus to Byte-wise write mask
+                # of memory
+                bwselw_int = self.module.new_HDLSignal(
+                    mem.c_name + "_sel_int", self.root.c_word_bits // tree.BYTE_SIZE
+                )
+
+                proc = HDLComb()
+                proc.sensitivity.extend([ibus.wr_sel])
+                proc.stmts.append(
+                    HDLAssign(
+                        bwselw_int,
+                        HDLReplicate(bit_0, self.root.c_word_bits // tree.BYTE_SIZE),
+                    )
+                )
+                for idx in range(self.root.c_word_bits // tree.BYTE_SIZE):
+                    proc_if = HDLIfElse(
+                        HDLNot(
+                            HDLEq(
+                                HDLSlice(
+                                    ibus.wr_sel, idx * tree.BYTE_SIZE, tree.BYTE_SIZE
+                                ),
+                                HDLReplicate(bit_0, tree.BYTE_SIZE, False),
+                            )
+                        )
+                    )
+                    proc_if.then_stmts.append(
+                        HDLAssign(HDLSlice(bwselw_int, idx, None), bit_1)
+                    )
+                    proc_if.else_stmts = None
+                    proc.stmts.append(proc_if)
+                self.module.stmts.append(proc)
+
                 # May need to use a slice of bit selects if the RAM width is
                 # smaller than the bus width
                 if wd < self.root.c_word_bits:
-                    bwselw = HDLSlice(ibus.wr_sel, 0, wd // tree.BYTE_SIZE)
+                    bwselw = HDLSlice(bwselw_int, 0, wd // tree.BYTE_SIZE)
                 else:
-                    bwselw = ibus.wr_sel
+                    bwselw = bwselw_int
             else:
                 bwselw = bwsel
 

--- a/proto/cheby/hdl/genreg.py
+++ b/proto/cheby/hdl/genreg.py
@@ -63,14 +63,23 @@ class GenFieldBase(object):
         else:
             return Slice_or_Index(val, lo, w)
 
+    def extract_mask2(self, val, lo, w):
+        if val is None:
+            return None
+        else:
+            return self.extract_dat2(val, lo, w)
+
     def extract_reg(self, off, val):
         lo, w = self.extract_reg_bounds(off)
         return self.extract_reg2(val, lo, w)
 
-    def extract_reg_dat(self, off, reg, dat):
+    def extract_reg_dat(self, off, reg, dat, mask):
         lo, w = self.extract_reg_bounds(off)
-        return (self.extract_reg2(reg, lo, w),
-                self.extract_dat2(dat, self.field.lo + lo - off, w))
+        return (
+            self.extract_reg2(reg, lo, w),
+            self.extract_dat2(dat, self.field.lo + lo - off, w),
+            self.extract_mask2(mask, self.field.lo + lo - off, w),
+        )
 
     def get_offset_range(self):
         """Return an iterator on the address offsets for this register."""
@@ -117,8 +126,20 @@ class GenFieldReg(GenFieldBase):
         stmts.append(HDLAssign(self.field.h_oport, self.field.h_reg))
 
     def assign_reg(self, then_stmts, else_stmts, off, ibus):
-        reg, dat = self.extract_reg_dat(off, self.field.h_reg, ibus.wr_dat)
-        then_stmts.append(HDLAssign(reg, dat))
+        reg, dat, mask = self.extract_reg_dat(
+            off, self.field.h_reg, ibus.wr_dat, ibus.wr_sel
+        )
+        if mask is not None:
+            then_stmts.append(
+                HDLAssign(
+                    reg,
+                    HDLOr(
+                        HDLParen(HDLAnd(reg, HDLNot(mask))), HDLParen(HDLAnd(dat, mask))
+                    ),
+                )
+            )
+        else:
+            then_stmts.append(HDLAssign(reg, dat))
 
 class GenFieldWire(GenFieldBase):
     def need_iport(self):
@@ -133,8 +154,21 @@ class GenFieldWire(GenFieldBase):
     def connect_output(self, stmts, ibus):
         # Handle wire fields: create connections between the bus and the outputs.
         for off in self.get_offset_range():
-            reg, dat = self.extract_reg_dat(off, self.field.h_oport, ibus.wr_dat)
-            stmts.append(HDLAssign(reg, dat))
+            reg, dat, mask = self.extract_reg_dat(
+                off, self.field.h_oport, ibus.wr_dat, ibus.wr_sel
+            )
+            if mask is not None:
+                stmts.append(
+                    HDLAssign(
+                        reg,
+                        HDLOr(
+                            HDLParen(HDLAnd(reg, HDLNot(mask))),
+                            HDLParen(HDLAnd(dat, mask)),
+                        ),
+                    )
+                )
+            else:
+                stmts.append(HDLAssign(reg, dat))
 
 class GenFieldConst(GenFieldBase):
     def get_input(self, off):
@@ -155,10 +189,21 @@ class GenFieldAutoclear(GenFieldBase):
         return HDLConst(0, w if w != 1 else None)
 
     def assign_reg(self, then_stmts, else_stmts, off, ibus):
-        lo, w = self.extract_reg_bounds(off)
-        reg = self.extract_reg2(self.field.h_reg, lo, w)
-        dat = self.extract_dat2(ibus.wr_dat, self.field.lo + lo - off, w)
-        then_stmts.append(HDLAssign(reg, dat))
+        _, w = self.extract_reg_bounds(off)
+        reg, dat, mask = self.extract_reg_dat(
+            off, self.field.h_reg, ibus.wr_dat, ibus.wr_sel
+        )
+        if mask is not None:
+            then_stmts.append(
+                HDLAssign(
+                    reg,
+                    HDLOr(
+                        HDLParen(HDLAnd(reg, HDLNot(mask))), HDLParen(HDLAnd(dat, mask))
+                    ),
+                )
+            )
+        else:
+            then_stmts.append(HDLAssign(reg, dat))
         else_stmts.append(HDLAssign(reg, HDLConst(0, w if w != 1 else None)))
 
     def connect_output(self, stmts, ibus):
@@ -180,6 +225,8 @@ class GenFieldOrClr(GenFieldBase):
         inp = self.extract_reg2(self.field.h_iport, lo, w)
         reg = self.extract_reg2(self.field.h_reg, lo, w)
         dat = self.extract_dat2(ibus.wr_dat, self.field.lo + lo - off, w)
+        # Since a write request to the register is used to clear individual bits (and
+        # not to store a new value), the mask is not applied
         then_stmts.append(HDLAssign(reg, HDLOr(inp, HDLParen(HDLAnd(reg, HDLNot(dat))))))
         else_stmts.append(HDLAssign(reg, HDLOr(inp, reg)))
 

--- a/proto/cheby/hdl/genreg.py
+++ b/proto/cheby/hdl/genreg.py
@@ -129,7 +129,7 @@ class GenFieldReg(GenFieldBase):
         reg, dat, mask = self.extract_reg_dat(
             off, self.field.h_reg, ibus.wr_dat, ibus.wr_sel
         )
-        if mask is not None:
+        if self.root.c_wmask_reg and mask is not None:
             then_stmts.append(
                 HDLAssign(
                     reg,
@@ -157,7 +157,7 @@ class GenFieldWire(GenFieldBase):
             reg, dat, mask = self.extract_reg_dat(
                 off, self.field.h_oport, ibus.wr_dat, ibus.wr_sel
             )
-            if mask is not None:
+            if self.root.c_wmask_reg and mask is not None:
                 stmts.append(
                     HDLAssign(
                         reg,
@@ -193,7 +193,7 @@ class GenFieldAutoclear(GenFieldBase):
         reg, dat, mask = self.extract_reg_dat(
             off, self.field.h_reg, ibus.wr_dat, ibus.wr_sel
         )
-        if mask is not None:
+        if self.root.c_wmask_reg and mask is not None:
             then_stmts.append(
                 HDLAssign(
                     reg,

--- a/proto/cheby/hdl/ibus.py
+++ b/proto/cheby/hdl/ibus.py
@@ -1,6 +1,4 @@
-from cheby.hdltree import (HDLAssign, HDLSync, HDLComment,
-                           bit_0)
-import cheby.tree as tree
+from cheby.hdltree import HDLAssign, HDLSync, HDLComment, bit_0
 from cheby.hdl.globals import gconfig
 
 
@@ -55,7 +53,12 @@ class Ibus:
         names.extend([('wr_req', c_wi, 'i', None, None),
                       ('wr_adr', c_wi, 'i', self.addr_size, self.addr_low),
                       ('wr_dat', c_wi, 'i', self.data_size, 0),
-                      ('wr_sel', c_wi, 'i', self.data_size // tree.BYTE_SIZE, 0)])
+                      # The write mask of the internal bus operates on a per bit level.
+                      # In case of a more coarse selection at an upper interface
+                      # driving the internal bus, it is supposed that the EDA tool will
+                      # make the necessary optimizations to propagate the reduce mask
+                      # width down to the application of it in the internal bus.
+                      ('wr_sel', c_wi, 'i', self.data_size, 0)])
         c_wo = 'wr-out' in conds
         names.extend([('wr_ack', c_wo, 'o', None, None),
                       ('wr_err', c_wo, 'o', None, None)])

--- a/proto/cheby/hdl/wbbus.py
+++ b/proto/cheby/hdl/wbbus.py
@@ -43,7 +43,24 @@ class WBBus(BusGen):
         ibus.rst = root.h_bus['brst']
         ibus.rd_dat = root.h_bus['dato']
         ibus.wr_dat = root.h_bus['dati']
-        ibus.wr_sel = root.h_bus['sel']
+
+        # Translate Byte-wise write mask of Wishbone bus to bit-wise write mask of ibus
+        ibus.wr_sel = module.new_HDLSignal('wr_sel', root.c_word_bits)
+        proc = HDLComb()
+        proc.sensitivity.extend([root.h_bus['sel']])
+        for idx in range(root.c_word_bits // tree.BYTE_SIZE):
+            proc.stmts.append(
+                HDLAssign(
+                    HDLSlice(ibus.wr_sel, idx * tree.BYTE_SIZE, tree.BYTE_SIZE),
+                    HDLReplicate(
+                        HDLSlice(root.h_bus['sel'], idx, None),
+                        tree.BYTE_SIZE,
+                        True,
+                    ),
+                )
+            )
+        module.stmts.append(proc)
+
         if ibus.addr_size > 0:
             if busgroup:
                 addr = module.new_HDLSignal('adr_int', ibus.addr_size, lo_idx=ibus.addr_low)
@@ -299,7 +316,41 @@ class WBBus(BusGen):
             else:
                 stmts.append(HDLAssign(n.h_bus['adr'],
                                     self.slice_addr(ibus.rd_adr, root, n)))
-        stmts.append(HDLAssign(n.h_bus['sel'], ibus.wr_sel or HDLReplicate(bit_1, 4)))
+
+        if ibus.wr_sel is not None:
+            # Translate bit-wise write mask of internal bus to Byte-wise write mask of
+            # Wishbone bus
+            proc = HDLComb()
+            proc.sensitivity.extend([ibus.wr_sel])
+            proc.stmts.append(
+                HDLAssign(
+                    n.h_bus['sel'],
+                    HDLReplicate(bit_0, root.c_word_bits // tree.BYTE_SIZE),
+                )
+            )
+            for idx in range(root.c_word_bits // tree.BYTE_SIZE):
+                proc_if = HDLIfElse(
+                    HDLNot(
+                        HDLEq(
+                            HDLSlice(ibus.wr_sel, idx * tree.BYTE_SIZE, tree.BYTE_SIZE),
+                            HDLReplicate(bit_0, tree.BYTE_SIZE, False),
+                        )
+                    )
+                )
+                proc_if.then_stmts.append(
+                    HDLAssign(HDLSlice(n.h_bus['sel'], idx, None), bit_1)
+                )
+                proc_if.else_stmts = None
+                proc.stmts.append(proc_if)
+            stmts.append(proc)
+        else:
+            stmts.append(
+                HDLAssign(
+                    n.h_bus['sel'],
+                    HDLReplicate(bit_1, root.c_word_bits // tree.BYTE_SIZE),
+                )
+            )
+
         stmts.append(HDLAssign(n.h_bus['we'], n.h_wt))
         stmts.append(HDLAssign(n.h_bus['dati'], ibus.wr_dat))
 

--- a/proto/cheby/layout.py
+++ b/proto/cheby/layout.py
@@ -649,12 +649,14 @@ def layout_bus(root, name):
        * c_align_reg
        * c_bussplit
        * c_buserr
+       * c_wmask_reg
        And deduce:
        * c_addr_word_bits
        * c_word_bits"""
     root.c_align_reg = True
     root.c_buserr = False
     root.c_bussplit = False
+    root.c_wmask_reg = False
     if name is None:    # default
         root.c_word_size = 4
         root.c_word_endian = 'big'
@@ -733,6 +735,7 @@ def copy_bus(dst, src):
     dst.c_align_reg = src.c_align_reg
     dst.c_bussplit = src.c_bussplit
     dst.c_buserr = src.c_buserr
+    dst.c_wmask_reg = src.c_wmask_reg
     dst.c_addr_word_bits = src.c_addr_word_bits
     dst.c_word_bits = src.c_word_bits
 

--- a/proto/cheby/print_vhdl.py
+++ b/proto/cheby/print_vhdl.py
@@ -445,6 +445,10 @@ def generate_stmts(fd, stmts, indent):
             w(fd, sindent)
             generate_assign(fd, s)
         elif isinstance(s, hdltree.HDLComb):
+            # Print processes only if they contain statements
+            if not s.stmts:
+                continue
+
             w(fd, sindent)
             if s.name is not None:
                 w(fd, '{}: '.format(s.name))

--- a/testfiles/bug-memory/mem64ro.vhdl
+++ b/testfiles/bug-memory/mem64ro.vhdl
@@ -31,6 +31,7 @@ entity mem64ro is
 end mem64ro;
 
 architecture syn of mem64ro is
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal rd_req_int                     : std_logic;
   signal wr_req_int                     : std_logic;
   signal rd_ack_int                     : std_logic;
@@ -55,10 +56,18 @@ architecture syn of mem64ro is
   signal wr_req_d0                      : std_logic;
   signal wr_adr_d0                      : std_logic_vector(9 downto 2);
   signal wr_dat_d0                      : std_logic_vector(31 downto 0);
-  signal wr_sel_d0                      : std_logic_vector(3 downto 0);
+  signal wr_sel_d0                      : std_logic_vector(31 downto 0);
+  signal DdrCapturesIndex_sel_int       : std_logic_vector(3 downto 0);
+  signal DdrCapturesIndex_sel_int       : std_logic_vector(3 downto 0);
 begin
 
   -- WB decode signals
+  process (wb_sel_i) begin
+    wr_sel(7 downto 0) <= (others => wb_sel_i(0));
+    wr_sel(15 downto 8) <= (others => wb_sel_i(1));
+    wr_sel(23 downto 16) <= (others => wb_sel_i(2));
+    wr_sel(31 downto 24) <= (others => wb_sel_i(3));
+  end process;
   wb_en <= wb_cyc_i and wb_stb_i;
 
   process (clk_i) begin
@@ -101,7 +110,7 @@ begin
         wr_req_d0 <= wr_req_int;
         wr_adr_d0 <= wb_adr_i;
         wr_dat_d0 <= wb_dat_i;
-        wr_sel_d0 <= wb_sel_i;
+        wr_sel_d0 <= wr_sel;
       end if;
     end if;
   end process;
@@ -135,7 +144,7 @@ begin
       clk_a_i              => clk_i,
       clk_b_i              => clk_i,
       addr_a_i             => wb_adr_i(8 downto 3),
-      bwsel_a_i            => wr_sel_d0,
+      bwsel_a_i            => DdrCapturesIndex_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => DdrCapturesIndex_DdrCaptures_int_dato0,
       rd_a_i               => DdrCapturesIndex_DdrCaptures_rreq0,
@@ -148,6 +157,21 @@ begin
       wr_b_i               => DdrCapturesIndex_DdrCaptures_we_i
     );
   
+  process (wr_sel_d0) begin
+    DdrCapturesIndex_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      DdrCapturesIndex_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      DdrCapturesIndex_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      DdrCapturesIndex_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      DdrCapturesIndex_sel_int(3) <= '1';
+    end if;
+  end process;
   DdrCapturesIndex_DdrCaptures_raminst1: cheby_dpssram
     generic map (
       g_data_width         => 32,
@@ -160,7 +184,7 @@ begin
       clk_a_i              => clk_i,
       clk_b_i              => clk_i,
       addr_a_i             => wb_adr_i(8 downto 3),
-      bwsel_a_i            => wr_sel_d0,
+      bwsel_a_i            => DdrCapturesIndex_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => DdrCapturesIndex_DdrCaptures_int_dato1,
       rd_a_i               => DdrCapturesIndex_DdrCaptures_rreq1,
@@ -173,6 +197,21 @@ begin
       wr_b_i               => DdrCapturesIndex_DdrCaptures_we_i
     );
   
+  process (wr_sel_d0) begin
+    DdrCapturesIndex_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      DdrCapturesIndex_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      DdrCapturesIndex_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      DdrCapturesIndex_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      DdrCapturesIndex_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk_i) begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then

--- a/testfiles/crossbar/crossbar.v
+++ b/testfiles/crossbar/crossbar.v
@@ -12,6 +12,7 @@ module crossbar_wb
     // WB bus bran
     t_wishbone.master bran
   );
+  reg [31:0] wr_sel;
   wire [17:2] adr_int;
   wire rd_req_int;
   wire wr_req_int;
@@ -47,9 +48,16 @@ module crossbar_wb
   reg wr_req_d0;
   reg [17:2] wr_adr_d0;
   reg [31:0] wr_dat_d0;
-  reg [3:0] wr_sel_d0;
+  reg [31:0] wr_sel_d0;
 
   // WB decode signals
+  always @(wb.sel)
+      begin
+        wr_sel[7:0] <= {8{wb.sel[0]}};
+        wr_sel[15:8] <= {8{wb.sel[1]}};
+        wr_sel[23:16] <= {8{wb.sel[2]}};
+        wr_sel[31:24] <= {8{wb.sel[3]}};
+      end
   assign adr_int = wb.adr[17:2];
   assign wb_en = wb.cyc & wb.stb;
 
@@ -92,7 +100,7 @@ module crossbar_wb
         wr_req_d0 <= wr_req_int;
         wr_adr_d0 <= adr_int;
         wr_dat_d0 <= wb.dato;
-        wr_sel_d0 <= wb.sel;
+        wr_sel_d0 <= wr_sel;
       end
   end
 
@@ -116,7 +124,18 @@ module crossbar_wb
   assign jesdavalon_wack = jesdavalon.ack & jesdavalon_wt;
   assign jesdavalon_rack = jesdavalon.ack & jesdavalon_rt;
   assign jesdavalon.adr = {22'b0, adr_int[9:2], 2'b0};
-  assign jesdavalon.sel = wr_sel_d0;
+  always @(wr_sel_d0)
+      begin
+        jesdavalon.sel <= 4'b0;
+        if (!(wr_sel_d0[7:0] == 8'b0))
+          jesdavalon.sel[0] <= 1'b1;
+        if (!(wr_sel_d0[15:8] == 8'b0))
+          jesdavalon.sel[1] <= 1'b1;
+        if (!(wr_sel_d0[23:16] == 8'b0))
+          jesdavalon.sel[2] <= 1'b1;
+        if (!(wr_sel_d0[31:24] == 8'b0))
+          jesdavalon.sel[3] <= 1'b1;
+      end
   assign jesdavalon.we = jesdavalon_wt;
   assign jesdavalon.dato = wr_dat_d0;
 
@@ -140,7 +159,18 @@ module crossbar_wb
   assign i2ctowb_wack = i2ctowb.ack & i2ctowb_wt;
   assign i2ctowb_rack = i2ctowb.ack & i2ctowb_rt;
   assign i2ctowb.adr = {18'b0, adr_int[13:2], 2'b0};
-  assign i2ctowb.sel = wr_sel_d0;
+  always @(wr_sel_d0)
+      begin
+        i2ctowb.sel <= 4'b0;
+        if (!(wr_sel_d0[7:0] == 8'b0))
+          i2ctowb.sel[0] <= 1'b1;
+        if (!(wr_sel_d0[15:8] == 8'b0))
+          i2ctowb.sel[1] <= 1'b1;
+        if (!(wr_sel_d0[23:16] == 8'b0))
+          i2ctowb.sel[2] <= 1'b1;
+        if (!(wr_sel_d0[31:24] == 8'b0))
+          i2ctowb.sel[3] <= 1'b1;
+      end
   assign i2ctowb.we = i2ctowb_wt;
   assign i2ctowb.dato = wr_dat_d0;
 
@@ -164,7 +194,18 @@ module crossbar_wb
   assign bran_wack = bran.ack & bran_wt;
   assign bran_rack = bran.ack & bran_rt;
   assign bran.adr = {15'b0, adr_int[16:2], 2'b0};
-  assign bran.sel = wr_sel_d0;
+  always @(wr_sel_d0)
+      begin
+        bran.sel <= 4'b0;
+        if (!(wr_sel_d0[7:0] == 8'b0))
+          bran.sel[0] <= 1'b1;
+        if (!(wr_sel_d0[15:8] == 8'b0))
+          bran.sel[1] <= 1'b1;
+        if (!(wr_sel_d0[23:16] == 8'b0))
+          bran.sel[2] <= 1'b1;
+        if (!(wr_sel_d0[31:24] == 8'b0))
+          bran.sel[3] <= 1'b1;
+      end
   assign bran.we = bran_wt;
   assign bran.dato = wr_dat_d0;
 

--- a/testfiles/features/mem64ro.vhdl
+++ b/testfiles/features/mem64ro.vhdl
@@ -31,6 +31,7 @@ entity mem64ro is
 end mem64ro;
 
 architecture syn of mem64ro is
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal rd_req_int                     : std_logic;
   signal wr_req_int                     : std_logic;
   signal rd_ack_int                     : std_logic;
@@ -55,10 +56,18 @@ architecture syn of mem64ro is
   signal wr_req_d0                      : std_logic;
   signal wr_adr_d0                      : std_logic_vector(9 downto 2);
   signal wr_dat_d0                      : std_logic_vector(31 downto 0);
-  signal wr_sel_d0                      : std_logic_vector(3 downto 0);
+  signal wr_sel_d0                      : std_logic_vector(31 downto 0);
+  signal DdrCapturesIndex_sel_int       : std_logic_vector(3 downto 0);
+  signal DdrCapturesIndex_sel_int       : std_logic_vector(3 downto 0);
 begin
 
   -- WB decode signals
+  process (wb_sel_i) begin
+    wr_sel(7 downto 0) <= (others => wb_sel_i(0));
+    wr_sel(15 downto 8) <= (others => wb_sel_i(1));
+    wr_sel(23 downto 16) <= (others => wb_sel_i(2));
+    wr_sel(31 downto 24) <= (others => wb_sel_i(3));
+  end process;
   wb_en <= wb_cyc_i and wb_stb_i;
 
   process (clk_i) begin
@@ -101,7 +110,7 @@ begin
         wr_req_d0 <= wr_req_int;
         wr_adr_d0 <= wb_adr_i;
         wr_dat_d0 <= wb_dat_i;
-        wr_sel_d0 <= wb_sel_i;
+        wr_sel_d0 <= wr_sel;
       end if;
     end if;
   end process;
@@ -135,7 +144,7 @@ begin
       clk_a_i              => clk_i,
       clk_b_i              => clk_i,
       addr_a_i             => wb_adr_i(8 downto 3),
-      bwsel_a_i            => wr_sel_d0,
+      bwsel_a_i            => DdrCapturesIndex_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => DdrCapturesIndex_DdrCaptures_int_dato0,
       rd_a_i               => DdrCapturesIndex_DdrCaptures_rreq0,
@@ -148,6 +157,21 @@ begin
       wr_b_i               => DdrCapturesIndex_DdrCaptures_we_i
     );
   
+  process (wr_sel_d0) begin
+    DdrCapturesIndex_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      DdrCapturesIndex_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      DdrCapturesIndex_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      DdrCapturesIndex_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      DdrCapturesIndex_sel_int(3) <= '1';
+    end if;
+  end process;
   DdrCapturesIndex_DdrCaptures_raminst1: cheby_dpssram
     generic map (
       g_data_width         => 32,
@@ -160,7 +184,7 @@ begin
       clk_a_i              => clk_i,
       clk_b_i              => clk_i,
       addr_a_i             => wb_adr_i(8 downto 3),
-      bwsel_a_i            => wr_sel_d0,
+      bwsel_a_i            => DdrCapturesIndex_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => DdrCapturesIndex_DdrCaptures_int_dato1,
       rd_a_i               => DdrCapturesIndex_DdrCaptures_rreq1,
@@ -173,6 +197,21 @@ begin
       wr_b_i               => DdrCapturesIndex_DdrCaptures_we_i
     );
   
+  process (wr_sel_d0) begin
+    DdrCapturesIndex_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      DdrCapturesIndex_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      DdrCapturesIndex_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      DdrCapturesIndex_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      DdrCapturesIndex_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk_i) begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then

--- a/testfiles/features/mem64rodual.vhdl
+++ b/testfiles/features/mem64rodual.vhdl
@@ -28,6 +28,7 @@ entity mem64rodual is
 end mem64rodual;
 
 architecture syn of mem64rodual is
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal rd_req_int                     : std_logic;
   signal wr_req_int                     : std_logic;
   signal rd_ack_int                     : std_logic;
@@ -47,10 +48,18 @@ architecture syn of mem64rodual is
   signal rd_ack_d0                      : std_logic;
   signal rd_dat_d0                      : std_logic_vector(31 downto 0);
   signal wr_req_d0                      : std_logic;
-  signal wr_sel_d0                      : std_logic_vector(3 downto 0);
+  signal wr_sel_d0                      : std_logic_vector(31 downto 0);
+  signal DdrCapturesIndex_sel_int       : std_logic_vector(3 downto 0);
+  signal DdrCapturesIndex_sel_int       : std_logic_vector(3 downto 0);
 begin
 
   -- WB decode signals
+  process (wb_sel_i) begin
+    wr_sel(7 downto 0) <= (others => wb_sel_i(0));
+    wr_sel(15 downto 8) <= (others => wb_sel_i(1));
+    wr_sel(23 downto 16) <= (others => wb_sel_i(2));
+    wr_sel(31 downto 24) <= (others => wb_sel_i(3));
+  end process;
   wb_en <= wb_cyc_i and wb_stb_i;
 
   process (clk_i) begin
@@ -91,7 +100,7 @@ begin
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;
         wr_req_d0 <= wr_req_int;
-        wr_sel_d0 <= wb_sel_i;
+        wr_sel_d0 <= wr_sel;
       end if;
     end if;
   end process;
@@ -109,7 +118,7 @@ begin
       clk_a_i              => clk_i,
       clk_b_i              => DdrCapturesIndex_clk_i,
       addr_a_i             => wb_adr_i(8 downto 3),
-      bwsel_a_i            => wr_sel_d0,
+      bwsel_a_i            => DdrCapturesIndex_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => DdrCapturesIndex_DdrCaptures_int_dato0,
       rd_a_i               => DdrCapturesIndex_DdrCaptures_rreq0,
@@ -122,6 +131,21 @@ begin
       wr_b_i               => DdrCapturesIndex_DdrCaptures_we_i
     );
   
+  process (wr_sel_d0) begin
+    DdrCapturesIndex_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      DdrCapturesIndex_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      DdrCapturesIndex_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      DdrCapturesIndex_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      DdrCapturesIndex_sel_int(3) <= '1';
+    end if;
+  end process;
   DdrCapturesIndex_DdrCaptures_raminst1: cheby_dpssram
     generic map (
       g_data_width         => 32,
@@ -134,7 +158,7 @@ begin
       clk_a_i              => clk_i,
       clk_b_i              => DdrCapturesIndex_clk_i,
       addr_a_i             => wb_adr_i(8 downto 3),
-      bwsel_a_i            => wr_sel_d0,
+      bwsel_a_i            => DdrCapturesIndex_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => DdrCapturesIndex_DdrCaptures_int_dato1,
       rd_a_i               => DdrCapturesIndex_DdrCaptures_rreq1,
@@ -147,6 +171,21 @@ begin
       wr_b_i               => DdrCapturesIndex_DdrCaptures_we_i
     );
   
+  process (wr_sel_d0) begin
+    DdrCapturesIndex_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      DdrCapturesIndex_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      DdrCapturesIndex_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      DdrCapturesIndex_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      DdrCapturesIndex_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk_i) begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then

--- a/testfiles/features/xilinx_attrs.vhdl
+++ b/testfiles/features/xilinx_attrs.vhdl
@@ -54,7 +54,7 @@ architecture syn of xilinx_attrs is
   signal wr_ack                         : std_logic;
   signal wr_addr                        : std_logic_vector(2 downto 2);
   signal wr_data                        : std_logic_vector(31 downto 0);
-  signal wr_strb                        : std_logic_vector(3 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal axi_awset                      : std_logic;
   signal axi_wset                       : std_logic;
   signal axi_wdone                      : std_logic;
@@ -74,7 +74,7 @@ architecture syn of xilinx_attrs is
   signal wr_req_d0                      : std_logic;
   signal wr_adr_d0                      : std_logic_vector(2 downto 2);
   signal wr_dat_d0                      : std_logic_vector(31 downto 0);
-  signal wr_sel_d0                      : std_logic_vector(3 downto 0);
+  signal wr_sel_d0                      : std_logic_vector(31 downto 0);
   attribute X_INTERFACE_INFO : string;
   attribute X_INTERFACE_INFO of awvalid : signal is
     "xilinx.com:interface:aximm:1.0 slave AWVALID";
@@ -174,7 +174,10 @@ begin
         end if;
         if wvalid = '1' and axi_wset = '0' then
           wr_data <= wdata;
-          wr_strb <= wstrb;
+          wr_sel(7 downto 0) <= (others => wstrb(0));
+          wr_sel(15 downto 8) <= (others => wstrb(1));
+          wr_sel(23 downto 16) <= (others => wstrb(2));
+          wr_sel(31 downto 24) <= (others => wstrb(3));
           axi_wset <= '1';
           wr_req <= axi_awset or awvalid;
         end if;
@@ -233,7 +236,7 @@ begin
         wr_req_d0 <= wr_req;
         wr_adr_d0 <= wr_addr;
         wr_dat_d0 <= wr_data;
-        wr_sel_d0 <= wr_strb;
+        wr_sel_d0 <= wr_sel;
       end if;
     end if;
   end process;
@@ -244,7 +247,21 @@ begin
   subm_awprot_o <= "000";
   subm_wvalid_o <= subm_w_val;
   subm_wdata_o <= wr_dat_d0;
-  subm_wstrb_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    subm_wstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      subm_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      subm_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      subm_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      subm_wstrb_o(3) <= '1';
+    end if;
+  end process;
   subm_bready_o <= '1';
   subm_arvalid_o <= subm_ar_val;
   subm_araddr_o <= rd_addr(2 downto 2);

--- a/testfiles/issue77/s1.vhdl
+++ b/testfiles/issue77/s1.vhdl
@@ -42,7 +42,7 @@ architecture syn of s1 is
   signal wr_req                         : std_logic;
   signal wr_ack                         : std_logic;
   signal wr_data                        : std_logic_vector(31 downto 0);
-  signal wr_strb                        : std_logic_vector(3 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal axi_awset                      : std_logic;
   signal axi_wset                       : std_logic;
   signal axi_wdone                      : std_logic;
@@ -64,7 +64,7 @@ architecture syn of s1 is
   signal rd_dat_d0                      : std_logic_vector(31 downto 0);
   signal wr_req_d0                      : std_logic;
   signal wr_dat_d0                      : std_logic_vector(31 downto 0);
-  signal wr_sel_d0                      : std_logic_vector(3 downto 0);
+  signal wr_sel_d0                      : std_logic_vector(31 downto 0);
 begin
 
   -- AW, W and B channels
@@ -86,7 +86,10 @@ begin
         end if;
         if wvalid = '1' and axi_wset = '0' then
           wr_data <= wdata;
-          wr_strb <= wstrb;
+          wr_sel(7 downto 0) <= (others => wstrb(0));
+          wr_sel(15 downto 8) <= (others => wstrb(1));
+          wr_sel(23 downto 16) <= (others => wstrb(2));
+          wr_sel(31 downto 24) <= (others => wstrb(3));
           axi_wset <= '1';
           wr_req <= axi_awset or awvalid;
         end if;
@@ -143,7 +146,7 @@ begin
         rd_data <= rd_dat_d0;
         wr_req_d0 <= wr_req;
         wr_dat_d0 <= wr_data;
-        wr_sel_d0 <= wr_strb;
+        wr_sel_d0 <= wr_sel;
       end if;
     end if;
   end process;
@@ -169,7 +172,21 @@ begin
   sub_stb_o <= sub_tr;
   sub_wack <= sub_ack_i and sub_wt;
   sub_rack <= sub_ack_i and sub_rt;
-  sub_sel_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub_sel_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub_sel_o(3) <= '1';
+    end if;
+  end process;
   sub_we_o <= sub_wt;
   sub_dat_o <= wr_dat_d0;
 

--- a/testfiles/issue77/s3.vhdl
+++ b/testfiles/issue77/s3.vhdl
@@ -49,7 +49,7 @@ architecture syn of s3 is
   signal wr_req                         : std_logic;
   signal wr_ack                         : std_logic;
   signal wr_data                        : std_logic_vector(31 downto 0);
-  signal wr_strb                        : std_logic_vector(3 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal axi_awset                      : std_logic;
   signal axi_wset                       : std_logic;
   signal axi_wdone                      : std_logic;
@@ -67,7 +67,7 @@ architecture syn of s3 is
   signal rd_dat_d0                      : std_logic_vector(31 downto 0);
   signal wr_req_d0                      : std_logic;
   signal wr_dat_d0                      : std_logic_vector(31 downto 0);
-  signal wr_sel_d0                      : std_logic_vector(3 downto 0);
+  signal wr_sel_d0                      : std_logic_vector(31 downto 0);
 begin
 
   -- AW, W and B channels
@@ -89,7 +89,10 @@ begin
         end if;
         if wvalid = '1' and axi_wset = '0' then
           wr_data <= wdata;
-          wr_strb <= wstrb;
+          wr_sel(7 downto 0) <= (others => wstrb(0));
+          wr_sel(15 downto 8) <= (others => wstrb(1));
+          wr_sel(23 downto 16) <= (others => wstrb(2));
+          wr_sel(31 downto 24) <= (others => wstrb(3));
           axi_wset <= '1';
           wr_req <= axi_awset or awvalid;
         end if;
@@ -146,7 +149,7 @@ begin
         rd_data <= rd_dat_d0;
         wr_req_d0 <= wr_req;
         wr_dat_d0 <= wr_data;
-        wr_sel_d0 <= wr_strb;
+        wr_sel_d0 <= wr_sel;
       end if;
     end if;
   end process;
@@ -156,7 +159,21 @@ begin
   sub_awprot_o <= "000";
   sub_wvalid_o <= sub_w_val;
   sub_wdata_o <= wr_dat_d0;
-  sub_wstrb_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub_wstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub_bready_o <= '1';
   sub_arvalid_o <= sub_ar_val;
   sub_arprot_o <= "000";

--- a/testfiles/issue77/s4.vhdl
+++ b/testfiles/issue77/s4.vhdl
@@ -36,6 +36,7 @@ entity s4 is
 end s4;
 
 architecture syn of s4 is
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal rd_req_int                     : std_logic;
   signal wr_req_int                     : std_logic;
   signal rd_ack_int                     : std_logic;
@@ -59,10 +60,16 @@ architecture syn of s4 is
   signal wr_req_d0                      : std_logic;
   signal wr_adr_d0                      : std_logic_vector(2 downto 2);
   signal wr_dat_d0                      : std_logic_vector(31 downto 0);
-  signal wr_sel_d0                      : std_logic_vector(3 downto 0);
+  signal wr_sel_d0                      : std_logic_vector(31 downto 0);
 begin
 
   -- WB decode signals
+  process (wb_sel_i) begin
+    wr_sel(7 downto 0) <= (others => wb_sel_i(0));
+    wr_sel(15 downto 8) <= (others => wb_sel_i(1));
+    wr_sel(23 downto 16) <= (others => wb_sel_i(2));
+    wr_sel(31 downto 24) <= (others => wb_sel_i(3));
+  end process;
   wb_en <= wb_cyc_i and wb_stb_i;
 
   process (clk_i) begin
@@ -105,7 +112,7 @@ begin
         wr_req_d0 <= wr_req_int;
         wr_adr_d0 <= wb_adr_i;
         wr_dat_d0 <= wb_dat_i;
-        wr_sel_d0 <= wb_sel_i;
+        wr_sel_d0 <= wr_sel;
       end if;
     end if;
   end process;
@@ -143,7 +150,21 @@ begin
   sub_stb_o <= sub_tr;
   sub_wack <= sub_ack_i and sub_wt;
   sub_rack <= sub_ack_i and sub_rt;
-  sub_sel_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub_sel_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub_sel_o(3) <= '1';
+    end if;
+  end process;
   sub_we_o <= sub_wt;
   sub_dat_o <= wr_dat_d0;
 

--- a/testfiles/issue77/s5.vhdl
+++ b/testfiles/issue77/s5.vhdl
@@ -29,6 +29,7 @@ entity s5 is
 end s5;
 
 architecture syn of s5 is
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal rd_req_int                     : std_logic;
   signal wr_req_int                     : std_logic;
   signal rd_ack_int                     : std_logic;
@@ -52,10 +53,16 @@ architecture syn of s5 is
   signal wr_req_d0                      : std_logic;
   signal wr_adr_d0                      : std_logic_vector(2 downto 2);
   signal wr_dat_d0                      : std_logic_vector(31 downto 0);
-  signal wr_sel_d0                      : std_logic_vector(3 downto 0);
+  signal wr_sel_d0                      : std_logic_vector(31 downto 0);
 begin
 
   -- WB decode signals
+  process (wb_sel_i) begin
+    wr_sel(7 downto 0) <= (others => wb_sel_i(0));
+    wr_sel(15 downto 8) <= (others => wb_sel_i(1));
+    wr_sel(23 downto 16) <= (others => wb_sel_i(2));
+    wr_sel(31 downto 24) <= (others => wb_sel_i(3));
+  end process;
   wb_en <= wb_cyc_i and wb_stb_i;
 
   process (clk_i) begin
@@ -98,7 +105,7 @@ begin
         wr_req_d0 <= wr_req_int;
         wr_adr_d0 <= wb_adr_i;
         wr_dat_d0 <= wb_dat_i;
-        wr_sel_d0 <= wb_sel_i;
+        wr_sel_d0 <= wr_sel;
       end if;
     end if;
   end process;
@@ -137,7 +144,21 @@ begin
   sub_wack <= sub_i.ack and sub_wt;
   sub_rack <= sub_i.ack and sub_rt;
   sub_o.adr <= ((29 downto 0 => '0') & wb_adr_i(1 downto 2)) & (1 downto 0 => '0');
-  sub_o.sel <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub_o.sel <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub_o.sel(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub_o.sel(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub_o.sel(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub_o.sel(3) <= '1';
+    end if;
+  end process;
   sub_o.we <= sub_wt;
   sub_o.dat <= wr_dat_d0;
 

--- a/testfiles/issue79/CSR.vhdl
+++ b/testfiles/issue79/CSR.vhdl
@@ -55,6 +55,7 @@ entity csr is
 end csr;
 
 architecture syn of csr is
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal rd_req_int                     : std_logic;
   signal wr_req_int                     : std_logic;
   signal rd_ack_int                     : std_logic;
@@ -86,10 +87,18 @@ architecture syn of csr is
   signal wr_req_d0                      : std_logic;
   signal wr_adr_d0                      : std_logic_vector(15 downto 2);
   signal wr_dat_d0                      : std_logic_vector(31 downto 0);
-  signal wr_sel_d0                      : std_logic_vector(3 downto 0);
+  signal wr_sel_d0                      : std_logic_vector(31 downto 0);
+  signal adc_offs_sel_int               : std_logic_vector(3 downto 0);
+  signal adc_meas_sel_int               : std_logic_vector(3 downto 0);
 begin
 
   -- WB decode signals
+  process (wb_sel_i) begin
+    wr_sel(7 downto 0) <= (others => wb_sel_i(0));
+    wr_sel(15 downto 8) <= (others => wb_sel_i(1));
+    wr_sel(23 downto 16) <= (others => wb_sel_i(2));
+    wr_sel(31 downto 24) <= (others => wb_sel_i(3));
+  end process;
   wb_en <= wb_cyc_i and wb_stb_i;
 
   process (clk_i) begin
@@ -132,7 +141,7 @@ begin
         wr_req_d0 <= wr_req_int;
         wr_adr_d0 <= wb_adr_i;
         wr_dat_d0 <= wb_dat_i;
-        wr_sel_d0 <= wb_sel_i;
+        wr_sel_d0 <= wr_sel;
       end if;
     end if;
   end process;
@@ -175,7 +184,21 @@ begin
   i2c_master_wack <= i2c_master_ack_i and i2c_master_wt;
   i2c_master_rack <= i2c_master_ack_i and i2c_master_rt;
   i2c_master_adr_o <= wb_adr_i(4 downto 2);
-  i2c_master_sel_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    i2c_master_sel_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      i2c_master_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      i2c_master_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      i2c_master_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      i2c_master_sel_o(3) <= '1';
+    end if;
+  end process;
   i2c_master_we_o <= i2c_master_wt;
   i2c_master_dat_o <= wr_dat_d0;
 
@@ -192,7 +215,7 @@ begin
       clk_a_i              => clk_i,
       clk_b_i              => clk_i,
       addr_a_i             => wb_adr_i(13 downto 2),
-      bwsel_a_i            => wr_sel_d0,
+      bwsel_a_i            => adc_offs_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => adc_offs_data_int_dato,
       rd_a_i               => adc_offs_data_rreq,
@@ -205,6 +228,21 @@ begin
       wr_b_i               => adc_offs_data_we_i
     );
   
+  process (wr_sel_d0) begin
+    adc_offs_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      adc_offs_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      adc_offs_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      adc_offs_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      adc_offs_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk_i) begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
@@ -228,7 +266,7 @@ begin
       clk_a_i              => clk_i,
       clk_b_i              => clk_i,
       addr_a_i             => wb_adr_i(13 downto 2),
-      bwsel_a_i            => wr_sel_d0,
+      bwsel_a_i            => adc_meas_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => adc_meas_data_int_dato,
       rd_a_i               => adc_meas_data_rreq,
@@ -241,6 +279,21 @@ begin
       wr_b_i               => adc_meas_data_we_i
     );
   
+  process (wr_sel_d0) begin
+    adc_meas_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      adc_meas_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      adc_meas_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      adc_meas_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      adc_meas_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk_i) begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then

--- a/testfiles/issue84/sps200CavityControl_as.vhdl
+++ b/testfiles/issue84/sps200CavityControl_as.vhdl
@@ -75,7 +75,7 @@ architecture syn of sps200CavityControl_regs is
   signal wr_ack                         : std_logic;
   signal wr_addr                        : std_logic_vector(20 downto 2);
   signal wr_data                        : std_logic_vector(31 downto 0);
-  signal wr_strb                        : std_logic_vector(3 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal axi_awset                      : std_logic;
   signal axi_wset                       : std_logic;
   signal axi_wdone                      : std_logic;
@@ -100,7 +100,7 @@ architecture syn of sps200CavityControl_regs is
   signal wr_req_d0                      : std_logic;
   signal wr_adr_d0                      : std_logic_vector(20 downto 2);
   signal wr_dat_d0                      : std_logic_vector(31 downto 0);
-  signal wr_sel_d0                      : std_logic_vector(3 downto 0);
+  signal wr_sel_d0                      : std_logic_vector(31 downto 0);
 begin
 
   -- AW, W and B channels
@@ -123,7 +123,10 @@ begin
         end if;
         if wvalid = '1' and axi_wset = '0' then
           wr_data <= wdata;
-          wr_strb <= wstrb;
+          wr_sel(7 downto 0) <= (others => wstrb(0));
+          wr_sel(15 downto 8) <= (others => wstrb(1));
+          wr_sel(23 downto 16) <= (others => wstrb(2));
+          wr_sel(31 downto 24) <= (others => wstrb(3));
           axi_wset <= '1';
           wr_req <= axi_awset or awvalid;
         end if;
@@ -182,7 +185,7 @@ begin
         wr_req_d0 <= wr_req;
         wr_adr_d0 <= wr_addr;
         wr_dat_d0 <= wr_data;
-        wr_sel_d0 <= wr_strb;
+        wr_sel_d0 <= wr_sel;
       end if;
     end if;
   end process;
@@ -193,7 +196,21 @@ begin
   hwInfo_awprot_o <= "000";
   hwInfo_wvalid_o <= hwInfo_w_val;
   hwInfo_wdata_o <= wr_dat_d0;
-  hwInfo_wstrb_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    hwInfo_wstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      hwInfo_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      hwInfo_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      hwInfo_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      hwInfo_wstrb_o(3) <= '1';
+    end if;
+  end process;
   hwInfo_bready_o <= '1';
   hwInfo_arvalid_o <= hwInfo_ar_val;
   hwInfo_araddr_o <= rd_addr(4 downto 2) & "00";
@@ -219,7 +236,21 @@ begin
   app_awprot_o <= "000";
   app_wvalid_o <= app_w_val;
   app_wdata_o <= wr_dat_d0;
-  app_wstrb_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    app_wstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      app_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      app_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      app_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      app_wstrb_o(3) <= '1';
+    end if;
+  end process;
   app_bready_o <= '1';
   app_arvalid_o <= app_ar_val;
   app_araddr_o <= rd_addr(18 downto 2) & "00";

--- a/testfiles/tb/.gitignore
+++ b/testfiles/tb/.gitignore
@@ -58,3 +58,11 @@ reg7const_wb.vhdl
 reg8orclr_wb.cheby
 reg8orclr_wb.vhdl
 sub2_axi4.vhdl
+wmask_apb.cheby
+wmask_apb.vhdl
+wmask_avalon.cheby
+wmask_avalon.vhdl
+wmask_axi4.cheby
+wmask_axi4.vhdl
+wmask_wb.cheby
+wmask_wb.vhdl

--- a/testfiles/tb/apb_tb_pkg.vhdl
+++ b/testfiles/tb/apb_tb_pkg.vhdl
@@ -31,6 +31,23 @@ package apb_tb_pkg is
     signal bus_i : in  t_apb_master_in;
     addr         : in  std_logic_vector(31 downto 0);
     data         : in  std_logic_vector(datalen - 1 downto 0);
+    mask         : in  std_logic_vector(datalen/8 - 1 downto 0);
+    slverr       : in  std_logic);
+
+  procedure apb_write (
+    signal clk_i : in  std_logic;
+    signal bus_o : out t_apb_master_out;
+    signal bus_i : in  t_apb_master_in;
+    addr         : in  std_logic_vector(31 downto 0);
+    data         : in  std_logic_vector(datalen - 1 downto 0);
+    mask         : in  std_logic_vector(datalen/8 - 1 downto 0));
+
+  procedure apb_write (
+    signal clk_i : in  std_logic;
+    signal bus_o : out t_apb_master_out;
+    signal bus_i : in  t_apb_master_in;
+    addr         : in  std_logic_vector(31 downto 0);
+    data         : in  std_logic_vector(datalen - 1 downto 0);
     slverr       : in  std_logic);
 
   procedure apb_write (
@@ -81,6 +98,7 @@ package body apb_tb_pkg is
       signal bus_i : in  t_apb_master_in;
       addr         : in  std_logic_vector(31 downto 0);
       data         : in  std_logic_vector(datalen - 1 downto 0);
+      mask         : in  std_logic_vector(datalen/8 - 1 downto 0);
       slverr       : in  std_logic) is
   begin
     wait until rising_edge(clk_i);
@@ -93,7 +111,7 @@ package body apb_tb_pkg is
       pwrite  => '1',
       penable => '0',
       pwdata  => data,
-      pstrb   => (others => '1')
+      pstrb   => mask
     );
 
     wait until rising_edge(clk_i);
@@ -123,9 +141,31 @@ package body apb_tb_pkg is
       signal bus_o : out t_apb_master_out;
       signal bus_i : in  t_apb_master_in;
       addr         : in  std_logic_vector(31 downto 0);
+      data         : in  std_logic_vector(datalen - 1 downto 0);
+      mask         : in  std_logic_vector(datalen/8 - 1 downto 0)) is
+  begin
+    apb_write(clk_i, bus_o, bus_i, addr, data, mask, '0');
+  end apb_write;
+
+  procedure apb_write (
+      signal clk_i : in  std_logic;
+      signal bus_o : out t_apb_master_out;
+      signal bus_i : in  t_apb_master_in;
+      addr         : in  std_logic_vector(31 downto 0);
+      data         : in  std_logic_vector(datalen - 1 downto 0);
+      slverr       : in  std_logic) is
+  begin
+    apb_write(clk_i, bus_o, bus_i, addr, data, (others => '1'), slverr);
+  end apb_write;
+
+  procedure apb_write (
+      signal clk_i : in  std_logic;
+      signal bus_o : out t_apb_master_out;
+      signal bus_i : in  t_apb_master_in;
+      addr         : in  std_logic_vector(31 downto 0);
       data         : in  std_logic_vector(datalen - 1 downto 0)) is
   begin
-    apb_write(clk_i, bus_o, bus_i, addr, data, '0');
+    apb_write(clk_i, bus_o, bus_i, addr, data, (others => '1'), '0');
   end apb_write;
 
   procedure apb_read (

--- a/testfiles/tb/avalon_tb_pkg.vhdl
+++ b/testfiles/tb/avalon_tb_pkg.vhdl
@@ -20,11 +20,20 @@ package avalon_tb_pkg is
                       signal avmm_in  : t_avmm_master_in;
                       signal avmm_out   : inout t_avmm_master_out);
 
-  procedure avmm_writel (signal clk     : std_logic;
-                         signal avmm_in  : t_avmm_master_in;
-                         signal avmm_out   : inout t_avmm_master_out;
-                         addr : std_logic_vector (31 downto 0);
-                         data : std_logic_vector (31 downto 0));
+  procedure avmm_writel(
+    signal clk      : in  std_logic;
+    signal avmm_in  : in  t_avmm_master_in;
+    signal avmm_out : out t_avmm_master_out;
+    addr            : in  std_logic_vector(31 downto 0);
+    data            : in  std_logic_vector(31 downto 0);
+    mask            : in  std_logic_vector(3 downto 0));
+
+  procedure avmm_writel(
+    signal clk      : in  std_logic;
+    signal avmm_in  : in  t_avmm_master_in;
+    signal avmm_out : out t_avmm_master_out;
+    addr            : in  std_logic_vector(31 downto 0);
+    data            : in  std_logic_vector(31 downto 0));
 
   procedure avmm_readl (signal clk     : std_logic;
                         signal avmm_in  : t_avmm_master_in;
@@ -42,36 +51,49 @@ package body avalon_tb_pkg is
     avmm_out.write <= '0';
   end avmm_init;
 
-  procedure avmm_writel (signal clk     : std_logic;
-                         signal avmm_in  : t_avmm_master_in;
-                         signal avmm_out   : inout t_avmm_master_out;
-                         addr : std_logic_vector (31 downto 0);
-                         data : std_logic_vector (31 downto 0))
-    is
-      variable rdata : std_logic_vector (31 downto 0);
-    begin
-      --  W transfer
-      avmm_out.write <= '1';
-      avmm_out.writedata <= data;
-      avmm_out.address <= addr;
-      avmm_out.byteenable <= "1111";
+  procedure avmm_writel(
+    signal clk      : in  std_logic;
+    signal avmm_in  : in  t_avmm_master_in;
+    signal avmm_out : out t_avmm_master_out;
+    addr            : in  std_logic_vector(31 downto 0);
+    data            : in  std_logic_vector(31 downto 0);
+    mask            : in  std_logic_vector(3 downto 0)) is
 
-      --  Wait until the request is accepted
-      loop
-        wait until rising_edge(clk);
-        exit when avmm_in.waitrequest = '0';
-      end loop;
+    variable rdata : std_logic_vector (31 downto 0);
+  begin
+    --  W transfer
+    avmm_out.write      <= '1';
+    avmm_out.writedata  <= data;
+    avmm_out.address    <= addr;
+    avmm_out.byteenable <= mask;
 
-      avmm_out.write <= '0';
-      avmm_out.writedata <= (others => 'X');
-      avmm_out.address <= (others => 'X');
+    --  Wait until the request is accepted
+    loop
+      wait until rising_edge(clk);
+      exit when avmm_in.waitrequest = '0';
+    end loop;
 
-      --  Wait until the bus is free (or until the request has been handled).
-      loop
-        wait until rising_edge(clk);
-        exit when avmm_in.waitrequest = '0';
-      end loop;
-    end avmm_writel;
+    avmm_out.write      <= '0';
+    avmm_out.writedata  <= (others => 'X');
+    avmm_out.address    <= (others => 'X');
+    avmm_out.byteenable <= (others => 'X');
+
+    --  Wait until the bus is free (or until the request has been handled).
+    loop
+      wait until rising_edge(clk);
+      exit when avmm_in.waitrequest = '0';
+    end loop;
+  end avmm_writel;
+
+  procedure avmm_writel(
+    signal clk      : in  std_logic;
+    signal avmm_in  : in  t_avmm_master_in;
+    signal avmm_out : out t_avmm_master_out;
+    addr            : in  std_logic_vector(31 downto 0);
+    data            : in  std_logic_vector(31 downto 0)) is
+  begin
+    avmm_writel(clk, avmm_in, avmm_out, addr, data, (others => '1'));
+  end avmm_writel;
 
     procedure avmm_readl (signal clk     : std_logic;
                         signal avmm_in  : t_avmm_master_in;

--- a/testfiles/tb/block1_apb.vhdl
+++ b/testfiles/tb/block1_apb.vhdl
@@ -18,6 +18,7 @@ begin
   process(bus_in)
     -- Preload single memory row with modules address
     variable mem     : std_logic_vector(31 downto 0) := x"0000_5000";
+    variable mask    : std_logic_vector(31 downto 0);
     variable pattern : std_logic_vector(31 downto 0);
   begin
     bus_out.pready  <= '0';
@@ -31,9 +32,14 @@ begin
 
       -- Write transaction
       if bus_in.pwrite = '1' then
+        -- Write mask
+        for idx in 3 downto 0 loop
+          mask((idx+1)*8-1 downto idx*8) := (others => bus_in.pstrb(idx));
+        end loop;
+
         if bus_in.paddr(11 downto 2) = (11 downto 2 => '0') then
           -- Write to memory
-          mem := bus_in.pwdata;
+          mem := (mem and not(mask)) or (bus_in.pwdata and mask);
         else
           -- Check pattern
           pattern( 7 downto  0) := not bus_in.paddr(9 downto 2);

--- a/testfiles/tb/block1_axi4.vhdl
+++ b/testfiles/tb/block1_axi4.vhdl
@@ -24,8 +24,8 @@ begin
       variable rdata_set : boolean;
 
       --  One line of memory.
-      variable mem : std_logic_vector(31 downto 0) := x"0000_2000";
-
+      variable mem     : std_logic_vector(31 downto 0) := x"0000_2000";
+      variable mask    : std_logic_vector(31 downto 0);
       variable pattern : std_logic_vector(31 downto 0);
 
       --  Wait states
@@ -92,8 +92,14 @@ begin
           end if;
 
           if sub2_wr_in.wvalid = '1' then
-            wdata := sub2_wr_in.wdata;
             wdata_set := true;
+            wdata     := sub2_wr_in.wdata;
+
+            -- Write mask
+            for idx in 3 downto 0 loop
+              mask((idx+1)*8-1 downto idx*8) := (others => sub2_wr_in.wstrb(idx));
+            end loop;
+
             sub2_wr_out.wready <= '0';
           end if;
 
@@ -102,7 +108,7 @@ begin
               wws := wws + 1;
             elsif wws = cur_wws then
               if awaddr = "0000000000" then
-                mem := wdata;
+                mem := (mem and not(mask)) or (wdata and mask);
               else
                 pattern( 7 downto  0) := not awaddr(9 downto 2);
                 pattern(15 downto  8) := awaddr(9 downto 2);

--- a/testfiles/tb/dpssram.vhdl
+++ b/testfiles/tb/dpssram.vhdl
@@ -45,14 +45,20 @@ begin
 
     variable addr_a : natural;
     variable addr_b : natural;
+    variable mask_a : std_logic_vector(g_data_width-1 downto 0);
+    variable mask_b : std_logic_vector(g_data_width-1 downto 0);
   begin
     wait until rising_edge(clk_a_i) or rising_edge(clk_b_i);
 
+    for idx in mask_a'range loop
+      mask_a(idx) := bwsel_a_i(idx / 8);
+      mask_b(idx) := bwsel_b_i(idx / 8);
+    end loop ;
+
     if rising_edge(clk_a_i) then
       if wr_a_i = '1' then
-        --  TODO: handle wbsel.
         addr_a := to_integer(unsigned(addr_a_i));
-        ram(addr_a) := data_a_i;
+        ram(addr_a) := (ram(addr_a) and not(mask_a)) or (data_a_i and mask_a);
       end if;
       if rd_a_i = '1' then
         addr_a := to_integer(unsigned(addr_a_i));
@@ -62,9 +68,8 @@ begin
 
     if rising_edge(clk_b_i) then
       if wr_b_i = '1' then
-        --  TODO: handle wbsel.
         addr_b := to_integer(unsigned(addr_b_i));
-        ram(addr_b) := data_b_i;
+        ram(addr_b) := (ram(addr_b) and not(mask_b)) or (data_b_i and mask_b);
       end if;
       if rd_a_i = '1' then
         addr_b := to_integer(unsigned(addr_b_i));

--- a/testfiles/tb/golden_files/addrwidth_axi4_mst_byte-byte.vhdl
+++ b/testfiles/tb/golden_files/addrwidth_axi4_mst_byte-byte.vhdl
@@ -57,7 +57,7 @@ architecture syn of addrwidth_axi4_byte is
   signal wr_ack                         : std_logic;
   signal wr_addr                        : std_logic_vector(3 downto 2);
   signal wr_data                        : std_logic_vector(31 downto 0);
-  signal wr_strb                        : std_logic_vector(3 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal axi_awset                      : std_logic;
   signal axi_wset                       : std_logic;
   signal axi_wdone                      : std_logic;
@@ -80,7 +80,7 @@ architecture syn of addrwidth_axi4_byte is
   signal wr_req_d0                      : std_logic;
   signal wr_adr_d0                      : std_logic_vector(3 downto 2);
   signal wr_dat_d0                      : std_logic_vector(31 downto 0);
-  signal wr_sel_d0                      : std_logic_vector(3 downto 0);
+  signal wr_sel_d0                      : std_logic_vector(31 downto 0);
 begin
 
   -- AW, W and B channels
@@ -103,7 +103,10 @@ begin
         end if;
         if wvalid = '1' and axi_wset = '0' then
           wr_data <= wdata;
-          wr_strb <= wstrb;
+          wr_sel(7 downto 0) <= (others => wstrb(0));
+          wr_sel(15 downto 8) <= (others => wstrb(1));
+          wr_sel(23 downto 16) <= (others => wstrb(2));
+          wr_sel(31 downto 24) <= (others => wstrb(3));
           axi_wset <= '1';
           wr_req <= axi_awset or awvalid;
         end if;
@@ -162,7 +165,7 @@ begin
         wr_req_d0 <= wr_req;
         wr_adr_d0 <= wr_addr;
         wr_dat_d0 <= wr_data;
-        wr_sel_d0 <= wr_strb;
+        wr_sel_d0 <= wr_sel;
       end if;
     end if;
   end process;
@@ -189,7 +192,21 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wr_dat_d0;
-  sub2_axi4_wstrb_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= rd_addr(2 downto 2) & "00";

--- a/testfiles/tb/golden_files/addrwidth_axi4_mst_byte-word.vhdl
+++ b/testfiles/tb/golden_files/addrwidth_axi4_mst_byte-word.vhdl
@@ -57,7 +57,7 @@ architecture syn of addrwidth_axi4_byte is
   signal wr_ack                         : std_logic;
   signal wr_addr                        : std_logic_vector(3 downto 2);
   signal wr_data                        : std_logic_vector(31 downto 0);
-  signal wr_strb                        : std_logic_vector(3 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal axi_awset                      : std_logic;
   signal axi_wset                       : std_logic;
   signal axi_wdone                      : std_logic;
@@ -80,7 +80,7 @@ architecture syn of addrwidth_axi4_byte is
   signal wr_req_d0                      : std_logic;
   signal wr_adr_d0                      : std_logic_vector(3 downto 2);
   signal wr_dat_d0                      : std_logic_vector(31 downto 0);
-  signal wr_sel_d0                      : std_logic_vector(3 downto 0);
+  signal wr_sel_d0                      : std_logic_vector(31 downto 0);
 begin
 
   -- AW, W and B channels
@@ -103,7 +103,10 @@ begin
         end if;
         if wvalid = '1' and axi_wset = '0' then
           wr_data <= wdata;
-          wr_strb <= wstrb;
+          wr_sel(7 downto 0) <= (others => wstrb(0));
+          wr_sel(15 downto 8) <= (others => wstrb(1));
+          wr_sel(23 downto 16) <= (others => wstrb(2));
+          wr_sel(31 downto 24) <= (others => wstrb(3));
           axi_wset <= '1';
           wr_req <= axi_awset or awvalid;
         end if;
@@ -162,7 +165,7 @@ begin
         wr_req_d0 <= wr_req;
         wr_adr_d0 <= wr_addr;
         wr_dat_d0 <= wr_data;
-        wr_sel_d0 <= wr_strb;
+        wr_sel_d0 <= wr_sel;
       end if;
     end if;
   end process;
@@ -189,7 +192,21 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wr_dat_d0;
-  sub2_axi4_wstrb_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= rd_addr(2 downto 2);

--- a/testfiles/tb/golden_files/addrwidth_axi4_mst_word-byte.vhdl
+++ b/testfiles/tb/golden_files/addrwidth_axi4_mst_word-byte.vhdl
@@ -57,7 +57,7 @@ architecture syn of addrwidth_axi4_word is
   signal wr_ack                         : std_logic;
   signal wr_addr                        : std_logic_vector(3 downto 2);
   signal wr_data                        : std_logic_vector(31 downto 0);
-  signal wr_strb                        : std_logic_vector(3 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal axi_awset                      : std_logic;
   signal axi_wset                       : std_logic;
   signal axi_wdone                      : std_logic;
@@ -80,7 +80,7 @@ architecture syn of addrwidth_axi4_word is
   signal wr_req_d0                      : std_logic;
   signal wr_adr_d0                      : std_logic_vector(3 downto 2);
   signal wr_dat_d0                      : std_logic_vector(31 downto 0);
-  signal wr_sel_d0                      : std_logic_vector(3 downto 0);
+  signal wr_sel_d0                      : std_logic_vector(31 downto 0);
 begin
 
   -- AW, W and B channels
@@ -103,7 +103,10 @@ begin
         end if;
         if wvalid = '1' and axi_wset = '0' then
           wr_data <= wdata;
-          wr_strb <= wstrb;
+          wr_sel(7 downto 0) <= (others => wstrb(0));
+          wr_sel(15 downto 8) <= (others => wstrb(1));
+          wr_sel(23 downto 16) <= (others => wstrb(2));
+          wr_sel(31 downto 24) <= (others => wstrb(3));
           axi_wset <= '1';
           wr_req <= axi_awset or awvalid;
         end if;
@@ -162,7 +165,7 @@ begin
         wr_req_d0 <= wr_req;
         wr_adr_d0 <= wr_addr;
         wr_dat_d0 <= wr_data;
-        wr_sel_d0 <= wr_strb;
+        wr_sel_d0 <= wr_sel;
       end if;
     end if;
   end process;
@@ -189,7 +192,21 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wr_dat_d0;
-  sub2_axi4_wstrb_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= rd_addr(2 downto 2) & "00";

--- a/testfiles/tb/golden_files/all1_apb_all.vhdl
+++ b/testfiles/tb/golden_files/all1_apb_all.vhdl
@@ -107,7 +107,7 @@ architecture syn of all1_apb is
   signal wr_req                         : std_logic;
   signal wr_addr                        : std_logic_vector(14 downto 2);
   signal wr_data                        : std_logic_vector(31 downto 0);
-  signal wr_strb                        : std_logic_vector(3 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal rd_req                         : std_logic;
   signal rd_addr                        : std_logic_vector(14 downto 2);
   signal rd_data                        : std_logic_vector(31 downto 0);
@@ -174,11 +174,13 @@ architecture syn of all1_apb is
   signal wr_req_d0                      : std_logic;
   signal wr_adr_d0                      : std_logic_vector(14 downto 2);
   signal wr_dat_d0                      : std_logic_vector(31 downto 0);
-  signal wr_sel_d0                      : std_logic_vector(3 downto 0);
+  signal wr_sel_d0                      : std_logic_vector(31 downto 0);
   signal wr_ack_d0                      : std_logic;
   signal ram1_wr                        : std_logic;
   signal ram1_wreq                      : std_logic;
   signal ram1_adr_int                   : std_logic_vector(2 downto 0);
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
   signal ram2_wp                        : std_logic;
   signal ram2_we                        : std_logic;
 begin
@@ -187,7 +189,12 @@ begin
   wr_req <= (psel and pwrite) and not penable;
   wr_addr <= paddr;
   wr_data <= pwdata;
-  wr_strb <= pstrb;
+  process (pstrb) begin
+    wr_sel(7 downto 0) <= (others => pstrb(0));
+    wr_sel(15 downto 8) <= (others => pstrb(1));
+    wr_sel(23 downto 16) <= (others => pstrb(2));
+    wr_sel(31 downto 24) <= (others => pstrb(3));
+  end process;
 
   -- Read Channel
   rd_req <= (psel and not pwrite) and not penable;
@@ -212,7 +219,7 @@ begin
         wr_req_d0 <= wr_req;
         wr_adr_d0 <= wr_addr;
         wr_dat_d0 <= wr_data;
-        wr_sel_d0 <= wr_strb;
+        wr_sel_d0 <= wr_sel;
         wr_ack <= wr_ack_d0;
       end if;
     end if;
@@ -272,7 +279,7 @@ begin
       clk_a_i              => pclk,
       clk_b_i              => pclk,
       addr_a_i             => ram1_adr_int,
-      bwsel_a_i            => wr_sel_d0,
+      bwsel_a_i            => ram1_sel_int,
       data_a_i             => wr_dat_d0,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
@@ -285,6 +292,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel_d0) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (pclk) begin
     if rising_edge(pclk) then
       if presetn = '0' then
@@ -308,7 +330,7 @@ begin
       clk_a_i              => pclk,
       clk_b_i              => pclk,
       addr_a_i             => rd_adr_d0(4 downto 2),
-      bwsel_a_i            => wr_sel_d0,
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -321,6 +343,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel_d0) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (pclk) begin
     if rising_edge(pclk) then
       if presetn = '0' then
@@ -388,7 +425,21 @@ begin
       sub1_wb_adr_o <= rd_adr_d0(11 downto 2);
     end if;
   end process;
-  sub1_wb_sel_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
   sub1_wb_dat_o <= wr_dat_d0;
 
@@ -398,7 +449,21 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wr_dat_d0;
-  sub2_axi4_wstrb_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= rd_adr_d0(11 downto 2);
@@ -470,7 +535,21 @@ begin
       sub4_avalon_address_o <= rd_adr_d0(11 downto 2);
     end if;
   end process;
-  sub4_avalon_byteenable_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
   sub4_avalon_writedata_o <= wr_dat_d0;
@@ -508,7 +587,21 @@ begin
     end if;
   end process;
   sub5_apb_pwdata_o <= wr_dat_d0;
-  sub5_apb_pstrb_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
   process (wr_adr_d0, wr_req_d0, reg1_wack, reg2_wack, ram2_we, sub1_wb_wack,

--- a/testfiles/tb/golden_files/all1_apb_in,out.vhdl
+++ b/testfiles/tb/golden_files/all1_apb_in,out.vhdl
@@ -107,7 +107,7 @@ architecture syn of all1_apb is
   signal wr_req                         : std_logic;
   signal wr_addr                        : std_logic_vector(14 downto 2);
   signal wr_data                        : std_logic_vector(31 downto 0);
-  signal wr_strb                        : std_logic_vector(3 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal rd_req                         : std_logic;
   signal rd_addr                        : std_logic_vector(14 downto 2);
   signal rd_data                        : std_logic_vector(31 downto 0);
@@ -174,11 +174,13 @@ architecture syn of all1_apb is
   signal wr_req_d0                      : std_logic;
   signal wr_adr_d0                      : std_logic_vector(14 downto 2);
   signal wr_dat_d0                      : std_logic_vector(31 downto 0);
-  signal wr_sel_d0                      : std_logic_vector(3 downto 0);
+  signal wr_sel_d0                      : std_logic_vector(31 downto 0);
   signal wr_ack_d0                      : std_logic;
   signal ram1_wr                        : std_logic;
   signal ram1_wreq                      : std_logic;
   signal ram1_adr_int                   : std_logic_vector(2 downto 0);
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
   signal ram2_wp                        : std_logic;
   signal ram2_we                        : std_logic;
 begin
@@ -187,7 +189,12 @@ begin
   wr_req <= (psel and pwrite) and not penable;
   wr_addr <= paddr;
   wr_data <= pwdata;
-  wr_strb <= pstrb;
+  process (pstrb) begin
+    wr_sel(7 downto 0) <= (others => pstrb(0));
+    wr_sel(15 downto 8) <= (others => pstrb(1));
+    wr_sel(23 downto 16) <= (others => pstrb(2));
+    wr_sel(31 downto 24) <= (others => pstrb(3));
+  end process;
 
   -- Read Channel
   rd_req <= (psel and not pwrite) and not penable;
@@ -212,7 +219,7 @@ begin
         wr_req_d0 <= wr_req;
         wr_adr_d0 <= wr_addr;
         wr_dat_d0 <= wr_data;
-        wr_sel_d0 <= wr_strb;
+        wr_sel_d0 <= wr_sel;
         wr_ack <= wr_ack_d0;
       end if;
     end if;
@@ -272,7 +279,7 @@ begin
       clk_a_i              => pclk,
       clk_b_i              => pclk,
       addr_a_i             => ram1_adr_int,
-      bwsel_a_i            => wr_sel_d0,
+      bwsel_a_i            => ram1_sel_int,
       data_a_i             => wr_dat_d0,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
@@ -285,6 +292,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel_d0) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (pclk) begin
     if rising_edge(pclk) then
       if presetn = '0' then
@@ -308,7 +330,7 @@ begin
       clk_a_i              => pclk,
       clk_b_i              => pclk,
       addr_a_i             => rd_adr_d0(4 downto 2),
-      bwsel_a_i            => wr_sel_d0,
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -321,6 +343,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel_d0) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (pclk) begin
     if rising_edge(pclk) then
       if presetn = '0' then
@@ -388,7 +425,21 @@ begin
       sub1_wb_adr_o <= rd_adr_d0(11 downto 2);
     end if;
   end process;
-  sub1_wb_sel_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
   sub1_wb_dat_o <= wr_dat_d0;
 
@@ -398,7 +449,21 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wr_dat_d0;
-  sub2_axi4_wstrb_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= rd_adr_d0(11 downto 2);
@@ -470,7 +535,21 @@ begin
       sub4_avalon_address_o <= rd_adr_d0(11 downto 2);
     end if;
   end process;
-  sub4_avalon_byteenable_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
   sub4_avalon_writedata_o <= wr_dat_d0;
@@ -508,7 +587,21 @@ begin
     end if;
   end process;
   sub5_apb_pwdata_o <= wr_dat_d0;
-  sub5_apb_pstrb_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
   process (wr_adr_d0, wr_req_d0, reg1_wack, reg2_wack, ram2_we, sub1_wb_wack,

--- a/testfiles/tb/golden_files/all1_apb_in.vhdl
+++ b/testfiles/tb/golden_files/all1_apb_in.vhdl
@@ -107,7 +107,7 @@ architecture syn of all1_apb is
   signal wr_req                         : std_logic;
   signal wr_addr                        : std_logic_vector(14 downto 2);
   signal wr_data                        : std_logic_vector(31 downto 0);
-  signal wr_strb                        : std_logic_vector(3 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal rd_req                         : std_logic;
   signal rd_addr                        : std_logic_vector(14 downto 2);
   signal rd_data                        : std_logic_vector(31 downto 0);
@@ -172,10 +172,12 @@ architecture syn of all1_apb is
   signal wr_req_d0                      : std_logic;
   signal wr_adr_d0                      : std_logic_vector(14 downto 2);
   signal wr_dat_d0                      : std_logic_vector(31 downto 0);
-  signal wr_sel_d0                      : std_logic_vector(3 downto 0);
+  signal wr_sel_d0                      : std_logic_vector(31 downto 0);
   signal ram1_wr                        : std_logic;
   signal ram1_wreq                      : std_logic;
   signal ram1_adr_int                   : std_logic_vector(2 downto 0);
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
   signal ram2_wp                        : std_logic;
   signal ram2_we                        : std_logic;
 begin
@@ -184,7 +186,12 @@ begin
   wr_req <= (psel and pwrite) and not penable;
   wr_addr <= paddr;
   wr_data <= pwdata;
-  wr_strb <= pstrb;
+  process (pstrb) begin
+    wr_sel(7 downto 0) <= (others => pstrb(0));
+    wr_sel(15 downto 8) <= (others => pstrb(1));
+    wr_sel(23 downto 16) <= (others => pstrb(2));
+    wr_sel(31 downto 24) <= (others => pstrb(3));
+  end process;
 
   -- Read Channel
   rd_req <= (psel and not pwrite) and not penable;
@@ -205,7 +212,7 @@ begin
         wr_req_d0 <= wr_req;
         wr_adr_d0 <= wr_addr;
         wr_dat_d0 <= wr_data;
-        wr_sel_d0 <= wr_strb;
+        wr_sel_d0 <= wr_sel;
       end if;
     end if;
   end process;
@@ -264,7 +271,7 @@ begin
       clk_a_i              => pclk,
       clk_b_i              => pclk,
       addr_a_i             => ram1_adr_int,
-      bwsel_a_i            => wr_sel_d0,
+      bwsel_a_i            => ram1_sel_int,
       data_a_i             => wr_dat_d0,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
@@ -277,6 +284,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel_d0) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (pclk) begin
     if rising_edge(pclk) then
       if presetn = '0' then
@@ -300,7 +322,7 @@ begin
       clk_a_i              => pclk,
       clk_b_i              => pclk,
       addr_a_i             => rd_adr_d0(4 downto 2),
-      bwsel_a_i            => wr_sel_d0,
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -313,6 +335,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel_d0) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (pclk) begin
     if rising_edge(pclk) then
       if presetn = '0' then
@@ -380,7 +417,21 @@ begin
       sub1_wb_adr_o <= rd_adr_d0(11 downto 2);
     end if;
   end process;
-  sub1_wb_sel_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
   sub1_wb_dat_o <= wr_dat_d0;
 
@@ -390,7 +441,21 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wr_dat_d0;
-  sub2_axi4_wstrb_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= rd_adr_d0(11 downto 2);
@@ -462,7 +527,21 @@ begin
       sub4_avalon_address_o <= rd_adr_d0(11 downto 2);
     end if;
   end process;
-  sub4_avalon_byteenable_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
   sub4_avalon_writedata_o <= wr_dat_d0;
@@ -500,7 +579,21 @@ begin
     end if;
   end process;
   sub5_apb_pwdata_o <= wr_dat_d0;
-  sub5_apb_pstrb_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
   process (wr_adr_d0, wr_req_d0, reg1_wack, reg2_wack, ram2_we, sub1_wb_wack,

--- a/testfiles/tb/golden_files/all1_apb_none.vhdl
+++ b/testfiles/tb/golden_files/all1_apb_none.vhdl
@@ -107,7 +107,7 @@ architecture syn of all1_apb is
   signal wr_req                         : std_logic;
   signal wr_addr                        : std_logic_vector(14 downto 2);
   signal wr_data                        : std_logic_vector(31 downto 0);
-  signal wr_strb                        : std_logic_vector(3 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal rd_req                         : std_logic;
   signal rd_addr                        : std_logic_vector(14 downto 2);
   signal rd_data                        : std_logic_vector(31 downto 0);
@@ -170,6 +170,8 @@ architecture syn of all1_apb is
   signal ram1_wr                        : std_logic;
   signal ram1_wreq                      : std_logic;
   signal ram1_adr_int                   : std_logic_vector(2 downto 0);
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
   signal ram2_wp                        : std_logic;
   signal ram2_we                        : std_logic;
 begin
@@ -178,7 +180,12 @@ begin
   wr_req <= (psel and pwrite) and not penable;
   wr_addr <= paddr;
   wr_data <= pwdata;
-  wr_strb <= pstrb;
+  process (pstrb) begin
+    wr_sel(7 downto 0) <= (others => pstrb(0));
+    wr_sel(15 downto 8) <= (others => pstrb(1));
+    wr_sel(23 downto 16) <= (others => pstrb(2));
+    wr_sel(31 downto 24) <= (others => pstrb(3));
+  end process;
 
   -- Read Channel
   rd_req <= (psel and not pwrite) and not penable;
@@ -241,7 +248,7 @@ begin
       clk_a_i              => pclk,
       clk_b_i              => pclk,
       addr_a_i             => ram1_adr_int,
-      bwsel_a_i            => wr_strb,
+      bwsel_a_i            => ram1_sel_int,
       data_a_i             => wr_data,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
@@ -254,6 +261,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (pclk) begin
     if rising_edge(pclk) then
       if presetn = '0' then
@@ -277,7 +299,7 @@ begin
       clk_a_i              => pclk,
       clk_b_i              => pclk,
       addr_a_i             => rd_addr(4 downto 2),
-      bwsel_a_i            => wr_strb,
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -290,6 +312,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (pclk) begin
     if rising_edge(pclk) then
       if presetn = '0' then
@@ -357,7 +394,21 @@ begin
       sub1_wb_adr_o <= rd_addr(11 downto 2);
     end if;
   end process;
-  sub1_wb_sel_o <= wr_strb;
+  process (wr_sel) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
   sub1_wb_dat_o <= wr_data;
 
@@ -367,7 +418,21 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wr_data;
-  sub2_axi4_wstrb_o <= wr_strb;
+  process (wr_sel) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= rd_addr(11 downto 2);
@@ -439,7 +504,21 @@ begin
       sub4_avalon_address_o <= rd_addr(11 downto 2);
     end if;
   end process;
-  sub4_avalon_byteenable_o <= wr_strb;
+  process (wr_sel) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
   sub4_avalon_writedata_o <= wr_data;
@@ -477,7 +556,21 @@ begin
     end if;
   end process;
   sub5_apb_pwdata_o <= wr_data;
-  sub5_apb_pstrb_o <= wr_strb;
+  process (wr_sel) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
   process (wr_addr, wr_req, reg1_wack, reg2_wack, ram2_we, sub1_wb_wack,

--- a/testfiles/tb/golden_files/all1_apb_out.vhdl
+++ b/testfiles/tb/golden_files/all1_apb_out.vhdl
@@ -107,7 +107,7 @@ architecture syn of all1_apb is
   signal wr_req                         : std_logic;
   signal wr_addr                        : std_logic_vector(14 downto 2);
   signal wr_data                        : std_logic_vector(31 downto 0);
-  signal wr_strb                        : std_logic_vector(3 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal rd_req                         : std_logic;
   signal rd_addr                        : std_logic_vector(14 downto 2);
   signal rd_data                        : std_logic_vector(31 downto 0);
@@ -173,6 +173,8 @@ architecture syn of all1_apb is
   signal ram1_wr                        : std_logic;
   signal ram1_wreq                      : std_logic;
   signal ram1_adr_int                   : std_logic_vector(2 downto 0);
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
   signal ram2_wp                        : std_logic;
   signal ram2_we                        : std_logic;
 begin
@@ -181,7 +183,12 @@ begin
   wr_req <= (psel and pwrite) and not penable;
   wr_addr <= paddr;
   wr_data <= pwdata;
-  wr_strb <= pstrb;
+  process (pstrb) begin
+    wr_sel(7 downto 0) <= (others => pstrb(0));
+    wr_sel(15 downto 8) <= (others => pstrb(1));
+    wr_sel(23 downto 16) <= (others => pstrb(2));
+    wr_sel(31 downto 24) <= (others => pstrb(3));
+  end process;
 
   -- Read Channel
   rd_req <= (psel and not pwrite) and not penable;
@@ -258,7 +265,7 @@ begin
       clk_a_i              => pclk,
       clk_b_i              => pclk,
       addr_a_i             => ram1_adr_int,
-      bwsel_a_i            => wr_strb,
+      bwsel_a_i            => ram1_sel_int,
       data_a_i             => wr_data,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
@@ -271,6 +278,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (pclk) begin
     if rising_edge(pclk) then
       if presetn = '0' then
@@ -294,7 +316,7 @@ begin
       clk_a_i              => pclk,
       clk_b_i              => pclk,
       addr_a_i             => rd_addr(4 downto 2),
-      bwsel_a_i            => wr_strb,
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -307,6 +329,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (pclk) begin
     if rising_edge(pclk) then
       if presetn = '0' then
@@ -374,7 +411,21 @@ begin
       sub1_wb_adr_o <= rd_addr(11 downto 2);
     end if;
   end process;
-  sub1_wb_sel_o <= wr_strb;
+  process (wr_sel) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
   sub1_wb_dat_o <= wr_data;
 
@@ -384,7 +435,21 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wr_data;
-  sub2_axi4_wstrb_o <= wr_strb;
+  process (wr_sel) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= rd_addr(11 downto 2);
@@ -456,7 +521,21 @@ begin
       sub4_avalon_address_o <= rd_addr(11 downto 2);
     end if;
   end process;
-  sub4_avalon_byteenable_o <= wr_strb;
+  process (wr_sel) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
   sub4_avalon_writedata_o <= wr_data;
@@ -494,7 +573,21 @@ begin
     end if;
   end process;
   sub5_apb_pwdata_o <= wr_data;
-  sub5_apb_pstrb_o <= wr_strb;
+  process (wr_sel) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
   process (wr_addr, wr_req, reg1_wack, reg2_wack, ram2_we, sub1_wb_wack,

--- a/testfiles/tb/golden_files/all1_apb_rd-in,wr-out.vhdl
+++ b/testfiles/tb/golden_files/all1_apb_rd-in,wr-out.vhdl
@@ -107,7 +107,7 @@ architecture syn of all1_apb is
   signal wr_req                         : std_logic;
   signal wr_addr                        : std_logic_vector(14 downto 2);
   signal wr_data                        : std_logic_vector(31 downto 0);
-  signal wr_strb                        : std_logic_vector(3 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal rd_req                         : std_logic;
   signal rd_addr                        : std_logic_vector(14 downto 2);
   signal rd_data                        : std_logic_vector(31 downto 0);
@@ -173,6 +173,8 @@ architecture syn of all1_apb is
   signal ram1_wr                        : std_logic;
   signal ram1_wreq                      : std_logic;
   signal ram1_adr_int                   : std_logic_vector(2 downto 0);
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
   signal ram2_wp                        : std_logic;
   signal ram2_we                        : std_logic;
 begin
@@ -181,7 +183,12 @@ begin
   wr_req <= (psel and pwrite) and not penable;
   wr_addr <= paddr;
   wr_data <= pwdata;
-  wr_strb <= pstrb;
+  process (pstrb) begin
+    wr_sel(7 downto 0) <= (others => pstrb(0));
+    wr_sel(15 downto 8) <= (others => pstrb(1));
+    wr_sel(23 downto 16) <= (others => pstrb(2));
+    wr_sel(31 downto 24) <= (others => pstrb(3));
+  end process;
 
   -- Read Channel
   rd_req <= (psel and not pwrite) and not penable;
@@ -258,7 +265,7 @@ begin
       clk_a_i              => pclk,
       clk_b_i              => pclk,
       addr_a_i             => ram1_adr_int,
-      bwsel_a_i            => wr_strb,
+      bwsel_a_i            => ram1_sel_int,
       data_a_i             => wr_data,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
@@ -271,6 +278,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (pclk) begin
     if rising_edge(pclk) then
       if presetn = '0' then
@@ -294,7 +316,7 @@ begin
       clk_a_i              => pclk,
       clk_b_i              => pclk,
       addr_a_i             => rd_adr_d0(4 downto 2),
-      bwsel_a_i            => wr_strb,
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -307,6 +329,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (pclk) begin
     if rising_edge(pclk) then
       if presetn = '0' then
@@ -374,7 +411,21 @@ begin
       sub1_wb_adr_o <= rd_adr_d0(11 downto 2);
     end if;
   end process;
-  sub1_wb_sel_o <= wr_strb;
+  process (wr_sel) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
   sub1_wb_dat_o <= wr_data;
 
@@ -384,7 +435,21 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wr_data;
-  sub2_axi4_wstrb_o <= wr_strb;
+  process (wr_sel) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= rd_adr_d0(11 downto 2);
@@ -456,7 +521,21 @@ begin
       sub4_avalon_address_o <= rd_adr_d0(11 downto 2);
     end if;
   end process;
-  sub4_avalon_byteenable_o <= wr_strb;
+  process (wr_sel) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
   sub4_avalon_writedata_o <= wr_data;
@@ -494,7 +573,21 @@ begin
     end if;
   end process;
   sub5_apb_pwdata_o <= wr_data;
-  sub5_apb_pstrb_o <= wr_strb;
+  process (wr_sel) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
   process (wr_addr, wr_req, reg1_wack, reg2_wack, ram2_we, sub1_wb_wack,

--- a/testfiles/tb/golden_files/all1_apb_rd-in.vhdl
+++ b/testfiles/tb/golden_files/all1_apb_rd-in.vhdl
@@ -107,7 +107,7 @@ architecture syn of all1_apb is
   signal wr_req                         : std_logic;
   signal wr_addr                        : std_logic_vector(14 downto 2);
   signal wr_data                        : std_logic_vector(31 downto 0);
-  signal wr_strb                        : std_logic_vector(3 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal rd_req                         : std_logic;
   signal rd_addr                        : std_logic_vector(14 downto 2);
   signal rd_data                        : std_logic_vector(31 downto 0);
@@ -172,6 +172,8 @@ architecture syn of all1_apb is
   signal ram1_wr                        : std_logic;
   signal ram1_wreq                      : std_logic;
   signal ram1_adr_int                   : std_logic_vector(2 downto 0);
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
   signal ram2_wp                        : std_logic;
   signal ram2_we                        : std_logic;
 begin
@@ -180,7 +182,12 @@ begin
   wr_req <= (psel and pwrite) and not penable;
   wr_addr <= paddr;
   wr_data <= pwdata;
-  wr_strb <= pstrb;
+  process (pstrb) begin
+    wr_sel(7 downto 0) <= (others => pstrb(0));
+    wr_sel(15 downto 8) <= (others => pstrb(1));
+    wr_sel(23 downto 16) <= (others => pstrb(2));
+    wr_sel(31 downto 24) <= (others => pstrb(3));
+  end process;
 
   -- Read Channel
   rd_req <= (psel and not pwrite) and not penable;
@@ -255,7 +262,7 @@ begin
       clk_a_i              => pclk,
       clk_b_i              => pclk,
       addr_a_i             => ram1_adr_int,
-      bwsel_a_i            => wr_strb,
+      bwsel_a_i            => ram1_sel_int,
       data_a_i             => wr_data,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
@@ -268,6 +275,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (pclk) begin
     if rising_edge(pclk) then
       if presetn = '0' then
@@ -291,7 +313,7 @@ begin
       clk_a_i              => pclk,
       clk_b_i              => pclk,
       addr_a_i             => rd_adr_d0(4 downto 2),
-      bwsel_a_i            => wr_strb,
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -304,6 +326,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (pclk) begin
     if rising_edge(pclk) then
       if presetn = '0' then
@@ -371,7 +408,21 @@ begin
       sub1_wb_adr_o <= rd_adr_d0(11 downto 2);
     end if;
   end process;
-  sub1_wb_sel_o <= wr_strb;
+  process (wr_sel) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
   sub1_wb_dat_o <= wr_data;
 
@@ -381,7 +432,21 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wr_data;
-  sub2_axi4_wstrb_o <= wr_strb;
+  process (wr_sel) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= rd_adr_d0(11 downto 2);
@@ -453,7 +518,21 @@ begin
       sub4_avalon_address_o <= rd_adr_d0(11 downto 2);
     end if;
   end process;
-  sub4_avalon_byteenable_o <= wr_strb;
+  process (wr_sel) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
   sub4_avalon_writedata_o <= wr_data;
@@ -491,7 +570,21 @@ begin
     end if;
   end process;
   sub5_apb_pwdata_o <= wr_data;
-  sub5_apb_pstrb_o <= wr_strb;
+  process (wr_sel) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
   process (wr_addr, wr_req, reg1_wack, reg2_wack, ram2_we, sub1_wb_wack,

--- a/testfiles/tb/golden_files/all1_apb_rd-out.vhdl
+++ b/testfiles/tb/golden_files/all1_apb_rd-out.vhdl
@@ -107,7 +107,7 @@ architecture syn of all1_apb is
   signal wr_req                         : std_logic;
   signal wr_addr                        : std_logic_vector(14 downto 2);
   signal wr_data                        : std_logic_vector(31 downto 0);
-  signal wr_strb                        : std_logic_vector(3 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal rd_req                         : std_logic;
   signal rd_addr                        : std_logic_vector(14 downto 2);
   signal rd_data                        : std_logic_vector(31 downto 0);
@@ -172,6 +172,8 @@ architecture syn of all1_apb is
   signal ram1_wr                        : std_logic;
   signal ram1_wreq                      : std_logic;
   signal ram1_adr_int                   : std_logic_vector(2 downto 0);
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
   signal ram2_wp                        : std_logic;
   signal ram2_we                        : std_logic;
 begin
@@ -180,7 +182,12 @@ begin
   wr_req <= (psel and pwrite) and not penable;
   wr_addr <= paddr;
   wr_data <= pwdata;
-  wr_strb <= pstrb;
+  process (pstrb) begin
+    wr_sel(7 downto 0) <= (others => pstrb(0));
+    wr_sel(15 downto 8) <= (others => pstrb(1));
+    wr_sel(23 downto 16) <= (others => pstrb(2));
+    wr_sel(31 downto 24) <= (others => pstrb(3));
+  end process;
 
   -- Read Channel
   rd_req <= (psel and not pwrite) and not penable;
@@ -255,7 +262,7 @@ begin
       clk_a_i              => pclk,
       clk_b_i              => pclk,
       addr_a_i             => ram1_adr_int,
-      bwsel_a_i            => wr_strb,
+      bwsel_a_i            => ram1_sel_int,
       data_a_i             => wr_data,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
@@ -268,6 +275,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (pclk) begin
     if rising_edge(pclk) then
       if presetn = '0' then
@@ -291,7 +313,7 @@ begin
       clk_a_i              => pclk,
       clk_b_i              => pclk,
       addr_a_i             => rd_addr(4 downto 2),
-      bwsel_a_i            => wr_strb,
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -304,6 +326,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (pclk) begin
     if rising_edge(pclk) then
       if presetn = '0' then
@@ -371,7 +408,21 @@ begin
       sub1_wb_adr_o <= rd_addr(11 downto 2);
     end if;
   end process;
-  sub1_wb_sel_o <= wr_strb;
+  process (wr_sel) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
   sub1_wb_dat_o <= wr_data;
 
@@ -381,7 +432,21 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wr_data;
-  sub2_axi4_wstrb_o <= wr_strb;
+  process (wr_sel) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= rd_addr(11 downto 2);
@@ -453,7 +518,21 @@ begin
       sub4_avalon_address_o <= rd_addr(11 downto 2);
     end if;
   end process;
-  sub4_avalon_byteenable_o <= wr_strb;
+  process (wr_sel) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
   sub4_avalon_writedata_o <= wr_data;
@@ -491,7 +570,21 @@ begin
     end if;
   end process;
   sub5_apb_pwdata_o <= wr_data;
-  sub5_apb_pstrb_o <= wr_strb;
+  process (wr_sel) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
   process (wr_addr, wr_req, reg1_wack, reg2_wack, ram2_we, sub1_wb_wack,

--- a/testfiles/tb/golden_files/all1_apb_rd.vhdl
+++ b/testfiles/tb/golden_files/all1_apb_rd.vhdl
@@ -107,7 +107,7 @@ architecture syn of all1_apb is
   signal wr_req                         : std_logic;
   signal wr_addr                        : std_logic_vector(14 downto 2);
   signal wr_data                        : std_logic_vector(31 downto 0);
-  signal wr_strb                        : std_logic_vector(3 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal rd_req                         : std_logic;
   signal rd_addr                        : std_logic_vector(14 downto 2);
   signal rd_data                        : std_logic_vector(31 downto 0);
@@ -174,6 +174,8 @@ architecture syn of all1_apb is
   signal ram1_wr                        : std_logic;
   signal ram1_wreq                      : std_logic;
   signal ram1_adr_int                   : std_logic_vector(2 downto 0);
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
   signal ram2_wp                        : std_logic;
   signal ram2_we                        : std_logic;
 begin
@@ -182,7 +184,12 @@ begin
   wr_req <= (psel and pwrite) and not penable;
   wr_addr <= paddr;
   wr_data <= pwdata;
-  wr_strb <= pstrb;
+  process (pstrb) begin
+    wr_sel(7 downto 0) <= (others => pstrb(0));
+    wr_sel(15 downto 8) <= (others => pstrb(1));
+    wr_sel(23 downto 16) <= (others => pstrb(2));
+    wr_sel(31 downto 24) <= (others => pstrb(3));
+  end process;
 
   -- Read Channel
   rd_req <= (psel and not pwrite) and not penable;
@@ -260,7 +267,7 @@ begin
       clk_a_i              => pclk,
       clk_b_i              => pclk,
       addr_a_i             => ram1_adr_int,
-      bwsel_a_i            => wr_strb,
+      bwsel_a_i            => ram1_sel_int,
       data_a_i             => wr_data,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
@@ -273,6 +280,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (pclk) begin
     if rising_edge(pclk) then
       if presetn = '0' then
@@ -296,7 +318,7 @@ begin
       clk_a_i              => pclk,
       clk_b_i              => pclk,
       addr_a_i             => rd_adr_d0(4 downto 2),
-      bwsel_a_i            => wr_strb,
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -309,6 +331,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (pclk) begin
     if rising_edge(pclk) then
       if presetn = '0' then
@@ -376,7 +413,21 @@ begin
       sub1_wb_adr_o <= rd_adr_d0(11 downto 2);
     end if;
   end process;
-  sub1_wb_sel_o <= wr_strb;
+  process (wr_sel) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
   sub1_wb_dat_o <= wr_data;
 
@@ -386,7 +437,21 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wr_data;
-  sub2_axi4_wstrb_o <= wr_strb;
+  process (wr_sel) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= rd_adr_d0(11 downto 2);
@@ -458,7 +523,21 @@ begin
       sub4_avalon_address_o <= rd_adr_d0(11 downto 2);
     end if;
   end process;
-  sub4_avalon_byteenable_o <= wr_strb;
+  process (wr_sel) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
   sub4_avalon_writedata_o <= wr_data;
@@ -496,7 +575,21 @@ begin
     end if;
   end process;
   sub5_apb_pwdata_o <= wr_data;
-  sub5_apb_pstrb_o <= wr_strb;
+  process (wr_sel) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
   process (wr_addr, wr_req, reg1_wack, reg2_wack, ram2_we, sub1_wb_wack,

--- a/testfiles/tb/golden_files/all1_apb_wr-in,rd-out.vhdl
+++ b/testfiles/tb/golden_files/all1_apb_wr-in,rd-out.vhdl
@@ -107,7 +107,7 @@ architecture syn of all1_apb is
   signal wr_req                         : std_logic;
   signal wr_addr                        : std_logic_vector(14 downto 2);
   signal wr_data                        : std_logic_vector(31 downto 0);
-  signal wr_strb                        : std_logic_vector(3 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal rd_req                         : std_logic;
   signal rd_addr                        : std_logic_vector(14 downto 2);
   signal rd_data                        : std_logic_vector(31 downto 0);
@@ -172,10 +172,12 @@ architecture syn of all1_apb is
   signal wr_req_d0                      : std_logic;
   signal wr_adr_d0                      : std_logic_vector(14 downto 2);
   signal wr_dat_d0                      : std_logic_vector(31 downto 0);
-  signal wr_sel_d0                      : std_logic_vector(3 downto 0);
+  signal wr_sel_d0                      : std_logic_vector(31 downto 0);
   signal ram1_wr                        : std_logic;
   signal ram1_wreq                      : std_logic;
   signal ram1_adr_int                   : std_logic_vector(2 downto 0);
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
   signal ram2_wp                        : std_logic;
   signal ram2_we                        : std_logic;
 begin
@@ -184,7 +186,12 @@ begin
   wr_req <= (psel and pwrite) and not penable;
   wr_addr <= paddr;
   wr_data <= pwdata;
-  wr_strb <= pstrb;
+  process (pstrb) begin
+    wr_sel(7 downto 0) <= (others => pstrb(0));
+    wr_sel(15 downto 8) <= (others => pstrb(1));
+    wr_sel(23 downto 16) <= (others => pstrb(2));
+    wr_sel(31 downto 24) <= (others => pstrb(3));
+  end process;
 
   -- Read Channel
   rd_req <= (psel and not pwrite) and not penable;
@@ -205,7 +212,7 @@ begin
         wr_req_d0 <= wr_req;
         wr_adr_d0 <= wr_addr;
         wr_dat_d0 <= wr_data;
-        wr_sel_d0 <= wr_strb;
+        wr_sel_d0 <= wr_sel;
       end if;
     end if;
   end process;
@@ -264,7 +271,7 @@ begin
       clk_a_i              => pclk,
       clk_b_i              => pclk,
       addr_a_i             => ram1_adr_int,
-      bwsel_a_i            => wr_sel_d0,
+      bwsel_a_i            => ram1_sel_int,
       data_a_i             => wr_dat_d0,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
@@ -277,6 +284,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel_d0) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (pclk) begin
     if rising_edge(pclk) then
       if presetn = '0' then
@@ -300,7 +322,7 @@ begin
       clk_a_i              => pclk,
       clk_b_i              => pclk,
       addr_a_i             => rd_addr(4 downto 2),
-      bwsel_a_i            => wr_sel_d0,
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -313,6 +335,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel_d0) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (pclk) begin
     if rising_edge(pclk) then
       if presetn = '0' then
@@ -380,7 +417,21 @@ begin
       sub1_wb_adr_o <= rd_addr(11 downto 2);
     end if;
   end process;
-  sub1_wb_sel_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
   sub1_wb_dat_o <= wr_dat_d0;
 
@@ -390,7 +441,21 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wr_dat_d0;
-  sub2_axi4_wstrb_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= rd_addr(11 downto 2);
@@ -462,7 +527,21 @@ begin
       sub4_avalon_address_o <= rd_addr(11 downto 2);
     end if;
   end process;
-  sub4_avalon_byteenable_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
   sub4_avalon_writedata_o <= wr_dat_d0;
@@ -500,7 +579,21 @@ begin
     end if;
   end process;
   sub5_apb_pwdata_o <= wr_dat_d0;
-  sub5_apb_pstrb_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
   process (wr_adr_d0, wr_req_d0, reg1_wack, reg2_wack, ram2_we, sub1_wb_wack,

--- a/testfiles/tb/golden_files/all1_apb_wr-in.vhdl
+++ b/testfiles/tb/golden_files/all1_apb_wr-in.vhdl
@@ -107,7 +107,7 @@ architecture syn of all1_apb is
   signal wr_req                         : std_logic;
   signal wr_addr                        : std_logic_vector(14 downto 2);
   signal wr_data                        : std_logic_vector(31 downto 0);
-  signal wr_strb                        : std_logic_vector(3 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal rd_req                         : std_logic;
   signal rd_addr                        : std_logic_vector(14 downto 2);
   signal rd_data                        : std_logic_vector(31 downto 0);
@@ -170,10 +170,12 @@ architecture syn of all1_apb is
   signal wr_req_d0                      : std_logic;
   signal wr_adr_d0                      : std_logic_vector(14 downto 2);
   signal wr_dat_d0                      : std_logic_vector(31 downto 0);
-  signal wr_sel_d0                      : std_logic_vector(3 downto 0);
+  signal wr_sel_d0                      : std_logic_vector(31 downto 0);
   signal ram1_wr                        : std_logic;
   signal ram1_wreq                      : std_logic;
   signal ram1_adr_int                   : std_logic_vector(2 downto 0);
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
   signal ram2_wp                        : std_logic;
   signal ram2_we                        : std_logic;
 begin
@@ -182,7 +184,12 @@ begin
   wr_req <= (psel and pwrite) and not penable;
   wr_addr <= paddr;
   wr_data <= pwdata;
-  wr_strb <= pstrb;
+  process (pstrb) begin
+    wr_sel(7 downto 0) <= (others => pstrb(0));
+    wr_sel(15 downto 8) <= (others => pstrb(1));
+    wr_sel(23 downto 16) <= (others => pstrb(2));
+    wr_sel(31 downto 24) <= (others => pstrb(3));
+  end process;
 
   -- Read Channel
   rd_req <= (psel and not pwrite) and not penable;
@@ -200,7 +207,7 @@ begin
         wr_req_d0 <= wr_req;
         wr_adr_d0 <= wr_addr;
         wr_dat_d0 <= wr_data;
-        wr_sel_d0 <= wr_strb;
+        wr_sel_d0 <= wr_sel;
       end if;
     end if;
   end process;
@@ -259,7 +266,7 @@ begin
       clk_a_i              => pclk,
       clk_b_i              => pclk,
       addr_a_i             => ram1_adr_int,
-      bwsel_a_i            => wr_sel_d0,
+      bwsel_a_i            => ram1_sel_int,
       data_a_i             => wr_dat_d0,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
@@ -272,6 +279,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel_d0) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (pclk) begin
     if rising_edge(pclk) then
       if presetn = '0' then
@@ -295,7 +317,7 @@ begin
       clk_a_i              => pclk,
       clk_b_i              => pclk,
       addr_a_i             => rd_addr(4 downto 2),
-      bwsel_a_i            => wr_sel_d0,
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -308,6 +330,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel_d0) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (pclk) begin
     if rising_edge(pclk) then
       if presetn = '0' then
@@ -375,7 +412,21 @@ begin
       sub1_wb_adr_o <= rd_addr(11 downto 2);
     end if;
   end process;
-  sub1_wb_sel_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
   sub1_wb_dat_o <= wr_dat_d0;
 
@@ -385,7 +436,21 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wr_dat_d0;
-  sub2_axi4_wstrb_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= rd_addr(11 downto 2);
@@ -457,7 +522,21 @@ begin
       sub4_avalon_address_o <= rd_addr(11 downto 2);
     end if;
   end process;
-  sub4_avalon_byteenable_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
   sub4_avalon_writedata_o <= wr_dat_d0;
@@ -495,7 +574,21 @@ begin
     end if;
   end process;
   sub5_apb_pwdata_o <= wr_dat_d0;
-  sub5_apb_pstrb_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
   process (wr_adr_d0, wr_req_d0, reg1_wack, reg2_wack, ram2_we, sub1_wb_wack,

--- a/testfiles/tb/golden_files/all1_apb_wr-out.vhdl
+++ b/testfiles/tb/golden_files/all1_apb_wr-out.vhdl
@@ -107,7 +107,7 @@ architecture syn of all1_apb is
   signal wr_req                         : std_logic;
   signal wr_addr                        : std_logic_vector(14 downto 2);
   signal wr_data                        : std_logic_vector(31 downto 0);
-  signal wr_strb                        : std_logic_vector(3 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal rd_req                         : std_logic;
   signal rd_addr                        : std_logic_vector(14 downto 2);
   signal rd_data                        : std_logic_vector(31 downto 0);
@@ -171,6 +171,8 @@ architecture syn of all1_apb is
   signal ram1_wr                        : std_logic;
   signal ram1_wreq                      : std_logic;
   signal ram1_adr_int                   : std_logic_vector(2 downto 0);
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
   signal ram2_wp                        : std_logic;
   signal ram2_we                        : std_logic;
 begin
@@ -179,7 +181,12 @@ begin
   wr_req <= (psel and pwrite) and not penable;
   wr_addr <= paddr;
   wr_data <= pwdata;
-  wr_strb <= pstrb;
+  process (pstrb) begin
+    wr_sel(7 downto 0) <= (others => pstrb(0));
+    wr_sel(15 downto 8) <= (others => pstrb(1));
+    wr_sel(23 downto 16) <= (others => pstrb(2));
+    wr_sel(31 downto 24) <= (others => pstrb(3));
+  end process;
 
   -- Read Channel
   rd_req <= (psel and not pwrite) and not penable;
@@ -253,7 +260,7 @@ begin
       clk_a_i              => pclk,
       clk_b_i              => pclk,
       addr_a_i             => ram1_adr_int,
-      bwsel_a_i            => wr_strb,
+      bwsel_a_i            => ram1_sel_int,
       data_a_i             => wr_data,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
@@ -266,6 +273,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (pclk) begin
     if rising_edge(pclk) then
       if presetn = '0' then
@@ -289,7 +311,7 @@ begin
       clk_a_i              => pclk,
       clk_b_i              => pclk,
       addr_a_i             => rd_addr(4 downto 2),
-      bwsel_a_i            => wr_strb,
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -302,6 +324,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (pclk) begin
     if rising_edge(pclk) then
       if presetn = '0' then
@@ -369,7 +406,21 @@ begin
       sub1_wb_adr_o <= rd_addr(11 downto 2);
     end if;
   end process;
-  sub1_wb_sel_o <= wr_strb;
+  process (wr_sel) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
   sub1_wb_dat_o <= wr_data;
 
@@ -379,7 +430,21 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wr_data;
-  sub2_axi4_wstrb_o <= wr_strb;
+  process (wr_sel) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= rd_addr(11 downto 2);
@@ -451,7 +516,21 @@ begin
       sub4_avalon_address_o <= rd_addr(11 downto 2);
     end if;
   end process;
-  sub4_avalon_byteenable_o <= wr_strb;
+  process (wr_sel) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
   sub4_avalon_writedata_o <= wr_data;
@@ -489,7 +568,21 @@ begin
     end if;
   end process;
   sub5_apb_pwdata_o <= wr_data;
-  sub5_apb_pstrb_o <= wr_strb;
+  process (wr_sel) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
   process (wr_addr, wr_req, reg1_wack, reg2_wack, ram2_we, sub1_wb_wack,

--- a/testfiles/tb/golden_files/all1_apb_wr.vhdl
+++ b/testfiles/tb/golden_files/all1_apb_wr.vhdl
@@ -107,7 +107,7 @@ architecture syn of all1_apb is
   signal wr_req                         : std_logic;
   signal wr_addr                        : std_logic_vector(14 downto 2);
   signal wr_data                        : std_logic_vector(31 downto 0);
-  signal wr_strb                        : std_logic_vector(3 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal rd_req                         : std_logic;
   signal rd_addr                        : std_logic_vector(14 downto 2);
   signal rd_data                        : std_logic_vector(31 downto 0);
@@ -170,11 +170,13 @@ architecture syn of all1_apb is
   signal wr_req_d0                      : std_logic;
   signal wr_adr_d0                      : std_logic_vector(14 downto 2);
   signal wr_dat_d0                      : std_logic_vector(31 downto 0);
-  signal wr_sel_d0                      : std_logic_vector(3 downto 0);
+  signal wr_sel_d0                      : std_logic_vector(31 downto 0);
   signal wr_ack_d0                      : std_logic;
   signal ram1_wr                        : std_logic;
   signal ram1_wreq                      : std_logic;
   signal ram1_adr_int                   : std_logic_vector(2 downto 0);
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
   signal ram2_wp                        : std_logic;
   signal ram2_we                        : std_logic;
 begin
@@ -183,7 +185,12 @@ begin
   wr_req <= (psel and pwrite) and not penable;
   wr_addr <= paddr;
   wr_data <= pwdata;
-  wr_strb <= pstrb;
+  process (pstrb) begin
+    wr_sel(7 downto 0) <= (others => pstrb(0));
+    wr_sel(15 downto 8) <= (others => pstrb(1));
+    wr_sel(23 downto 16) <= (others => pstrb(2));
+    wr_sel(31 downto 24) <= (others => pstrb(3));
+  end process;
 
   -- Read Channel
   rd_req <= (psel and not pwrite) and not penable;
@@ -202,7 +209,7 @@ begin
         wr_req_d0 <= wr_req;
         wr_adr_d0 <= wr_addr;
         wr_dat_d0 <= wr_data;
-        wr_sel_d0 <= wr_strb;
+        wr_sel_d0 <= wr_sel;
         wr_ack <= wr_ack_d0;
       end if;
     end if;
@@ -262,7 +269,7 @@ begin
       clk_a_i              => pclk,
       clk_b_i              => pclk,
       addr_a_i             => ram1_adr_int,
-      bwsel_a_i            => wr_sel_d0,
+      bwsel_a_i            => ram1_sel_int,
       data_a_i             => wr_dat_d0,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
@@ -275,6 +282,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel_d0) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (pclk) begin
     if rising_edge(pclk) then
       if presetn = '0' then
@@ -298,7 +320,7 @@ begin
       clk_a_i              => pclk,
       clk_b_i              => pclk,
       addr_a_i             => rd_addr(4 downto 2),
-      bwsel_a_i            => wr_sel_d0,
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -311,6 +333,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel_d0) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (pclk) begin
     if rising_edge(pclk) then
       if presetn = '0' then
@@ -378,7 +415,21 @@ begin
       sub1_wb_adr_o <= rd_addr(11 downto 2);
     end if;
   end process;
-  sub1_wb_sel_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
   sub1_wb_dat_o <= wr_dat_d0;
 
@@ -388,7 +439,21 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wr_dat_d0;
-  sub2_axi4_wstrb_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= rd_addr(11 downto 2);
@@ -460,7 +525,21 @@ begin
       sub4_avalon_address_o <= rd_addr(11 downto 2);
     end if;
   end process;
-  sub4_avalon_byteenable_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
   sub4_avalon_writedata_o <= wr_dat_d0;
@@ -498,7 +577,21 @@ begin
     end if;
   end process;
   sub5_apb_pwdata_o <= wr_dat_d0;
-  sub5_apb_pstrb_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
   process (wr_adr_d0, wr_req_d0, reg1_wack, reg2_wack, ram2_we, sub1_wb_wack,

--- a/testfiles/tb/golden_files/all1_avalon_in.vhdl
+++ b/testfiles/tb/golden_files/all1_avalon_in.vhdl
@@ -104,13 +104,15 @@ end all1_avalon;
 
 architecture syn of all1_avalon is
   signal rst_n                          : std_logic;
-  signal rd_ack_int                     : std_logic;
-  signal wr_ack_int                     : std_logic;
-  signal rd_req_int                     : std_logic;
-  signal wr_req_int                     : std_logic;
+  signal rd_req                         : std_logic;
+  signal rd_ack                         : std_logic;
+  signal wr_req                         : std_logic;
+  signal wr_ack                         : std_logic;
+  signal wr_dat                         : std_logic_vector(31 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal wait_int                       : std_logic;
-  signal addr_int                       : std_logic_vector(14 downto 2);
-  signal dati_int                       : std_logic_vector(31 downto 0);
+  signal sel_int                        : std_logic_vector(31 downto 0);
+  signal adr                            : std_logic_vector(14 downto 2);
   signal reg1_reg                       : std_logic_vector(31 downto 0);
   signal reg1_wreq                      : std_logic;
   signal reg1_wack                      : std_logic;
@@ -156,6 +158,9 @@ architecture syn of all1_avalon is
   signal rd_adr_d0                      : std_logic_vector(14 downto 2);
   signal wr_req_d0                      : std_logic;
   signal wr_dat_d0                      : std_logic_vector(31 downto 0);
+  signal wr_sel_d0                      : std_logic_vector(31 downto 0);
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
 begin
   rst_n <= not reset;
   process (clk) begin
@@ -163,30 +168,37 @@ begin
       if rst_n = '0' then
         wait_int <= '0';
       else
-        wait_int <= (wait_int or (read or write)) and not (rd_ack_int or wr_ack_int);
+        wait_int <= (wait_int or (read or write)) and not (rd_ack or wr_ack);
       end if;
     end if;
+  end process;
+  process (byteenable) begin
+    sel_int(7 downto 0) <= (others => byteenable(0));
+    sel_int(15 downto 8) <= (others => byteenable(1));
+    sel_int(23 downto 16) <= (others => byteenable(2));
+    sel_int(31 downto 24) <= (others => byteenable(3));
   end process;
   process (clk) begin
     if rising_edge(clk) then
       if rst_n = '0' then
-        rd_req_int <= '0';
-        wr_req_int <= '0';
+        rd_req <= '0';
+        wr_req <= '0';
       else
         if ((read or write) and not wait_int) = '1' then
-          addr_int <= address;
+          adr <= address;
         else
         end if;
         if (write and not wait_int) = '1' then
-          dati_int <= writedata;
+          wr_sel <= sel_int;
+          wr_dat <= writedata;
         else
         end if;
-        rd_req_int <= read and not wait_int;
-        wr_req_int <= write and not wait_int;
+        rd_req <= read and not wait_int;
+        wr_req <= write and not wait_int;
       end if;
     end if;
   end process;
-  readdatavalid <= rd_ack_int;
+  readdatavalid <= rd_ack;
   waitrequest <= wait_int;
 
   -- pipelining for rd-in+wr-in
@@ -196,10 +208,11 @@ begin
         rd_req_d0 <= '0';
         wr_req_d0 <= '0';
       else
-        rd_req_d0 <= rd_req_int;
-        rd_adr_d0 <= addr_int;
-        wr_req_d0 <= wr_req_int;
-        wr_dat_d0 <= dati_int;
+        rd_req_d0 <= rd_req;
+        rd_adr_d0 <= adr;
+        wr_req_d0 <= wr_req;
+        wr_dat_d0 <= wr_dat;
+        wr_sel_d0 <= wr_sel;
       end if;
     end if;
   end process;
@@ -243,13 +256,13 @@ begin
       g_size               => 8,
       g_addr_width         => 3,
       g_dual_clock         => '0',
-      g_use_bwsel          => '0'
+      g_use_bwsel          => '1'
     )
     port map (
       clk_a_i              => clk,
       clk_b_i              => clk,
       addr_a_i             => rd_adr_d0(4 downto 2),
-      bwsel_a_i            => (others => '1'),
+      bwsel_a_i            => ram1_sel_int,
       data_a_i             => wr_dat_d0,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
@@ -262,6 +275,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel_d0) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk) begin
     if rising_edge(clk) then
       if rst_n = '0' then
@@ -279,13 +307,13 @@ begin
       g_size               => 8,
       g_addr_width         => 3,
       g_dual_clock         => '0',
-      g_use_bwsel          => '0'
+      g_use_bwsel          => '1'
     )
     port map (
       clk_a_i              => clk,
       clk_b_i              => clk,
       addr_a_i             => rd_adr_d0(4 downto 2),
-      bwsel_a_i            => (others => '1'),
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -298,6 +326,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel_d0) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk) begin
     if rising_edge(clk) then
       if rst_n = '0' then
@@ -339,7 +382,21 @@ begin
   sub1_wb_wack <= sub1_wb_ack_i and sub1_wb_wt;
   sub1_wb_rack <= sub1_wb_ack_i and sub1_wb_rt;
   sub1_wb_adr_o <= rd_adr_d0(11 downto 2);
-  sub1_wb_sel_o <= (others => '1');
+  process (wr_sel_d0) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
   sub1_wb_dat_o <= wr_dat_d0;
 
@@ -349,7 +406,21 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wr_dat_d0;
-  sub2_axi4_wstrb_o <= (others => '1');
+  process (wr_sel_d0) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= rd_adr_d0(11 downto 2);
@@ -386,7 +457,21 @@ begin
     end if;
   end process;
   sub4_avalon_address_o <= rd_adr_d0(11 downto 2);
-  sub4_avalon_byteenable_o <= (others => '1');
+  process (wr_sel_d0) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
   sub4_avalon_writedata_o <= wr_dat_d0;
@@ -424,12 +509,26 @@ begin
     end if;
   end process;
   sub5_apb_pwdata_o <= wr_dat_d0;
-  sub5_apb_pstrb_o <= (others => '1');
+  process (wr_sel_d0) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
   process (rd_adr_d0, wr_req_d0, reg1_wack, reg2_wack, sub1_wb_wack,
            sub2_axi4_bvalid_i, sub3_cernbe_VMEWrDone_i, sub4_avalon_wr,
-           sub4_avalon_waitrequest_i, wr_ack_int, sub5_apb_wr, sub5_apb_pready_i,
+           sub4_avalon_waitrequest_i, wr_ack, sub5_apb_wr, sub5_apb_pready_i,
            sub5_apb_pslverr_i) begin
     reg1_wreq <= '0';
     reg2_wreq <= '0';
@@ -449,51 +548,51 @@ begin
         when "000" =>
           -- Reg reg1
           reg1_wreq <= wr_req_d0;
-          wr_ack_int <= reg1_wack;
+          wr_ack <= reg1_wack;
         when "001" =>
           -- Reg reg2
           reg2_wreq <= wr_req_d0;
-          wr_ack_int <= reg2_wack;
+          wr_ack <= reg2_wack;
         when others =>
-          wr_ack_int <= wr_req_d0;
+          wr_ack <= wr_req_d0;
         end case;
       when "0000001" =>
         -- Memory ram1
         ram1_val_int_wr <= wr_req_d0;
-        wr_ack_int <= wr_req_d0;
+        wr_ack <= wr_req_d0;
       when "0000010" =>
         -- Memory ram_ro
-        wr_ack_int <= wr_req_d0;
+        wr_ack <= wr_req_d0;
       when "0000011" =>
         -- Memory ram2
         ram2_wr_o <= wr_req_d0;
-        wr_ack_int <= wr_req_d0;
+        wr_ack <= wr_req_d0;
       when others =>
-        wr_ack_int <= wr_req_d0;
+        wr_ack <= wr_req_d0;
       end case;
     when "001" =>
       -- Submap sub1_wb
       sub1_wb_we <= wr_req_d0;
-      wr_ack_int <= sub1_wb_wack;
+      wr_ack <= sub1_wb_wack;
     when "010" =>
       -- Submap sub2_axi4
       sub2_axi4_wr <= wr_req_d0;
-      wr_ack_int <= sub2_axi4_bvalid_i;
+      wr_ack <= sub2_axi4_bvalid_i;
     when "011" =>
       -- Submap sub3_cernbe
       sub3_cernbe_VMEWrMem_o <= wr_req_d0;
-      wr_ack_int <= sub3_cernbe_VMEWrDone_i;
+      wr_ack <= sub3_cernbe_VMEWrDone_i;
     when "100" =>
       -- Submap sub4_avalon
       sub4_avalon_we <= wr_req_d0;
-      wr_ack_int <= sub4_avalon_wr and not sub4_avalon_waitrequest_i;
+      wr_ack <= sub4_avalon_wr and not sub4_avalon_waitrequest_i;
     when "101" =>
       -- Submap sub5_apb
       sub5_apb_wr_req <= wr_req_d0;
-      sub5_apb_wr_ack <= wr_ack_int;
-      wr_ack_int <= sub5_apb_wr and sub5_apb_pready_i;
+      sub5_apb_wr_ack <= wr_ack;
+      wr_ack <= sub5_apb_wr and sub5_apb_pready_i;
     when others =>
-      wr_ack_int <= wr_req_d0;
+      wr_ack <= wr_req_d0;
     end case;
   end process;
 
@@ -503,8 +602,8 @@ begin
            ram2_rack, sub1_wb_dat_i, sub1_wb_rack, sub2_axi4_rdata_i,
            sub2_axi4_rvalid_i, sub3_cernbe_VMERdData_i,
            sub3_cernbe_VMERdDone_i, sub4_avalon_readdata_i,
-           sub4_avalon_readdatavalid_i, rd_ack_int, sub5_apb_prdata_i,
-           sub5_apb_rd, sub5_apb_pready_i, sub5_apb_pslverr_i) begin
+           sub4_avalon_readdatavalid_i, rd_ack, sub5_apb_prdata_i, sub5_apb_rd,
+           sub5_apb_pready_i, sub5_apb_pslverr_i) begin
     -- By default ack read requests
     readdata <= (others => 'X');
     ram1_val_rreq <= '0';
@@ -523,61 +622,61 @@ begin
         case rd_adr_d0(4 downto 2) is
         when "000" =>
           -- Reg reg1
-          rd_ack_int <= rd_req_d0;
+          rd_ack <= rd_req_d0;
           readdata <= reg1_reg;
         when "001" =>
           -- Reg reg2
-          rd_ack_int <= rd_req_d0;
+          rd_ack <= rd_req_d0;
           readdata <= reg2_reg;
         when others =>
-          rd_ack_int <= rd_req_d0;
+          rd_ack <= rd_req_d0;
         end case;
       when "0000001" =>
         -- Memory ram1
         readdata <= ram1_val_int_dato;
         ram1_val_rreq <= rd_req_d0;
-        rd_ack_int <= ram1_val_rack;
+        rd_ack <= ram1_val_rack;
       when "0000010" =>
         -- Memory ram_ro
         readdata <= ram_ro_val_int_dato;
         ram_ro_val_rreq <= rd_req_d0;
-        rd_ack_int <= ram_ro_val_rack;
+        rd_ack <= ram_ro_val_rack;
       when "0000011" =>
         -- Memory ram2
         readdata <= ram2_data_i;
-        rd_ack_int <= ram2_rack;
+        rd_ack <= ram2_rack;
         ram2_re <= rd_req_d0;
       when others =>
-        rd_ack_int <= rd_req_d0;
+        rd_ack <= rd_req_d0;
       end case;
     when "001" =>
       -- Submap sub1_wb
       sub1_wb_re <= rd_req_d0;
       readdata <= sub1_wb_dat_i;
-      rd_ack_int <= sub1_wb_rack;
+      rd_ack <= sub1_wb_rack;
     when "010" =>
       -- Submap sub2_axi4
       sub2_axi4_rd <= rd_req_d0;
       readdata <= sub2_axi4_rdata_i;
-      rd_ack_int <= sub2_axi4_rvalid_i;
+      rd_ack <= sub2_axi4_rvalid_i;
     when "011" =>
       -- Submap sub3_cernbe
       sub3_cernbe_VMERdMem_o <= rd_req_d0;
       readdata <= sub3_cernbe_VMERdData_i;
-      rd_ack_int <= sub3_cernbe_VMERdDone_i;
+      rd_ack <= sub3_cernbe_VMERdDone_i;
     when "100" =>
       -- Submap sub4_avalon
       sub4_avalon_re <= rd_req_d0;
       readdata <= sub4_avalon_readdata_i;
-      rd_ack_int <= sub4_avalon_readdatavalid_i;
+      rd_ack <= sub4_avalon_readdatavalid_i;
     when "101" =>
       -- Submap sub5_apb
       sub5_apb_rd_req <= rd_req_d0;
-      sub5_apb_rd_ack <= rd_ack_int;
+      sub5_apb_rd_ack <= rd_ack;
       readdata <= sub5_apb_prdata_i;
-      rd_ack_int <= sub5_apb_rd and sub5_apb_pready_i;
+      rd_ack <= sub5_apb_rd and sub5_apb_pready_i;
     when others =>
-      rd_ack_int <= rd_req_d0;
+      rd_ack <= rd_req_d0;
     end case;
   end process;
 end syn;

--- a/testfiles/tb/golden_files/all1_avalon_none.vhdl
+++ b/testfiles/tb/golden_files/all1_avalon_none.vhdl
@@ -104,13 +104,15 @@ end all1_avalon;
 
 architecture syn of all1_avalon is
   signal rst_n                          : std_logic;
-  signal rd_ack_int                     : std_logic;
-  signal wr_ack_int                     : std_logic;
-  signal rd_req_int                     : std_logic;
-  signal wr_req_int                     : std_logic;
+  signal rd_req                         : std_logic;
+  signal rd_ack                         : std_logic;
+  signal wr_req                         : std_logic;
+  signal wr_ack                         : std_logic;
+  signal wr_dat                         : std_logic_vector(31 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal wait_int                       : std_logic;
-  signal addr_int                       : std_logic_vector(14 downto 2);
-  signal dati_int                       : std_logic_vector(31 downto 0);
+  signal sel_int                        : std_logic_vector(31 downto 0);
+  signal adr                            : std_logic_vector(14 downto 2);
   signal reg1_reg                       : std_logic_vector(31 downto 0);
   signal reg1_wreq                      : std_logic;
   signal reg1_wack                      : std_logic;
@@ -152,6 +154,8 @@ architecture syn of all1_avalon is
   signal sub5_apb_rd_ack                : std_logic;
   signal sub5_apb_rd                    : std_logic;
   signal sub5_apb_rd_reg                : std_logic;
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
 begin
   rst_n <= not reset;
   process (clk) begin
@@ -159,30 +163,37 @@ begin
       if rst_n = '0' then
         wait_int <= '0';
       else
-        wait_int <= (wait_int or (read or write)) and not (rd_ack_int or wr_ack_int);
+        wait_int <= (wait_int or (read or write)) and not (rd_ack or wr_ack);
       end if;
     end if;
+  end process;
+  process (byteenable) begin
+    sel_int(7 downto 0) <= (others => byteenable(0));
+    sel_int(15 downto 8) <= (others => byteenable(1));
+    sel_int(23 downto 16) <= (others => byteenable(2));
+    sel_int(31 downto 24) <= (others => byteenable(3));
   end process;
   process (clk) begin
     if rising_edge(clk) then
       if rst_n = '0' then
-        rd_req_int <= '0';
-        wr_req_int <= '0';
+        rd_req <= '0';
+        wr_req <= '0';
       else
         if ((read or write) and not wait_int) = '1' then
-          addr_int <= address;
+          adr <= address;
         else
         end if;
         if (write and not wait_int) = '1' then
-          dati_int <= writedata;
+          wr_sel <= sel_int;
+          wr_dat <= writedata;
         else
         end if;
-        rd_req_int <= read and not wait_int;
-        wr_req_int <= write and not wait_int;
+        rd_req <= read and not wait_int;
+        wr_req <= write and not wait_int;
       end if;
     end if;
   end process;
-  readdatavalid <= rd_ack_int;
+  readdatavalid <= rd_ack;
   waitrequest <= wait_int;
 
   -- Register reg1
@@ -194,7 +205,7 @@ begin
         reg1_wack <= '0';
       else
         if reg1_wreq = '1' then
-          reg1_reg <= dati_int;
+          reg1_reg <= wr_dat;
         end if;
         reg1_wack <= reg1_wreq;
       end if;
@@ -210,7 +221,7 @@ begin
         reg2_wack <= '0';
       else
         if reg2_wreq = '1' then
-          reg2_reg <= dati_int;
+          reg2_reg <= wr_dat;
         end if;
         reg2_wack <= reg2_wreq;
       end if;
@@ -224,14 +235,14 @@ begin
       g_size               => 8,
       g_addr_width         => 3,
       g_dual_clock         => '0',
-      g_use_bwsel          => '0'
+      g_use_bwsel          => '1'
     )
     port map (
       clk_a_i              => clk,
       clk_b_i              => clk,
-      addr_a_i             => addr_int(4 downto 2),
-      bwsel_a_i            => (others => '1'),
-      data_a_i             => dati_int,
+      addr_a_i             => adr(4 downto 2),
+      bwsel_a_i            => ram1_sel_int,
+      data_a_i             => wr_dat,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
       wr_a_i               => ram1_val_int_wr,
@@ -243,6 +254,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk) begin
     if rising_edge(clk) then
       if rst_n = '0' then
@@ -260,13 +286,13 @@ begin
       g_size               => 8,
       g_addr_width         => 3,
       g_dual_clock         => '0',
-      g_use_bwsel          => '0'
+      g_use_bwsel          => '1'
     )
     port map (
       clk_a_i              => clk,
       clk_b_i              => clk,
-      addr_a_i             => addr_int(4 downto 2),
-      bwsel_a_i            => (others => '1'),
+      addr_a_i             => adr(4 downto 2),
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -279,6 +305,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk) begin
     if rising_edge(clk) then
       if rst_n = '0' then
@@ -299,8 +340,8 @@ begin
       end if;
     end if;
   end process;
-  ram2_data_o <= dati_int;
-  ram2_addr_o <= addr_int(4 downto 2);
+  ram2_data_o <= wr_dat;
+  ram2_addr_o <= adr(4 downto 2);
 
   -- Interface sub1_wb
   sub1_wb_tr <= sub1_wb_wt or sub1_wb_rt;
@@ -319,21 +360,49 @@ begin
   sub1_wb_stb_o <= sub1_wb_tr;
   sub1_wb_wack <= sub1_wb_ack_i and sub1_wb_wt;
   sub1_wb_rack <= sub1_wb_ack_i and sub1_wb_rt;
-  sub1_wb_adr_o <= addr_int(11 downto 2);
-  sub1_wb_sel_o <= (others => '1');
+  sub1_wb_adr_o <= adr(11 downto 2);
+  process (wr_sel) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
-  sub1_wb_dat_o <= dati_int;
+  sub1_wb_dat_o <= wr_dat;
 
   -- Interface sub2_axi4
   sub2_axi4_awvalid_o <= sub2_axi4_aw_val;
-  sub2_axi4_awaddr_o <= addr_int(11 downto 2);
+  sub2_axi4_awaddr_o <= adr(11 downto 2);
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
-  sub2_axi4_wdata_o <= dati_int;
-  sub2_axi4_wstrb_o <= (others => '1');
+  sub2_axi4_wdata_o <= wr_dat;
+  process (wr_sel) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
-  sub2_axi4_araddr_o <= addr_int(11 downto 2);
+  sub2_axi4_araddr_o <= adr(11 downto 2);
   sub2_axi4_arprot_o <= "000";
   sub2_axi4_rready_o <= '1';
   process (clk) begin
@@ -351,8 +420,8 @@ begin
   end process;
 
   -- Interface sub3_cernbe
-  sub3_cernbe_VMEWrData_o <= dati_int;
-  sub3_cernbe_VMEAddr_o <= addr_int(11 downto 2);
+  sub3_cernbe_VMEWrData_o <= wr_dat;
+  sub3_cernbe_VMEAddr_o <= adr(11 downto 2);
 
   -- Interface sub4_avalon
   process (clk) begin
@@ -366,11 +435,25 @@ begin
       end if;
     end if;
   end process;
-  sub4_avalon_address_o <= addr_int(11 downto 2);
-  sub4_avalon_byteenable_o <= (others => '1');
+  sub4_avalon_address_o <= adr(11 downto 2);
+  process (wr_sel) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
-  sub4_avalon_writedata_o <= dati_int;
+  sub4_avalon_writedata_o <= wr_dat;
 
   -- Interface sub5_apb
   process (clk) begin
@@ -395,23 +478,36 @@ begin
   sub5_apb_wr <= sub5_apb_wr_reg or sub5_apb_wr_req;
   sub5_apb_rd <= sub5_apb_rd_reg or sub5_apb_rd_req;
   sub5_apb_psel_o <= sub5_apb_wr or sub5_apb_rd;
-  sub5_apb_penable_o <= (not wr_req_int and sub5_apb_wr) or (not rd_req_int and sub5_apb_rd);
+  sub5_apb_penable_o <= (not wr_req and sub5_apb_wr) or (not rd_req and sub5_apb_rd);
   sub5_apb_pwrite_o <= sub5_apb_wr;
-  process (sub5_apb_wr, addr_int, addr_int) begin
+  process (sub5_apb_wr, adr, adr) begin
     if sub5_apb_wr = '1' then
-      sub5_apb_paddr_o <= addr_int(11 downto 2);
+      sub5_apb_paddr_o <= adr(11 downto 2);
     else
-      sub5_apb_paddr_o <= addr_int(11 downto 2);
+      sub5_apb_paddr_o <= adr(11 downto 2);
     end if;
   end process;
-  sub5_apb_pwdata_o <= dati_int;
-  sub5_apb_pstrb_o <= (others => '1');
+  sub5_apb_pwdata_o <= wr_dat;
+  process (wr_sel) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
-  process (addr_int, wr_req_int, reg1_wack, reg2_wack, sub1_wb_wack,
-           sub2_axi4_bvalid_i, sub3_cernbe_VMEWrDone_i, sub4_avalon_wr,
-           sub4_avalon_waitrequest_i, wr_ack_int, sub5_apb_wr, sub5_apb_pready_i,
-           sub5_apb_pslverr_i) begin
+  process (adr, wr_req, reg1_wack, reg2_wack, sub1_wb_wack, sub2_axi4_bvalid_i,
+           sub3_cernbe_VMEWrDone_i, sub4_avalon_wr, sub4_avalon_waitrequest_i,
+           wr_ack, sub5_apb_wr, sub5_apb_pready_i, sub5_apb_pslverr_i) begin
     reg1_wreq <= '0';
     reg2_wreq <= '0';
     ram1_val_int_wr <= '0';
@@ -422,70 +518,69 @@ begin
     sub4_avalon_we <= '0';
     sub5_apb_wr_req <= '0';
     sub5_apb_wr_ack <= '0';
-    case addr_int(14 downto 12) is
+    case adr(14 downto 12) is
     when "000" =>
-      case addr_int(11 downto 5) is
+      case adr(11 downto 5) is
       when "0000000" =>
-        case addr_int(4 downto 2) is
+        case adr(4 downto 2) is
         when "000" =>
           -- Reg reg1
-          reg1_wreq <= wr_req_int;
-          wr_ack_int <= reg1_wack;
+          reg1_wreq <= wr_req;
+          wr_ack <= reg1_wack;
         when "001" =>
           -- Reg reg2
-          reg2_wreq <= wr_req_int;
-          wr_ack_int <= reg2_wack;
+          reg2_wreq <= wr_req;
+          wr_ack <= reg2_wack;
         when others =>
-          wr_ack_int <= wr_req_int;
+          wr_ack <= wr_req;
         end case;
       when "0000001" =>
         -- Memory ram1
-        ram1_val_int_wr <= wr_req_int;
-        wr_ack_int <= wr_req_int;
+        ram1_val_int_wr <= wr_req;
+        wr_ack <= wr_req;
       when "0000010" =>
         -- Memory ram_ro
-        wr_ack_int <= wr_req_int;
+        wr_ack <= wr_req;
       when "0000011" =>
         -- Memory ram2
-        ram2_wr_o <= wr_req_int;
-        wr_ack_int <= wr_req_int;
+        ram2_wr_o <= wr_req;
+        wr_ack <= wr_req;
       when others =>
-        wr_ack_int <= wr_req_int;
+        wr_ack <= wr_req;
       end case;
     when "001" =>
       -- Submap sub1_wb
-      sub1_wb_we <= wr_req_int;
-      wr_ack_int <= sub1_wb_wack;
+      sub1_wb_we <= wr_req;
+      wr_ack <= sub1_wb_wack;
     when "010" =>
       -- Submap sub2_axi4
-      sub2_axi4_wr <= wr_req_int;
-      wr_ack_int <= sub2_axi4_bvalid_i;
+      sub2_axi4_wr <= wr_req;
+      wr_ack <= sub2_axi4_bvalid_i;
     when "011" =>
       -- Submap sub3_cernbe
-      sub3_cernbe_VMEWrMem_o <= wr_req_int;
-      wr_ack_int <= sub3_cernbe_VMEWrDone_i;
+      sub3_cernbe_VMEWrMem_o <= wr_req;
+      wr_ack <= sub3_cernbe_VMEWrDone_i;
     when "100" =>
       -- Submap sub4_avalon
-      sub4_avalon_we <= wr_req_int;
-      wr_ack_int <= sub4_avalon_wr and not sub4_avalon_waitrequest_i;
+      sub4_avalon_we <= wr_req;
+      wr_ack <= sub4_avalon_wr and not sub4_avalon_waitrequest_i;
     when "101" =>
       -- Submap sub5_apb
-      sub5_apb_wr_req <= wr_req_int;
-      sub5_apb_wr_ack <= wr_ack_int;
-      wr_ack_int <= sub5_apb_wr and sub5_apb_pready_i;
+      sub5_apb_wr_req <= wr_req;
+      sub5_apb_wr_ack <= wr_ack;
+      wr_ack <= sub5_apb_wr and sub5_apb_pready_i;
     when others =>
-      wr_ack_int <= wr_req_int;
+      wr_ack <= wr_req;
     end case;
   end process;
 
   -- Process for read requests.
-  process (addr_int, rd_req_int, reg1_reg, reg2_reg, ram1_val_int_dato,
-           ram1_val_rack, ram_ro_val_int_dato, ram_ro_val_rack, ram2_data_i,
-           ram2_rack, sub1_wb_dat_i, sub1_wb_rack, sub2_axi4_rdata_i,
-           sub2_axi4_rvalid_i, sub3_cernbe_VMERdData_i,
-           sub3_cernbe_VMERdDone_i, sub4_avalon_readdata_i,
-           sub4_avalon_readdatavalid_i, rd_ack_int, sub5_apb_prdata_i,
-           sub5_apb_rd, sub5_apb_pready_i, sub5_apb_pslverr_i) begin
+  process (adr, rd_req, reg1_reg, reg2_reg, ram1_val_int_dato, ram1_val_rack,
+           ram_ro_val_int_dato, ram_ro_val_rack, ram2_data_i, ram2_rack,
+           sub1_wb_dat_i, sub1_wb_rack, sub2_axi4_rdata_i, sub2_axi4_rvalid_i,
+           sub3_cernbe_VMERdData_i, sub3_cernbe_VMERdDone_i,
+           sub4_avalon_readdata_i, sub4_avalon_readdatavalid_i, rd_ack,
+           sub5_apb_prdata_i, sub5_apb_rd, sub5_apb_pready_i, sub5_apb_pslverr_i) begin
     -- By default ack read requests
     readdata <= (others => 'X');
     ram1_val_rreq <= '0';
@@ -497,68 +592,68 @@ begin
     sub4_avalon_re <= '0';
     sub5_apb_rd_req <= '0';
     sub5_apb_rd_ack <= '0';
-    case addr_int(14 downto 12) is
+    case adr(14 downto 12) is
     when "000" =>
-      case addr_int(11 downto 5) is
+      case adr(11 downto 5) is
       when "0000000" =>
-        case addr_int(4 downto 2) is
+        case adr(4 downto 2) is
         when "000" =>
           -- Reg reg1
-          rd_ack_int <= rd_req_int;
+          rd_ack <= rd_req;
           readdata <= reg1_reg;
         when "001" =>
           -- Reg reg2
-          rd_ack_int <= rd_req_int;
+          rd_ack <= rd_req;
           readdata <= reg2_reg;
         when others =>
-          rd_ack_int <= rd_req_int;
+          rd_ack <= rd_req;
         end case;
       when "0000001" =>
         -- Memory ram1
         readdata <= ram1_val_int_dato;
-        ram1_val_rreq <= rd_req_int;
-        rd_ack_int <= ram1_val_rack;
+        ram1_val_rreq <= rd_req;
+        rd_ack <= ram1_val_rack;
       when "0000010" =>
         -- Memory ram_ro
         readdata <= ram_ro_val_int_dato;
-        ram_ro_val_rreq <= rd_req_int;
-        rd_ack_int <= ram_ro_val_rack;
+        ram_ro_val_rreq <= rd_req;
+        rd_ack <= ram_ro_val_rack;
       when "0000011" =>
         -- Memory ram2
         readdata <= ram2_data_i;
-        rd_ack_int <= ram2_rack;
-        ram2_re <= rd_req_int;
+        rd_ack <= ram2_rack;
+        ram2_re <= rd_req;
       when others =>
-        rd_ack_int <= rd_req_int;
+        rd_ack <= rd_req;
       end case;
     when "001" =>
       -- Submap sub1_wb
-      sub1_wb_re <= rd_req_int;
+      sub1_wb_re <= rd_req;
       readdata <= sub1_wb_dat_i;
-      rd_ack_int <= sub1_wb_rack;
+      rd_ack <= sub1_wb_rack;
     when "010" =>
       -- Submap sub2_axi4
-      sub2_axi4_rd <= rd_req_int;
+      sub2_axi4_rd <= rd_req;
       readdata <= sub2_axi4_rdata_i;
-      rd_ack_int <= sub2_axi4_rvalid_i;
+      rd_ack <= sub2_axi4_rvalid_i;
     when "011" =>
       -- Submap sub3_cernbe
-      sub3_cernbe_VMERdMem_o <= rd_req_int;
+      sub3_cernbe_VMERdMem_o <= rd_req;
       readdata <= sub3_cernbe_VMERdData_i;
-      rd_ack_int <= sub3_cernbe_VMERdDone_i;
+      rd_ack <= sub3_cernbe_VMERdDone_i;
     when "100" =>
       -- Submap sub4_avalon
-      sub4_avalon_re <= rd_req_int;
+      sub4_avalon_re <= rd_req;
       readdata <= sub4_avalon_readdata_i;
-      rd_ack_int <= sub4_avalon_readdatavalid_i;
+      rd_ack <= sub4_avalon_readdatavalid_i;
     when "101" =>
       -- Submap sub5_apb
-      sub5_apb_rd_req <= rd_req_int;
-      sub5_apb_rd_ack <= rd_ack_int;
+      sub5_apb_rd_req <= rd_req;
+      sub5_apb_rd_ack <= rd_ack;
       readdata <= sub5_apb_prdata_i;
-      rd_ack_int <= sub5_apb_rd and sub5_apb_pready_i;
+      rd_ack <= sub5_apb_rd and sub5_apb_pready_i;
     when others =>
-      rd_ack_int <= rd_req_int;
+      rd_ack <= rd_req;
     end case;
   end process;
 end syn;

--- a/testfiles/tb/golden_files/all1_avalon_out.vhdl
+++ b/testfiles/tb/golden_files/all1_avalon_out.vhdl
@@ -104,13 +104,15 @@ end all1_avalon;
 
 architecture syn of all1_avalon is
   signal rst_n                          : std_logic;
-  signal rd_ack_int                     : std_logic;
-  signal wr_ack_int                     : std_logic;
-  signal rd_req_int                     : std_logic;
-  signal wr_req_int                     : std_logic;
+  signal rd_req                         : std_logic;
+  signal rd_ack                         : std_logic;
+  signal wr_req                         : std_logic;
+  signal wr_ack                         : std_logic;
+  signal wr_dat                         : std_logic_vector(31 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal wait_int                       : std_logic;
-  signal addr_int                       : std_logic_vector(14 downto 2);
-  signal dati_int                       : std_logic_vector(31 downto 0);
+  signal sel_int                        : std_logic_vector(31 downto 0);
+  signal adr                            : std_logic_vector(14 downto 2);
   signal reg1_reg                       : std_logic_vector(31 downto 0);
   signal reg1_wreq                      : std_logic;
   signal reg1_wack                      : std_logic;
@@ -155,6 +157,8 @@ architecture syn of all1_avalon is
   signal rd_ack_d0                      : std_logic;
   signal rd_dat_d0                      : std_logic_vector(31 downto 0);
   signal wr_ack_d0                      : std_logic;
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
 begin
   rst_n <= not reset;
   process (clk) begin
@@ -162,42 +166,49 @@ begin
       if rst_n = '0' then
         wait_int <= '0';
       else
-        wait_int <= (wait_int or (read or write)) and not (rd_ack_int or wr_ack_int);
+        wait_int <= (wait_int or (read or write)) and not (rd_ack or wr_ack);
       end if;
     end if;
+  end process;
+  process (byteenable) begin
+    sel_int(7 downto 0) <= (others => byteenable(0));
+    sel_int(15 downto 8) <= (others => byteenable(1));
+    sel_int(23 downto 16) <= (others => byteenable(2));
+    sel_int(31 downto 24) <= (others => byteenable(3));
   end process;
   process (clk) begin
     if rising_edge(clk) then
       if rst_n = '0' then
-        rd_req_int <= '0';
-        wr_req_int <= '0';
+        rd_req <= '0';
+        wr_req <= '0';
       else
         if ((read or write) and not wait_int) = '1' then
-          addr_int <= address;
+          adr <= address;
         else
         end if;
         if (write and not wait_int) = '1' then
-          dati_int <= writedata;
+          wr_sel <= sel_int;
+          wr_dat <= writedata;
         else
         end if;
-        rd_req_int <= read and not wait_int;
-        wr_req_int <= write and not wait_int;
+        rd_req <= read and not wait_int;
+        wr_req <= write and not wait_int;
       end if;
     end if;
   end process;
-  readdatavalid <= rd_ack_int;
+  readdatavalid <= rd_ack;
   waitrequest <= wait_int;
 
   -- pipelining for rd-out+wr-out
   process (clk) begin
     if rising_edge(clk) then
       if rst_n = '0' then
-        rd_ack_int <= '0';
-        wr_ack_int <= '0';
+        rd_ack <= '0';
+        wr_ack <= '0';
       else
-        rd_ack_int <= rd_ack_d0;
+        rd_ack <= rd_ack_d0;
         readdata <= rd_dat_d0;
-        wr_ack_int <= wr_ack_d0;
+        wr_ack <= wr_ack_d0;
       end if;
     end if;
   end process;
@@ -211,7 +222,7 @@ begin
         reg1_wack <= '0';
       else
         if reg1_wreq = '1' then
-          reg1_reg <= dati_int;
+          reg1_reg <= wr_dat;
         end if;
         reg1_wack <= reg1_wreq;
       end if;
@@ -227,7 +238,7 @@ begin
         reg2_wack <= '0';
       else
         if reg2_wreq = '1' then
-          reg2_reg <= dati_int;
+          reg2_reg <= wr_dat;
         end if;
         reg2_wack <= reg2_wreq;
       end if;
@@ -241,14 +252,14 @@ begin
       g_size               => 8,
       g_addr_width         => 3,
       g_dual_clock         => '0',
-      g_use_bwsel          => '0'
+      g_use_bwsel          => '1'
     )
     port map (
       clk_a_i              => clk,
       clk_b_i              => clk,
-      addr_a_i             => addr_int(4 downto 2),
-      bwsel_a_i            => (others => '1'),
-      data_a_i             => dati_int,
+      addr_a_i             => adr(4 downto 2),
+      bwsel_a_i            => ram1_sel_int,
+      data_a_i             => wr_dat,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
       wr_a_i               => ram1_val_int_wr,
@@ -260,6 +271,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk) begin
     if rising_edge(clk) then
       if rst_n = '0' then
@@ -277,13 +303,13 @@ begin
       g_size               => 8,
       g_addr_width         => 3,
       g_dual_clock         => '0',
-      g_use_bwsel          => '0'
+      g_use_bwsel          => '1'
     )
     port map (
       clk_a_i              => clk,
       clk_b_i              => clk,
-      addr_a_i             => addr_int(4 downto 2),
-      bwsel_a_i            => (others => '1'),
+      addr_a_i             => adr(4 downto 2),
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -296,6 +322,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk) begin
     if rising_edge(clk) then
       if rst_n = '0' then
@@ -316,8 +357,8 @@ begin
       end if;
     end if;
   end process;
-  ram2_data_o <= dati_int;
-  ram2_addr_o <= addr_int(4 downto 2);
+  ram2_data_o <= wr_dat;
+  ram2_addr_o <= adr(4 downto 2);
 
   -- Interface sub1_wb
   sub1_wb_tr <= sub1_wb_wt or sub1_wb_rt;
@@ -336,21 +377,49 @@ begin
   sub1_wb_stb_o <= sub1_wb_tr;
   sub1_wb_wack <= sub1_wb_ack_i and sub1_wb_wt;
   sub1_wb_rack <= sub1_wb_ack_i and sub1_wb_rt;
-  sub1_wb_adr_o <= addr_int(11 downto 2);
-  sub1_wb_sel_o <= (others => '1');
+  sub1_wb_adr_o <= adr(11 downto 2);
+  process (wr_sel) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
-  sub1_wb_dat_o <= dati_int;
+  sub1_wb_dat_o <= wr_dat;
 
   -- Interface sub2_axi4
   sub2_axi4_awvalid_o <= sub2_axi4_aw_val;
-  sub2_axi4_awaddr_o <= addr_int(11 downto 2);
+  sub2_axi4_awaddr_o <= adr(11 downto 2);
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
-  sub2_axi4_wdata_o <= dati_int;
-  sub2_axi4_wstrb_o <= (others => '1');
+  sub2_axi4_wdata_o <= wr_dat;
+  process (wr_sel) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
-  sub2_axi4_araddr_o <= addr_int(11 downto 2);
+  sub2_axi4_araddr_o <= adr(11 downto 2);
   sub2_axi4_arprot_o <= "000";
   sub2_axi4_rready_o <= '1';
   process (clk) begin
@@ -368,8 +437,8 @@ begin
   end process;
 
   -- Interface sub3_cernbe
-  sub3_cernbe_VMEWrData_o <= dati_int;
-  sub3_cernbe_VMEAddr_o <= addr_int(11 downto 2);
+  sub3_cernbe_VMEWrData_o <= wr_dat;
+  sub3_cernbe_VMEAddr_o <= adr(11 downto 2);
 
   -- Interface sub4_avalon
   process (clk) begin
@@ -383,11 +452,25 @@ begin
       end if;
     end if;
   end process;
-  sub4_avalon_address_o <= addr_int(11 downto 2);
-  sub4_avalon_byteenable_o <= (others => '1');
+  sub4_avalon_address_o <= adr(11 downto 2);
+  process (wr_sel) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
-  sub4_avalon_writedata_o <= dati_int;
+  sub4_avalon_writedata_o <= wr_dat;
 
   -- Interface sub5_apb
   process (clk) begin
@@ -412,23 +495,36 @@ begin
   sub5_apb_wr <= sub5_apb_wr_reg or sub5_apb_wr_req;
   sub5_apb_rd <= sub5_apb_rd_reg or sub5_apb_rd_req;
   sub5_apb_psel_o <= sub5_apb_wr or sub5_apb_rd;
-  sub5_apb_penable_o <= (not wr_req_int and sub5_apb_wr) or (not rd_req_int and sub5_apb_rd);
+  sub5_apb_penable_o <= (not wr_req and sub5_apb_wr) or (not rd_req and sub5_apb_rd);
   sub5_apb_pwrite_o <= sub5_apb_wr;
-  process (sub5_apb_wr, addr_int, addr_int) begin
+  process (sub5_apb_wr, adr, adr) begin
     if sub5_apb_wr = '1' then
-      sub5_apb_paddr_o <= addr_int(11 downto 2);
+      sub5_apb_paddr_o <= adr(11 downto 2);
     else
-      sub5_apb_paddr_o <= addr_int(11 downto 2);
+      sub5_apb_paddr_o <= adr(11 downto 2);
     end if;
   end process;
-  sub5_apb_pwdata_o <= dati_int;
-  sub5_apb_pstrb_o <= (others => '1');
+  sub5_apb_pwdata_o <= wr_dat;
+  process (wr_sel) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
-  process (addr_int, wr_req_int, reg1_wack, reg2_wack, sub1_wb_wack,
-           sub2_axi4_bvalid_i, sub3_cernbe_VMEWrDone_i, sub4_avalon_wr,
-           sub4_avalon_waitrequest_i, wr_ack_d0, sub5_apb_wr, sub5_apb_pready_i,
-           sub5_apb_pslverr_i) begin
+  process (adr, wr_req, reg1_wack, reg2_wack, sub1_wb_wack, sub2_axi4_bvalid_i,
+           sub3_cernbe_VMEWrDone_i, sub4_avalon_wr, sub4_avalon_waitrequest_i,
+           wr_ack_d0, sub5_apb_wr, sub5_apb_pready_i, sub5_apb_pslverr_i) begin
     reg1_wreq <= '0';
     reg2_wreq <= '0';
     ram1_val_int_wr <= '0';
@@ -439,70 +535,69 @@ begin
     sub4_avalon_we <= '0';
     sub5_apb_wr_req <= '0';
     sub5_apb_wr_ack <= '0';
-    case addr_int(14 downto 12) is
+    case adr(14 downto 12) is
     when "000" =>
-      case addr_int(11 downto 5) is
+      case adr(11 downto 5) is
       when "0000000" =>
-        case addr_int(4 downto 2) is
+        case adr(4 downto 2) is
         when "000" =>
           -- Reg reg1
-          reg1_wreq <= wr_req_int;
+          reg1_wreq <= wr_req;
           wr_ack_d0 <= reg1_wack;
         when "001" =>
           -- Reg reg2
-          reg2_wreq <= wr_req_int;
+          reg2_wreq <= wr_req;
           wr_ack_d0 <= reg2_wack;
         when others =>
-          wr_ack_d0 <= wr_req_int;
+          wr_ack_d0 <= wr_req;
         end case;
       when "0000001" =>
         -- Memory ram1
-        ram1_val_int_wr <= wr_req_int;
-        wr_ack_d0 <= wr_req_int;
+        ram1_val_int_wr <= wr_req;
+        wr_ack_d0 <= wr_req;
       when "0000010" =>
         -- Memory ram_ro
-        wr_ack_d0 <= wr_req_int;
+        wr_ack_d0 <= wr_req;
       when "0000011" =>
         -- Memory ram2
-        ram2_wr_o <= wr_req_int;
-        wr_ack_d0 <= wr_req_int;
+        ram2_wr_o <= wr_req;
+        wr_ack_d0 <= wr_req;
       when others =>
-        wr_ack_d0 <= wr_req_int;
+        wr_ack_d0 <= wr_req;
       end case;
     when "001" =>
       -- Submap sub1_wb
-      sub1_wb_we <= wr_req_int;
+      sub1_wb_we <= wr_req;
       wr_ack_d0 <= sub1_wb_wack;
     when "010" =>
       -- Submap sub2_axi4
-      sub2_axi4_wr <= wr_req_int;
+      sub2_axi4_wr <= wr_req;
       wr_ack_d0 <= sub2_axi4_bvalid_i;
     when "011" =>
       -- Submap sub3_cernbe
-      sub3_cernbe_VMEWrMem_o <= wr_req_int;
+      sub3_cernbe_VMEWrMem_o <= wr_req;
       wr_ack_d0 <= sub3_cernbe_VMEWrDone_i;
     when "100" =>
       -- Submap sub4_avalon
-      sub4_avalon_we <= wr_req_int;
+      sub4_avalon_we <= wr_req;
       wr_ack_d0 <= sub4_avalon_wr and not sub4_avalon_waitrequest_i;
     when "101" =>
       -- Submap sub5_apb
-      sub5_apb_wr_req <= wr_req_int;
+      sub5_apb_wr_req <= wr_req;
       sub5_apb_wr_ack <= wr_ack_d0;
       wr_ack_d0 <= sub5_apb_wr and sub5_apb_pready_i;
     when others =>
-      wr_ack_d0 <= wr_req_int;
+      wr_ack_d0 <= wr_req;
     end case;
   end process;
 
   -- Process for read requests.
-  process (addr_int, rd_req_int, reg1_reg, reg2_reg, ram1_val_int_dato,
-           ram1_val_rack, ram_ro_val_int_dato, ram_ro_val_rack, ram2_data_i,
-           ram2_rack, sub1_wb_dat_i, sub1_wb_rack, sub2_axi4_rdata_i,
-           sub2_axi4_rvalid_i, sub3_cernbe_VMERdData_i,
-           sub3_cernbe_VMERdDone_i, sub4_avalon_readdata_i,
-           sub4_avalon_readdatavalid_i, rd_ack_d0, sub5_apb_prdata_i,
-           sub5_apb_rd, sub5_apb_pready_i, sub5_apb_pslverr_i) begin
+  process (adr, rd_req, reg1_reg, reg2_reg, ram1_val_int_dato, ram1_val_rack,
+           ram_ro_val_int_dato, ram_ro_val_rack, ram2_data_i, ram2_rack,
+           sub1_wb_dat_i, sub1_wb_rack, sub2_axi4_rdata_i, sub2_axi4_rvalid_i,
+           sub3_cernbe_VMERdData_i, sub3_cernbe_VMERdDone_i,
+           sub4_avalon_readdata_i, sub4_avalon_readdatavalid_i, rd_ack_d0,
+           sub5_apb_prdata_i, sub5_apb_rd, sub5_apb_pready_i, sub5_apb_pslverr_i) begin
     -- By default ack read requests
     rd_dat_d0 <= (others => 'X');
     ram1_val_rreq <= '0';
@@ -514,68 +609,68 @@ begin
     sub4_avalon_re <= '0';
     sub5_apb_rd_req <= '0';
     sub5_apb_rd_ack <= '0';
-    case addr_int(14 downto 12) is
+    case adr(14 downto 12) is
     when "000" =>
-      case addr_int(11 downto 5) is
+      case adr(11 downto 5) is
       when "0000000" =>
-        case addr_int(4 downto 2) is
+        case adr(4 downto 2) is
         when "000" =>
           -- Reg reg1
-          rd_ack_d0 <= rd_req_int;
+          rd_ack_d0 <= rd_req;
           rd_dat_d0 <= reg1_reg;
         when "001" =>
           -- Reg reg2
-          rd_ack_d0 <= rd_req_int;
+          rd_ack_d0 <= rd_req;
           rd_dat_d0 <= reg2_reg;
         when others =>
-          rd_ack_d0 <= rd_req_int;
+          rd_ack_d0 <= rd_req;
         end case;
       when "0000001" =>
         -- Memory ram1
         rd_dat_d0 <= ram1_val_int_dato;
-        ram1_val_rreq <= rd_req_int;
+        ram1_val_rreq <= rd_req;
         rd_ack_d0 <= ram1_val_rack;
       when "0000010" =>
         -- Memory ram_ro
         rd_dat_d0 <= ram_ro_val_int_dato;
-        ram_ro_val_rreq <= rd_req_int;
+        ram_ro_val_rreq <= rd_req;
         rd_ack_d0 <= ram_ro_val_rack;
       when "0000011" =>
         -- Memory ram2
         rd_dat_d0 <= ram2_data_i;
         rd_ack_d0 <= ram2_rack;
-        ram2_re <= rd_req_int;
+        ram2_re <= rd_req;
       when others =>
-        rd_ack_d0 <= rd_req_int;
+        rd_ack_d0 <= rd_req;
       end case;
     when "001" =>
       -- Submap sub1_wb
-      sub1_wb_re <= rd_req_int;
+      sub1_wb_re <= rd_req;
       rd_dat_d0 <= sub1_wb_dat_i;
       rd_ack_d0 <= sub1_wb_rack;
     when "010" =>
       -- Submap sub2_axi4
-      sub2_axi4_rd <= rd_req_int;
+      sub2_axi4_rd <= rd_req;
       rd_dat_d0 <= sub2_axi4_rdata_i;
       rd_ack_d0 <= sub2_axi4_rvalid_i;
     when "011" =>
       -- Submap sub3_cernbe
-      sub3_cernbe_VMERdMem_o <= rd_req_int;
+      sub3_cernbe_VMERdMem_o <= rd_req;
       rd_dat_d0 <= sub3_cernbe_VMERdData_i;
       rd_ack_d0 <= sub3_cernbe_VMERdDone_i;
     when "100" =>
       -- Submap sub4_avalon
-      sub4_avalon_re <= rd_req_int;
+      sub4_avalon_re <= rd_req;
       rd_dat_d0 <= sub4_avalon_readdata_i;
       rd_ack_d0 <= sub4_avalon_readdatavalid_i;
     when "101" =>
       -- Submap sub5_apb
-      sub5_apb_rd_req <= rd_req_int;
+      sub5_apb_rd_req <= rd_req;
       sub5_apb_rd_ack <= rd_ack_d0;
       rd_dat_d0 <= sub5_apb_prdata_i;
       rd_ack_d0 <= sub5_apb_rd and sub5_apb_pready_i;
     when others =>
-      rd_ack_d0 <= rd_req_int;
+      rd_ack_d0 <= rd_req;
     end case;
   end process;
 end syn;

--- a/testfiles/tb/golden_files/all1_avalon_rd-in,wr-out.vhdl
+++ b/testfiles/tb/golden_files/all1_avalon_rd-in,wr-out.vhdl
@@ -104,13 +104,15 @@ end all1_avalon;
 
 architecture syn of all1_avalon is
   signal rst_n                          : std_logic;
-  signal rd_ack_int                     : std_logic;
-  signal wr_ack_int                     : std_logic;
-  signal rd_req_int                     : std_logic;
-  signal wr_req_int                     : std_logic;
+  signal rd_req                         : std_logic;
+  signal rd_ack                         : std_logic;
+  signal wr_req                         : std_logic;
+  signal wr_ack                         : std_logic;
+  signal wr_dat                         : std_logic_vector(31 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal wait_int                       : std_logic;
-  signal addr_int                       : std_logic_vector(14 downto 2);
-  signal dati_int                       : std_logic_vector(31 downto 0);
+  signal sel_int                        : std_logic_vector(31 downto 0);
+  signal adr                            : std_logic_vector(14 downto 2);
   signal reg1_reg                       : std_logic_vector(31 downto 0);
   signal reg1_wreq                      : std_logic;
   signal reg1_wack                      : std_logic;
@@ -158,6 +160,8 @@ architecture syn of all1_avalon is
   signal ram1_wr                        : std_logic;
   signal ram1_wreq                      : std_logic;
   signal ram1_adr_int                   : std_logic_vector(2 downto 0);
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
   signal ram2_wp                        : std_logic;
   signal ram2_we                        : std_logic;
   signal sub3_cernbe_ws                 : std_logic;
@@ -169,30 +173,37 @@ begin
       if rst_n = '0' then
         wait_int <= '0';
       else
-        wait_int <= (wait_int or (read or write)) and not (rd_ack_int or wr_ack_int);
+        wait_int <= (wait_int or (read or write)) and not (rd_ack or wr_ack);
       end if;
     end if;
+  end process;
+  process (byteenable) begin
+    sel_int(7 downto 0) <= (others => byteenable(0));
+    sel_int(15 downto 8) <= (others => byteenable(1));
+    sel_int(23 downto 16) <= (others => byteenable(2));
+    sel_int(31 downto 24) <= (others => byteenable(3));
   end process;
   process (clk) begin
     if rising_edge(clk) then
       if rst_n = '0' then
-        rd_req_int <= '0';
-        wr_req_int <= '0';
+        rd_req <= '0';
+        wr_req <= '0';
       else
         if ((read or write) and not wait_int) = '1' then
-          addr_int <= address;
+          adr <= address;
         else
         end if;
         if (write and not wait_int) = '1' then
-          dati_int <= writedata;
+          wr_sel <= sel_int;
+          wr_dat <= writedata;
         else
         end if;
-        rd_req_int <= read and not wait_int;
-        wr_req_int <= write and not wait_int;
+        rd_req <= read and not wait_int;
+        wr_req <= write and not wait_int;
       end if;
     end if;
   end process;
-  readdatavalid <= rd_ack_int;
+  readdatavalid <= rd_ack;
   waitrequest <= wait_int;
 
   -- pipelining for rd-in+wr-out
@@ -200,11 +211,11 @@ begin
     if rising_edge(clk) then
       if rst_n = '0' then
         rd_req_d0 <= '0';
-        wr_ack_int <= '0';
+        wr_ack <= '0';
       else
-        rd_req_d0 <= rd_req_int;
-        rd_adr_d0 <= addr_int;
-        wr_ack_int <= wr_ack_d0;
+        rd_req_d0 <= rd_req;
+        rd_adr_d0 <= adr;
+        wr_ack <= wr_ack_d0;
       end if;
     end if;
   end process;
@@ -218,7 +229,7 @@ begin
         reg1_wack <= '0';
       else
         if reg1_wreq = '1' then
-          reg1_reg <= dati_int;
+          reg1_reg <= wr_dat;
         end if;
         reg1_wack <= reg1_wreq;
       end if;
@@ -234,7 +245,7 @@ begin
         reg2_wack <= '0';
       else
         if reg2_wreq = '1' then
-          reg2_reg <= dati_int;
+          reg2_reg <= wr_dat;
         end if;
         reg2_wack <= reg2_wreq;
       end if;
@@ -242,9 +253,9 @@ begin
   end process;
 
   -- Memory ram1
-  process (rd_adr_d0, addr_int, ram1_wr) begin
+  process (rd_adr_d0, adr, ram1_wr) begin
     if ram1_wr = '1' then
-      ram1_adr_int <= addr_int(4 downto 2);
+      ram1_adr_int <= adr(4 downto 2);
     else
       ram1_adr_int <= rd_adr_d0(4 downto 2);
     end if;
@@ -257,14 +268,14 @@ begin
       g_size               => 8,
       g_addr_width         => 3,
       g_dual_clock         => '0',
-      g_use_bwsel          => '0'
+      g_use_bwsel          => '1'
     )
     port map (
       clk_a_i              => clk,
       clk_b_i              => clk,
       addr_a_i             => ram1_adr_int,
-      bwsel_a_i            => (others => '1'),
-      data_a_i             => dati_int,
+      bwsel_a_i            => ram1_sel_int,
+      data_a_i             => wr_dat,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
       wr_a_i               => ram1_val_int_wr,
@@ -276,6 +287,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk) begin
     if rising_edge(clk) then
       if rst_n = '0' then
@@ -293,13 +319,13 @@ begin
       g_size               => 8,
       g_addr_width         => 3,
       g_dual_clock         => '0',
-      g_use_bwsel          => '0'
+      g_use_bwsel          => '1'
     )
     port map (
       clk_a_i              => clk,
       clk_b_i              => clk,
       addr_a_i             => rd_adr_d0(4 downto 2),
-      bwsel_a_i            => (others => '1'),
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -312,6 +338,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk) begin
     if rising_edge(clk) then
       if rst_n = '0' then
@@ -332,22 +373,22 @@ begin
       end if;
     end if;
   end process;
-  ram2_data_o <= dati_int;
+  ram2_data_o <= wr_dat;
   process (clk) begin
     if rising_edge(clk) then
       if rst_n = '0' then
         ram2_wp <= '0';
       else
-        ram2_wp <= (wr_req_int or ram2_wp) and rd_req_d0;
+        ram2_wp <= (wr_req or ram2_wp) and rd_req_d0;
       end if;
     end if;
   end process;
-  ram2_we <= (wr_req_int or ram2_wp) and not rd_req_d0;
-  process (rd_adr_d0, addr_int, ram2_re) begin
+  ram2_we <= (wr_req or ram2_wp) and not rd_req_d0;
+  process (rd_adr_d0, adr, ram2_re) begin
     if ram2_re = '1' then
       ram2_addr_o <= rd_adr_d0(4 downto 2);
     else
-      ram2_addr_o <= addr_int(4 downto 2);
+      ram2_addr_o <= adr(4 downto 2);
     end if;
   end process;
 
@@ -369,17 +410,45 @@ begin
   sub1_wb_wack <= sub1_wb_ack_i and sub1_wb_wt;
   sub1_wb_rack <= sub1_wb_ack_i and sub1_wb_rt;
   sub1_wb_adr_o <= rd_adr_d0(11 downto 2);
-  sub1_wb_sel_o <= (others => '1');
+  process (wr_sel) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
-  sub1_wb_dat_o <= dati_int;
+  sub1_wb_dat_o <= wr_dat;
 
   -- Interface sub2_axi4
   sub2_axi4_awvalid_o <= sub2_axi4_aw_val;
-  sub2_axi4_awaddr_o <= addr_int(11 downto 2);
+  sub2_axi4_awaddr_o <= adr(11 downto 2);
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
-  sub2_axi4_wdata_o <= dati_int;
-  sub2_axi4_wstrb_o <= (others => '1');
+  sub2_axi4_wdata_o <= wr_dat;
+  process (wr_sel) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= rd_adr_d0(11 downto 2);
@@ -400,7 +469,7 @@ begin
   end process;
 
   -- Interface sub3_cernbe
-  sub3_cernbe_VMEWrData_o <= dati_int;
+  sub3_cernbe_VMEWrData_o <= wr_dat;
   process (clk) begin
     if rising_edge(clk) then
       if rst_n = '0' then
@@ -411,9 +480,9 @@ begin
     end if;
   end process;
   sub3_cernbe_VMEWrMem_o <= sub3_cernbe_ws;
-  process (rd_adr_d0, addr_int, sub3_cernbe_wt, sub3_cernbe_ws) begin
+  process (rd_adr_d0, adr, sub3_cernbe_wt, sub3_cernbe_ws) begin
     if (sub3_cernbe_ws or sub3_cernbe_wt) = '1' then
-      sub3_cernbe_VMEAddr_o <= addr_int(11 downto 2);
+      sub3_cernbe_VMEAddr_o <= adr(11 downto 2);
     else
       sub3_cernbe_VMEAddr_o <= rd_adr_d0(11 downto 2);
     end if;
@@ -432,10 +501,24 @@ begin
     end if;
   end process;
   sub4_avalon_address_o <= rd_adr_d0(11 downto 2);
-  sub4_avalon_byteenable_o <= (others => '1');
+  process (wr_sel) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
-  sub4_avalon_writedata_o <= dati_int;
+  sub4_avalon_writedata_o <= wr_dat;
 
   -- Interface sub5_apb
   process (clk) begin
@@ -460,20 +543,34 @@ begin
   sub5_apb_wr <= sub5_apb_wr_reg or sub5_apb_wr_req;
   sub5_apb_rd <= sub5_apb_rd_reg or sub5_apb_rd_req;
   sub5_apb_psel_o <= sub5_apb_wr or sub5_apb_rd;
-  sub5_apb_penable_o <= (not wr_req_int and sub5_apb_wr) or (not rd_req_d0 and sub5_apb_rd);
+  sub5_apb_penable_o <= (not wr_req and sub5_apb_wr) or (not rd_req_d0 and sub5_apb_rd);
   sub5_apb_pwrite_o <= sub5_apb_wr;
-  process (sub5_apb_wr, addr_int, rd_adr_d0) begin
+  process (sub5_apb_wr, adr, rd_adr_d0) begin
     if sub5_apb_wr = '1' then
-      sub5_apb_paddr_o <= addr_int(11 downto 2);
+      sub5_apb_paddr_o <= adr(11 downto 2);
     else
       sub5_apb_paddr_o <= rd_adr_d0(11 downto 2);
     end if;
   end process;
-  sub5_apb_pwdata_o <= dati_int;
-  sub5_apb_pstrb_o <= (others => '1');
+  sub5_apb_pwdata_o <= wr_dat;
+  process (wr_sel) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
-  process (addr_int, wr_req_int, reg1_wack, reg2_wack, ram2_we, sub1_wb_wack,
+  process (adr, wr_req, reg1_wack, reg2_wack, ram2_we, sub1_wb_wack,
            sub2_axi4_bvalid_i, sub3_cernbe_VMEWrDone_i, sub4_avalon_wr,
            sub4_avalon_waitrequest_i, wr_ack_d0, sub5_apb_wr, sub5_apb_pready_i,
            sub5_apb_pslverr_i) begin
@@ -487,59 +584,59 @@ begin
     sub4_avalon_we <= '0';
     sub5_apb_wr_req <= '0';
     sub5_apb_wr_ack <= '0';
-    case addr_int(14 downto 12) is
+    case adr(14 downto 12) is
     when "000" =>
-      case addr_int(11 downto 5) is
+      case adr(11 downto 5) is
       when "0000000" =>
-        case addr_int(4 downto 2) is
+        case adr(4 downto 2) is
         when "000" =>
           -- Reg reg1
-          reg1_wreq <= wr_req_int;
+          reg1_wreq <= wr_req;
           wr_ack_d0 <= reg1_wack;
         when "001" =>
           -- Reg reg2
-          reg2_wreq <= wr_req_int;
+          reg2_wreq <= wr_req;
           wr_ack_d0 <= reg2_wack;
         when others =>
-          wr_ack_d0 <= wr_req_int;
+          wr_ack_d0 <= wr_req;
         end case;
       when "0000001" =>
         -- Memory ram1
-        ram1_val_int_wr <= wr_req_int;
-        wr_ack_d0 <= wr_req_int;
+        ram1_val_int_wr <= wr_req;
+        wr_ack_d0 <= wr_req;
       when "0000010" =>
         -- Memory ram_ro
-        wr_ack_d0 <= wr_req_int;
+        wr_ack_d0 <= wr_req;
       when "0000011" =>
         -- Memory ram2
         ram2_wr_o <= ram2_we;
         wr_ack_d0 <= ram2_we;
       when others =>
-        wr_ack_d0 <= wr_req_int;
+        wr_ack_d0 <= wr_req;
       end case;
     when "001" =>
       -- Submap sub1_wb
-      sub1_wb_we <= wr_req_int;
+      sub1_wb_we <= wr_req;
       wr_ack_d0 <= sub1_wb_wack;
     when "010" =>
       -- Submap sub2_axi4
-      sub2_axi4_wr <= wr_req_int;
+      sub2_axi4_wr <= wr_req;
       wr_ack_d0 <= sub2_axi4_bvalid_i;
     when "011" =>
       -- Submap sub3_cernbe
-      sub3_cernbe_ws <= wr_req_int;
+      sub3_cernbe_ws <= wr_req;
       wr_ack_d0 <= sub3_cernbe_VMEWrDone_i;
     when "100" =>
       -- Submap sub4_avalon
-      sub4_avalon_we <= wr_req_int;
+      sub4_avalon_we <= wr_req;
       wr_ack_d0 <= sub4_avalon_wr and not sub4_avalon_waitrequest_i;
     when "101" =>
       -- Submap sub5_apb
-      sub5_apb_wr_req <= wr_req_int;
+      sub5_apb_wr_req <= wr_req;
       sub5_apb_wr_ack <= wr_ack_d0;
       wr_ack_d0 <= sub5_apb_wr and sub5_apb_pready_i;
     when others =>
-      wr_ack_d0 <= wr_req_int;
+      wr_ack_d0 <= wr_req;
     end case;
   end process;
 
@@ -549,8 +646,8 @@ begin
            ram2_rack, sub1_wb_dat_i, sub1_wb_rack, sub2_axi4_rdata_i,
            sub2_axi4_rvalid_i, sub3_cernbe_VMERdData_i,
            sub3_cernbe_VMERdDone_i, sub4_avalon_readdata_i,
-           sub4_avalon_readdatavalid_i, rd_ack_int, sub5_apb_prdata_i,
-           sub5_apb_rd, sub5_apb_pready_i, sub5_apb_pslverr_i) begin
+           sub4_avalon_readdatavalid_i, rd_ack, sub5_apb_prdata_i, sub5_apb_rd,
+           sub5_apb_pready_i, sub5_apb_pslverr_i) begin
     -- By default ack read requests
     readdata <= (others => 'X');
     ram1_val_rreq <= '0';
@@ -569,61 +666,61 @@ begin
         case rd_adr_d0(4 downto 2) is
         when "000" =>
           -- Reg reg1
-          rd_ack_int <= rd_req_d0;
+          rd_ack <= rd_req_d0;
           readdata <= reg1_reg;
         when "001" =>
           -- Reg reg2
-          rd_ack_int <= rd_req_d0;
+          rd_ack <= rd_req_d0;
           readdata <= reg2_reg;
         when others =>
-          rd_ack_int <= rd_req_d0;
+          rd_ack <= rd_req_d0;
         end case;
       when "0000001" =>
         -- Memory ram1
         readdata <= ram1_val_int_dato;
         ram1_val_rreq <= rd_req_d0;
-        rd_ack_int <= ram1_val_rack;
+        rd_ack <= ram1_val_rack;
       when "0000010" =>
         -- Memory ram_ro
         readdata <= ram_ro_val_int_dato;
         ram_ro_val_rreq <= rd_req_d0;
-        rd_ack_int <= ram_ro_val_rack;
+        rd_ack <= ram_ro_val_rack;
       when "0000011" =>
         -- Memory ram2
         readdata <= ram2_data_i;
-        rd_ack_int <= ram2_rack;
+        rd_ack <= ram2_rack;
         ram2_re <= rd_req_d0;
       when others =>
-        rd_ack_int <= rd_req_d0;
+        rd_ack <= rd_req_d0;
       end case;
     when "001" =>
       -- Submap sub1_wb
       sub1_wb_re <= rd_req_d0;
       readdata <= sub1_wb_dat_i;
-      rd_ack_int <= sub1_wb_rack;
+      rd_ack <= sub1_wb_rack;
     when "010" =>
       -- Submap sub2_axi4
       sub2_axi4_rd <= rd_req_d0;
       readdata <= sub2_axi4_rdata_i;
-      rd_ack_int <= sub2_axi4_rvalid_i;
+      rd_ack <= sub2_axi4_rvalid_i;
     when "011" =>
       -- Submap sub3_cernbe
       sub3_cernbe_VMERdMem_o <= rd_req_d0;
       readdata <= sub3_cernbe_VMERdData_i;
-      rd_ack_int <= sub3_cernbe_VMERdDone_i;
+      rd_ack <= sub3_cernbe_VMERdDone_i;
     when "100" =>
       -- Submap sub4_avalon
       sub4_avalon_re <= rd_req_d0;
       readdata <= sub4_avalon_readdata_i;
-      rd_ack_int <= sub4_avalon_readdatavalid_i;
+      rd_ack <= sub4_avalon_readdatavalid_i;
     when "101" =>
       -- Submap sub5_apb
       sub5_apb_rd_req <= rd_req_d0;
-      sub5_apb_rd_ack <= rd_ack_int;
+      sub5_apb_rd_ack <= rd_ack;
       readdata <= sub5_apb_prdata_i;
-      rd_ack_int <= sub5_apb_rd and sub5_apb_pready_i;
+      rd_ack <= sub5_apb_rd and sub5_apb_pready_i;
     when others =>
-      rd_ack_int <= rd_req_d0;
+      rd_ack <= rd_req_d0;
     end case;
   end process;
 end syn;

--- a/testfiles/tb/golden_files/all1_avalon_rd-in.vhdl
+++ b/testfiles/tb/golden_files/all1_avalon_rd-in.vhdl
@@ -104,13 +104,15 @@ end all1_avalon;
 
 architecture syn of all1_avalon is
   signal rst_n                          : std_logic;
-  signal rd_ack_int                     : std_logic;
-  signal wr_ack_int                     : std_logic;
-  signal rd_req_int                     : std_logic;
-  signal wr_req_int                     : std_logic;
+  signal rd_req                         : std_logic;
+  signal rd_ack                         : std_logic;
+  signal wr_req                         : std_logic;
+  signal wr_ack                         : std_logic;
+  signal wr_dat                         : std_logic_vector(31 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal wait_int                       : std_logic;
-  signal addr_int                       : std_logic_vector(14 downto 2);
-  signal dati_int                       : std_logic_vector(31 downto 0);
+  signal sel_int                        : std_logic_vector(31 downto 0);
+  signal adr                            : std_logic_vector(14 downto 2);
   signal reg1_reg                       : std_logic_vector(31 downto 0);
   signal reg1_wreq                      : std_logic;
   signal reg1_wack                      : std_logic;
@@ -157,6 +159,8 @@ architecture syn of all1_avalon is
   signal ram1_wr                        : std_logic;
   signal ram1_wreq                      : std_logic;
   signal ram1_adr_int                   : std_logic_vector(2 downto 0);
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
   signal ram2_wp                        : std_logic;
   signal ram2_we                        : std_logic;
   signal sub3_cernbe_ws                 : std_logic;
@@ -168,30 +172,37 @@ begin
       if rst_n = '0' then
         wait_int <= '0';
       else
-        wait_int <= (wait_int or (read or write)) and not (rd_ack_int or wr_ack_int);
+        wait_int <= (wait_int or (read or write)) and not (rd_ack or wr_ack);
       end if;
     end if;
+  end process;
+  process (byteenable) begin
+    sel_int(7 downto 0) <= (others => byteenable(0));
+    sel_int(15 downto 8) <= (others => byteenable(1));
+    sel_int(23 downto 16) <= (others => byteenable(2));
+    sel_int(31 downto 24) <= (others => byteenable(3));
   end process;
   process (clk) begin
     if rising_edge(clk) then
       if rst_n = '0' then
-        rd_req_int <= '0';
-        wr_req_int <= '0';
+        rd_req <= '0';
+        wr_req <= '0';
       else
         if ((read or write) and not wait_int) = '1' then
-          addr_int <= address;
+          adr <= address;
         else
         end if;
         if (write and not wait_int) = '1' then
-          dati_int <= writedata;
+          wr_sel <= sel_int;
+          wr_dat <= writedata;
         else
         end if;
-        rd_req_int <= read and not wait_int;
-        wr_req_int <= write and not wait_int;
+        rd_req <= read and not wait_int;
+        wr_req <= write and not wait_int;
       end if;
     end if;
   end process;
-  readdatavalid <= rd_ack_int;
+  readdatavalid <= rd_ack;
   waitrequest <= wait_int;
 
   -- pipelining for rd-in
@@ -200,8 +211,8 @@ begin
       if rst_n = '0' then
         rd_req_d0 <= '0';
       else
-        rd_req_d0 <= rd_req_int;
-        rd_adr_d0 <= addr_int;
+        rd_req_d0 <= rd_req;
+        rd_adr_d0 <= adr;
       end if;
     end if;
   end process;
@@ -215,7 +226,7 @@ begin
         reg1_wack <= '0';
       else
         if reg1_wreq = '1' then
-          reg1_reg <= dati_int;
+          reg1_reg <= wr_dat;
         end if;
         reg1_wack <= reg1_wreq;
       end if;
@@ -231,7 +242,7 @@ begin
         reg2_wack <= '0';
       else
         if reg2_wreq = '1' then
-          reg2_reg <= dati_int;
+          reg2_reg <= wr_dat;
         end if;
         reg2_wack <= reg2_wreq;
       end if;
@@ -239,9 +250,9 @@ begin
   end process;
 
   -- Memory ram1
-  process (rd_adr_d0, addr_int, ram1_wr) begin
+  process (rd_adr_d0, adr, ram1_wr) begin
     if ram1_wr = '1' then
-      ram1_adr_int <= addr_int(4 downto 2);
+      ram1_adr_int <= adr(4 downto 2);
     else
       ram1_adr_int <= rd_adr_d0(4 downto 2);
     end if;
@@ -254,14 +265,14 @@ begin
       g_size               => 8,
       g_addr_width         => 3,
       g_dual_clock         => '0',
-      g_use_bwsel          => '0'
+      g_use_bwsel          => '1'
     )
     port map (
       clk_a_i              => clk,
       clk_b_i              => clk,
       addr_a_i             => ram1_adr_int,
-      bwsel_a_i            => (others => '1'),
-      data_a_i             => dati_int,
+      bwsel_a_i            => ram1_sel_int,
+      data_a_i             => wr_dat,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
       wr_a_i               => ram1_val_int_wr,
@@ -273,6 +284,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk) begin
     if rising_edge(clk) then
       if rst_n = '0' then
@@ -290,13 +316,13 @@ begin
       g_size               => 8,
       g_addr_width         => 3,
       g_dual_clock         => '0',
-      g_use_bwsel          => '0'
+      g_use_bwsel          => '1'
     )
     port map (
       clk_a_i              => clk,
       clk_b_i              => clk,
       addr_a_i             => rd_adr_d0(4 downto 2),
-      bwsel_a_i            => (others => '1'),
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -309,6 +335,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk) begin
     if rising_edge(clk) then
       if rst_n = '0' then
@@ -329,22 +370,22 @@ begin
       end if;
     end if;
   end process;
-  ram2_data_o <= dati_int;
+  ram2_data_o <= wr_dat;
   process (clk) begin
     if rising_edge(clk) then
       if rst_n = '0' then
         ram2_wp <= '0';
       else
-        ram2_wp <= (wr_req_int or ram2_wp) and rd_req_d0;
+        ram2_wp <= (wr_req or ram2_wp) and rd_req_d0;
       end if;
     end if;
   end process;
-  ram2_we <= (wr_req_int or ram2_wp) and not rd_req_d0;
-  process (rd_adr_d0, addr_int, ram2_re) begin
+  ram2_we <= (wr_req or ram2_wp) and not rd_req_d0;
+  process (rd_adr_d0, adr, ram2_re) begin
     if ram2_re = '1' then
       ram2_addr_o <= rd_adr_d0(4 downto 2);
     else
-      ram2_addr_o <= addr_int(4 downto 2);
+      ram2_addr_o <= adr(4 downto 2);
     end if;
   end process;
 
@@ -366,17 +407,45 @@ begin
   sub1_wb_wack <= sub1_wb_ack_i and sub1_wb_wt;
   sub1_wb_rack <= sub1_wb_ack_i and sub1_wb_rt;
   sub1_wb_adr_o <= rd_adr_d0(11 downto 2);
-  sub1_wb_sel_o <= (others => '1');
+  process (wr_sel) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
-  sub1_wb_dat_o <= dati_int;
+  sub1_wb_dat_o <= wr_dat;
 
   -- Interface sub2_axi4
   sub2_axi4_awvalid_o <= sub2_axi4_aw_val;
-  sub2_axi4_awaddr_o <= addr_int(11 downto 2);
+  sub2_axi4_awaddr_o <= adr(11 downto 2);
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
-  sub2_axi4_wdata_o <= dati_int;
-  sub2_axi4_wstrb_o <= (others => '1');
+  sub2_axi4_wdata_o <= wr_dat;
+  process (wr_sel) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= rd_adr_d0(11 downto 2);
@@ -397,7 +466,7 @@ begin
   end process;
 
   -- Interface sub3_cernbe
-  sub3_cernbe_VMEWrData_o <= dati_int;
+  sub3_cernbe_VMEWrData_o <= wr_dat;
   process (clk) begin
     if rising_edge(clk) then
       if rst_n = '0' then
@@ -408,9 +477,9 @@ begin
     end if;
   end process;
   sub3_cernbe_VMEWrMem_o <= sub3_cernbe_ws;
-  process (rd_adr_d0, addr_int, sub3_cernbe_wt, sub3_cernbe_ws) begin
+  process (rd_adr_d0, adr, sub3_cernbe_wt, sub3_cernbe_ws) begin
     if (sub3_cernbe_ws or sub3_cernbe_wt) = '1' then
-      sub3_cernbe_VMEAddr_o <= addr_int(11 downto 2);
+      sub3_cernbe_VMEAddr_o <= adr(11 downto 2);
     else
       sub3_cernbe_VMEAddr_o <= rd_adr_d0(11 downto 2);
     end if;
@@ -429,10 +498,24 @@ begin
     end if;
   end process;
   sub4_avalon_address_o <= rd_adr_d0(11 downto 2);
-  sub4_avalon_byteenable_o <= (others => '1');
+  process (wr_sel) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
-  sub4_avalon_writedata_o <= dati_int;
+  sub4_avalon_writedata_o <= wr_dat;
 
   -- Interface sub5_apb
   process (clk) begin
@@ -457,22 +540,36 @@ begin
   sub5_apb_wr <= sub5_apb_wr_reg or sub5_apb_wr_req;
   sub5_apb_rd <= sub5_apb_rd_reg or sub5_apb_rd_req;
   sub5_apb_psel_o <= sub5_apb_wr or sub5_apb_rd;
-  sub5_apb_penable_o <= (not wr_req_int and sub5_apb_wr) or (not rd_req_d0 and sub5_apb_rd);
+  sub5_apb_penable_o <= (not wr_req and sub5_apb_wr) or (not rd_req_d0 and sub5_apb_rd);
   sub5_apb_pwrite_o <= sub5_apb_wr;
-  process (sub5_apb_wr, addr_int, rd_adr_d0) begin
+  process (sub5_apb_wr, adr, rd_adr_d0) begin
     if sub5_apb_wr = '1' then
-      sub5_apb_paddr_o <= addr_int(11 downto 2);
+      sub5_apb_paddr_o <= adr(11 downto 2);
     else
       sub5_apb_paddr_o <= rd_adr_d0(11 downto 2);
     end if;
   end process;
-  sub5_apb_pwdata_o <= dati_int;
-  sub5_apb_pstrb_o <= (others => '1');
+  sub5_apb_pwdata_o <= wr_dat;
+  process (wr_sel) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
-  process (addr_int, wr_req_int, reg1_wack, reg2_wack, ram2_we, sub1_wb_wack,
+  process (adr, wr_req, reg1_wack, reg2_wack, ram2_we, sub1_wb_wack,
            sub2_axi4_bvalid_i, sub3_cernbe_VMEWrDone_i, sub4_avalon_wr,
-           sub4_avalon_waitrequest_i, wr_ack_int, sub5_apb_wr, sub5_apb_pready_i,
+           sub4_avalon_waitrequest_i, wr_ack, sub5_apb_wr, sub5_apb_pready_i,
            sub5_apb_pslverr_i) begin
     reg1_wreq <= '0';
     reg2_wreq <= '0';
@@ -484,59 +581,59 @@ begin
     sub4_avalon_we <= '0';
     sub5_apb_wr_req <= '0';
     sub5_apb_wr_ack <= '0';
-    case addr_int(14 downto 12) is
+    case adr(14 downto 12) is
     when "000" =>
-      case addr_int(11 downto 5) is
+      case adr(11 downto 5) is
       when "0000000" =>
-        case addr_int(4 downto 2) is
+        case adr(4 downto 2) is
         when "000" =>
           -- Reg reg1
-          reg1_wreq <= wr_req_int;
-          wr_ack_int <= reg1_wack;
+          reg1_wreq <= wr_req;
+          wr_ack <= reg1_wack;
         when "001" =>
           -- Reg reg2
-          reg2_wreq <= wr_req_int;
-          wr_ack_int <= reg2_wack;
+          reg2_wreq <= wr_req;
+          wr_ack <= reg2_wack;
         when others =>
-          wr_ack_int <= wr_req_int;
+          wr_ack <= wr_req;
         end case;
       when "0000001" =>
         -- Memory ram1
-        ram1_val_int_wr <= wr_req_int;
-        wr_ack_int <= wr_req_int;
+        ram1_val_int_wr <= wr_req;
+        wr_ack <= wr_req;
       when "0000010" =>
         -- Memory ram_ro
-        wr_ack_int <= wr_req_int;
+        wr_ack <= wr_req;
       when "0000011" =>
         -- Memory ram2
         ram2_wr_o <= ram2_we;
-        wr_ack_int <= ram2_we;
+        wr_ack <= ram2_we;
       when others =>
-        wr_ack_int <= wr_req_int;
+        wr_ack <= wr_req;
       end case;
     when "001" =>
       -- Submap sub1_wb
-      sub1_wb_we <= wr_req_int;
-      wr_ack_int <= sub1_wb_wack;
+      sub1_wb_we <= wr_req;
+      wr_ack <= sub1_wb_wack;
     when "010" =>
       -- Submap sub2_axi4
-      sub2_axi4_wr <= wr_req_int;
-      wr_ack_int <= sub2_axi4_bvalid_i;
+      sub2_axi4_wr <= wr_req;
+      wr_ack <= sub2_axi4_bvalid_i;
     when "011" =>
       -- Submap sub3_cernbe
-      sub3_cernbe_ws <= wr_req_int;
-      wr_ack_int <= sub3_cernbe_VMEWrDone_i;
+      sub3_cernbe_ws <= wr_req;
+      wr_ack <= sub3_cernbe_VMEWrDone_i;
     when "100" =>
       -- Submap sub4_avalon
-      sub4_avalon_we <= wr_req_int;
-      wr_ack_int <= sub4_avalon_wr and not sub4_avalon_waitrequest_i;
+      sub4_avalon_we <= wr_req;
+      wr_ack <= sub4_avalon_wr and not sub4_avalon_waitrequest_i;
     when "101" =>
       -- Submap sub5_apb
-      sub5_apb_wr_req <= wr_req_int;
-      sub5_apb_wr_ack <= wr_ack_int;
-      wr_ack_int <= sub5_apb_wr and sub5_apb_pready_i;
+      sub5_apb_wr_req <= wr_req;
+      sub5_apb_wr_ack <= wr_ack;
+      wr_ack <= sub5_apb_wr and sub5_apb_pready_i;
     when others =>
-      wr_ack_int <= wr_req_int;
+      wr_ack <= wr_req;
     end case;
   end process;
 
@@ -546,8 +643,8 @@ begin
            ram2_rack, sub1_wb_dat_i, sub1_wb_rack, sub2_axi4_rdata_i,
            sub2_axi4_rvalid_i, sub3_cernbe_VMERdData_i,
            sub3_cernbe_VMERdDone_i, sub4_avalon_readdata_i,
-           sub4_avalon_readdatavalid_i, rd_ack_int, sub5_apb_prdata_i,
-           sub5_apb_rd, sub5_apb_pready_i, sub5_apb_pslverr_i) begin
+           sub4_avalon_readdatavalid_i, rd_ack, sub5_apb_prdata_i, sub5_apb_rd,
+           sub5_apb_pready_i, sub5_apb_pslverr_i) begin
     -- By default ack read requests
     readdata <= (others => 'X');
     ram1_val_rreq <= '0';
@@ -566,61 +663,61 @@ begin
         case rd_adr_d0(4 downto 2) is
         when "000" =>
           -- Reg reg1
-          rd_ack_int <= rd_req_d0;
+          rd_ack <= rd_req_d0;
           readdata <= reg1_reg;
         when "001" =>
           -- Reg reg2
-          rd_ack_int <= rd_req_d0;
+          rd_ack <= rd_req_d0;
           readdata <= reg2_reg;
         when others =>
-          rd_ack_int <= rd_req_d0;
+          rd_ack <= rd_req_d0;
         end case;
       when "0000001" =>
         -- Memory ram1
         readdata <= ram1_val_int_dato;
         ram1_val_rreq <= rd_req_d0;
-        rd_ack_int <= ram1_val_rack;
+        rd_ack <= ram1_val_rack;
       when "0000010" =>
         -- Memory ram_ro
         readdata <= ram_ro_val_int_dato;
         ram_ro_val_rreq <= rd_req_d0;
-        rd_ack_int <= ram_ro_val_rack;
+        rd_ack <= ram_ro_val_rack;
       when "0000011" =>
         -- Memory ram2
         readdata <= ram2_data_i;
-        rd_ack_int <= ram2_rack;
+        rd_ack <= ram2_rack;
         ram2_re <= rd_req_d0;
       when others =>
-        rd_ack_int <= rd_req_d0;
+        rd_ack <= rd_req_d0;
       end case;
     when "001" =>
       -- Submap sub1_wb
       sub1_wb_re <= rd_req_d0;
       readdata <= sub1_wb_dat_i;
-      rd_ack_int <= sub1_wb_rack;
+      rd_ack <= sub1_wb_rack;
     when "010" =>
       -- Submap sub2_axi4
       sub2_axi4_rd <= rd_req_d0;
       readdata <= sub2_axi4_rdata_i;
-      rd_ack_int <= sub2_axi4_rvalid_i;
+      rd_ack <= sub2_axi4_rvalid_i;
     when "011" =>
       -- Submap sub3_cernbe
       sub3_cernbe_VMERdMem_o <= rd_req_d0;
       readdata <= sub3_cernbe_VMERdData_i;
-      rd_ack_int <= sub3_cernbe_VMERdDone_i;
+      rd_ack <= sub3_cernbe_VMERdDone_i;
     when "100" =>
       -- Submap sub4_avalon
       sub4_avalon_re <= rd_req_d0;
       readdata <= sub4_avalon_readdata_i;
-      rd_ack_int <= sub4_avalon_readdatavalid_i;
+      rd_ack <= sub4_avalon_readdatavalid_i;
     when "101" =>
       -- Submap sub5_apb
       sub5_apb_rd_req <= rd_req_d0;
-      sub5_apb_rd_ack <= rd_ack_int;
+      sub5_apb_rd_ack <= rd_ack;
       readdata <= sub5_apb_prdata_i;
-      rd_ack_int <= sub5_apb_rd and sub5_apb_pready_i;
+      rd_ack <= sub5_apb_rd and sub5_apb_pready_i;
     when others =>
-      rd_ack_int <= rd_req_d0;
+      rd_ack <= rd_req_d0;
     end case;
   end process;
 end syn;

--- a/testfiles/tb/golden_files/all1_avalon_rd-out.vhdl
+++ b/testfiles/tb/golden_files/all1_avalon_rd-out.vhdl
@@ -104,13 +104,15 @@ end all1_avalon;
 
 architecture syn of all1_avalon is
   signal rst_n                          : std_logic;
-  signal rd_ack_int                     : std_logic;
-  signal wr_ack_int                     : std_logic;
-  signal rd_req_int                     : std_logic;
-  signal wr_req_int                     : std_logic;
+  signal rd_req                         : std_logic;
+  signal rd_ack                         : std_logic;
+  signal wr_req                         : std_logic;
+  signal wr_ack                         : std_logic;
+  signal wr_dat                         : std_logic_vector(31 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal wait_int                       : std_logic;
-  signal addr_int                       : std_logic_vector(14 downto 2);
-  signal dati_int                       : std_logic_vector(31 downto 0);
+  signal sel_int                        : std_logic_vector(31 downto 0);
+  signal adr                            : std_logic_vector(14 downto 2);
   signal reg1_reg                       : std_logic_vector(31 downto 0);
   signal reg1_wreq                      : std_logic;
   signal reg1_wack                      : std_logic;
@@ -154,6 +156,8 @@ architecture syn of all1_avalon is
   signal sub5_apb_rd_reg                : std_logic;
   signal rd_ack_d0                      : std_logic;
   signal rd_dat_d0                      : std_logic_vector(31 downto 0);
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
 begin
   rst_n <= not reset;
   process (clk) begin
@@ -161,39 +165,46 @@ begin
       if rst_n = '0' then
         wait_int <= '0';
       else
-        wait_int <= (wait_int or (read or write)) and not (rd_ack_int or wr_ack_int);
+        wait_int <= (wait_int or (read or write)) and not (rd_ack or wr_ack);
       end if;
     end if;
+  end process;
+  process (byteenable) begin
+    sel_int(7 downto 0) <= (others => byteenable(0));
+    sel_int(15 downto 8) <= (others => byteenable(1));
+    sel_int(23 downto 16) <= (others => byteenable(2));
+    sel_int(31 downto 24) <= (others => byteenable(3));
   end process;
   process (clk) begin
     if rising_edge(clk) then
       if rst_n = '0' then
-        rd_req_int <= '0';
-        wr_req_int <= '0';
+        rd_req <= '0';
+        wr_req <= '0';
       else
         if ((read or write) and not wait_int) = '1' then
-          addr_int <= address;
+          adr <= address;
         else
         end if;
         if (write and not wait_int) = '1' then
-          dati_int <= writedata;
+          wr_sel <= sel_int;
+          wr_dat <= writedata;
         else
         end if;
-        rd_req_int <= read and not wait_int;
-        wr_req_int <= write and not wait_int;
+        rd_req <= read and not wait_int;
+        wr_req <= write and not wait_int;
       end if;
     end if;
   end process;
-  readdatavalid <= rd_ack_int;
+  readdatavalid <= rd_ack;
   waitrequest <= wait_int;
 
   -- pipelining for rd-out
   process (clk) begin
     if rising_edge(clk) then
       if rst_n = '0' then
-        rd_ack_int <= '0';
+        rd_ack <= '0';
       else
-        rd_ack_int <= rd_ack_d0;
+        rd_ack <= rd_ack_d0;
         readdata <= rd_dat_d0;
       end if;
     end if;
@@ -208,7 +219,7 @@ begin
         reg1_wack <= '0';
       else
         if reg1_wreq = '1' then
-          reg1_reg <= dati_int;
+          reg1_reg <= wr_dat;
         end if;
         reg1_wack <= reg1_wreq;
       end if;
@@ -224,7 +235,7 @@ begin
         reg2_wack <= '0';
       else
         if reg2_wreq = '1' then
-          reg2_reg <= dati_int;
+          reg2_reg <= wr_dat;
         end if;
         reg2_wack <= reg2_wreq;
       end if;
@@ -238,14 +249,14 @@ begin
       g_size               => 8,
       g_addr_width         => 3,
       g_dual_clock         => '0',
-      g_use_bwsel          => '0'
+      g_use_bwsel          => '1'
     )
     port map (
       clk_a_i              => clk,
       clk_b_i              => clk,
-      addr_a_i             => addr_int(4 downto 2),
-      bwsel_a_i            => (others => '1'),
-      data_a_i             => dati_int,
+      addr_a_i             => adr(4 downto 2),
+      bwsel_a_i            => ram1_sel_int,
+      data_a_i             => wr_dat,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
       wr_a_i               => ram1_val_int_wr,
@@ -257,6 +268,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk) begin
     if rising_edge(clk) then
       if rst_n = '0' then
@@ -274,13 +300,13 @@ begin
       g_size               => 8,
       g_addr_width         => 3,
       g_dual_clock         => '0',
-      g_use_bwsel          => '0'
+      g_use_bwsel          => '1'
     )
     port map (
       clk_a_i              => clk,
       clk_b_i              => clk,
-      addr_a_i             => addr_int(4 downto 2),
-      bwsel_a_i            => (others => '1'),
+      addr_a_i             => adr(4 downto 2),
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -293,6 +319,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk) begin
     if rising_edge(clk) then
       if rst_n = '0' then
@@ -313,8 +354,8 @@ begin
       end if;
     end if;
   end process;
-  ram2_data_o <= dati_int;
-  ram2_addr_o <= addr_int(4 downto 2);
+  ram2_data_o <= wr_dat;
+  ram2_addr_o <= adr(4 downto 2);
 
   -- Interface sub1_wb
   sub1_wb_tr <= sub1_wb_wt or sub1_wb_rt;
@@ -333,21 +374,49 @@ begin
   sub1_wb_stb_o <= sub1_wb_tr;
   sub1_wb_wack <= sub1_wb_ack_i and sub1_wb_wt;
   sub1_wb_rack <= sub1_wb_ack_i and sub1_wb_rt;
-  sub1_wb_adr_o <= addr_int(11 downto 2);
-  sub1_wb_sel_o <= (others => '1');
+  sub1_wb_adr_o <= adr(11 downto 2);
+  process (wr_sel) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
-  sub1_wb_dat_o <= dati_int;
+  sub1_wb_dat_o <= wr_dat;
 
   -- Interface sub2_axi4
   sub2_axi4_awvalid_o <= sub2_axi4_aw_val;
-  sub2_axi4_awaddr_o <= addr_int(11 downto 2);
+  sub2_axi4_awaddr_o <= adr(11 downto 2);
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
-  sub2_axi4_wdata_o <= dati_int;
-  sub2_axi4_wstrb_o <= (others => '1');
+  sub2_axi4_wdata_o <= wr_dat;
+  process (wr_sel) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
-  sub2_axi4_araddr_o <= addr_int(11 downto 2);
+  sub2_axi4_araddr_o <= adr(11 downto 2);
   sub2_axi4_arprot_o <= "000";
   sub2_axi4_rready_o <= '1';
   process (clk) begin
@@ -365,8 +434,8 @@ begin
   end process;
 
   -- Interface sub3_cernbe
-  sub3_cernbe_VMEWrData_o <= dati_int;
-  sub3_cernbe_VMEAddr_o <= addr_int(11 downto 2);
+  sub3_cernbe_VMEWrData_o <= wr_dat;
+  sub3_cernbe_VMEAddr_o <= adr(11 downto 2);
 
   -- Interface sub4_avalon
   process (clk) begin
@@ -380,11 +449,25 @@ begin
       end if;
     end if;
   end process;
-  sub4_avalon_address_o <= addr_int(11 downto 2);
-  sub4_avalon_byteenable_o <= (others => '1');
+  sub4_avalon_address_o <= adr(11 downto 2);
+  process (wr_sel) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
-  sub4_avalon_writedata_o <= dati_int;
+  sub4_avalon_writedata_o <= wr_dat;
 
   -- Interface sub5_apb
   process (clk) begin
@@ -409,23 +492,36 @@ begin
   sub5_apb_wr <= sub5_apb_wr_reg or sub5_apb_wr_req;
   sub5_apb_rd <= sub5_apb_rd_reg or sub5_apb_rd_req;
   sub5_apb_psel_o <= sub5_apb_wr or sub5_apb_rd;
-  sub5_apb_penable_o <= (not wr_req_int and sub5_apb_wr) or (not rd_req_int and sub5_apb_rd);
+  sub5_apb_penable_o <= (not wr_req and sub5_apb_wr) or (not rd_req and sub5_apb_rd);
   sub5_apb_pwrite_o <= sub5_apb_wr;
-  process (sub5_apb_wr, addr_int, addr_int) begin
+  process (sub5_apb_wr, adr, adr) begin
     if sub5_apb_wr = '1' then
-      sub5_apb_paddr_o <= addr_int(11 downto 2);
+      sub5_apb_paddr_o <= adr(11 downto 2);
     else
-      sub5_apb_paddr_o <= addr_int(11 downto 2);
+      sub5_apb_paddr_o <= adr(11 downto 2);
     end if;
   end process;
-  sub5_apb_pwdata_o <= dati_int;
-  sub5_apb_pstrb_o <= (others => '1');
+  sub5_apb_pwdata_o <= wr_dat;
+  process (wr_sel) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
-  process (addr_int, wr_req_int, reg1_wack, reg2_wack, sub1_wb_wack,
-           sub2_axi4_bvalid_i, sub3_cernbe_VMEWrDone_i, sub4_avalon_wr,
-           sub4_avalon_waitrequest_i, wr_ack_int, sub5_apb_wr, sub5_apb_pready_i,
-           sub5_apb_pslverr_i) begin
+  process (adr, wr_req, reg1_wack, reg2_wack, sub1_wb_wack, sub2_axi4_bvalid_i,
+           sub3_cernbe_VMEWrDone_i, sub4_avalon_wr, sub4_avalon_waitrequest_i,
+           wr_ack, sub5_apb_wr, sub5_apb_pready_i, sub5_apb_pslverr_i) begin
     reg1_wreq <= '0';
     reg2_wreq <= '0';
     ram1_val_int_wr <= '0';
@@ -436,70 +532,69 @@ begin
     sub4_avalon_we <= '0';
     sub5_apb_wr_req <= '0';
     sub5_apb_wr_ack <= '0';
-    case addr_int(14 downto 12) is
+    case adr(14 downto 12) is
     when "000" =>
-      case addr_int(11 downto 5) is
+      case adr(11 downto 5) is
       when "0000000" =>
-        case addr_int(4 downto 2) is
+        case adr(4 downto 2) is
         when "000" =>
           -- Reg reg1
-          reg1_wreq <= wr_req_int;
-          wr_ack_int <= reg1_wack;
+          reg1_wreq <= wr_req;
+          wr_ack <= reg1_wack;
         when "001" =>
           -- Reg reg2
-          reg2_wreq <= wr_req_int;
-          wr_ack_int <= reg2_wack;
+          reg2_wreq <= wr_req;
+          wr_ack <= reg2_wack;
         when others =>
-          wr_ack_int <= wr_req_int;
+          wr_ack <= wr_req;
         end case;
       when "0000001" =>
         -- Memory ram1
-        ram1_val_int_wr <= wr_req_int;
-        wr_ack_int <= wr_req_int;
+        ram1_val_int_wr <= wr_req;
+        wr_ack <= wr_req;
       when "0000010" =>
         -- Memory ram_ro
-        wr_ack_int <= wr_req_int;
+        wr_ack <= wr_req;
       when "0000011" =>
         -- Memory ram2
-        ram2_wr_o <= wr_req_int;
-        wr_ack_int <= wr_req_int;
+        ram2_wr_o <= wr_req;
+        wr_ack <= wr_req;
       when others =>
-        wr_ack_int <= wr_req_int;
+        wr_ack <= wr_req;
       end case;
     when "001" =>
       -- Submap sub1_wb
-      sub1_wb_we <= wr_req_int;
-      wr_ack_int <= sub1_wb_wack;
+      sub1_wb_we <= wr_req;
+      wr_ack <= sub1_wb_wack;
     when "010" =>
       -- Submap sub2_axi4
-      sub2_axi4_wr <= wr_req_int;
-      wr_ack_int <= sub2_axi4_bvalid_i;
+      sub2_axi4_wr <= wr_req;
+      wr_ack <= sub2_axi4_bvalid_i;
     when "011" =>
       -- Submap sub3_cernbe
-      sub3_cernbe_VMEWrMem_o <= wr_req_int;
-      wr_ack_int <= sub3_cernbe_VMEWrDone_i;
+      sub3_cernbe_VMEWrMem_o <= wr_req;
+      wr_ack <= sub3_cernbe_VMEWrDone_i;
     when "100" =>
       -- Submap sub4_avalon
-      sub4_avalon_we <= wr_req_int;
-      wr_ack_int <= sub4_avalon_wr and not sub4_avalon_waitrequest_i;
+      sub4_avalon_we <= wr_req;
+      wr_ack <= sub4_avalon_wr and not sub4_avalon_waitrequest_i;
     when "101" =>
       -- Submap sub5_apb
-      sub5_apb_wr_req <= wr_req_int;
-      sub5_apb_wr_ack <= wr_ack_int;
-      wr_ack_int <= sub5_apb_wr and sub5_apb_pready_i;
+      sub5_apb_wr_req <= wr_req;
+      sub5_apb_wr_ack <= wr_ack;
+      wr_ack <= sub5_apb_wr and sub5_apb_pready_i;
     when others =>
-      wr_ack_int <= wr_req_int;
+      wr_ack <= wr_req;
     end case;
   end process;
 
   -- Process for read requests.
-  process (addr_int, rd_req_int, reg1_reg, reg2_reg, ram1_val_int_dato,
-           ram1_val_rack, ram_ro_val_int_dato, ram_ro_val_rack, ram2_data_i,
-           ram2_rack, sub1_wb_dat_i, sub1_wb_rack, sub2_axi4_rdata_i,
-           sub2_axi4_rvalid_i, sub3_cernbe_VMERdData_i,
-           sub3_cernbe_VMERdDone_i, sub4_avalon_readdata_i,
-           sub4_avalon_readdatavalid_i, rd_ack_d0, sub5_apb_prdata_i,
-           sub5_apb_rd, sub5_apb_pready_i, sub5_apb_pslverr_i) begin
+  process (adr, rd_req, reg1_reg, reg2_reg, ram1_val_int_dato, ram1_val_rack,
+           ram_ro_val_int_dato, ram_ro_val_rack, ram2_data_i, ram2_rack,
+           sub1_wb_dat_i, sub1_wb_rack, sub2_axi4_rdata_i, sub2_axi4_rvalid_i,
+           sub3_cernbe_VMERdData_i, sub3_cernbe_VMERdDone_i,
+           sub4_avalon_readdata_i, sub4_avalon_readdatavalid_i, rd_ack_d0,
+           sub5_apb_prdata_i, sub5_apb_rd, sub5_apb_pready_i, sub5_apb_pslverr_i) begin
     -- By default ack read requests
     rd_dat_d0 <= (others => 'X');
     ram1_val_rreq <= '0';
@@ -511,68 +606,68 @@ begin
     sub4_avalon_re <= '0';
     sub5_apb_rd_req <= '0';
     sub5_apb_rd_ack <= '0';
-    case addr_int(14 downto 12) is
+    case adr(14 downto 12) is
     when "000" =>
-      case addr_int(11 downto 5) is
+      case adr(11 downto 5) is
       when "0000000" =>
-        case addr_int(4 downto 2) is
+        case adr(4 downto 2) is
         when "000" =>
           -- Reg reg1
-          rd_ack_d0 <= rd_req_int;
+          rd_ack_d0 <= rd_req;
           rd_dat_d0 <= reg1_reg;
         when "001" =>
           -- Reg reg2
-          rd_ack_d0 <= rd_req_int;
+          rd_ack_d0 <= rd_req;
           rd_dat_d0 <= reg2_reg;
         when others =>
-          rd_ack_d0 <= rd_req_int;
+          rd_ack_d0 <= rd_req;
         end case;
       when "0000001" =>
         -- Memory ram1
         rd_dat_d0 <= ram1_val_int_dato;
-        ram1_val_rreq <= rd_req_int;
+        ram1_val_rreq <= rd_req;
         rd_ack_d0 <= ram1_val_rack;
       when "0000010" =>
         -- Memory ram_ro
         rd_dat_d0 <= ram_ro_val_int_dato;
-        ram_ro_val_rreq <= rd_req_int;
+        ram_ro_val_rreq <= rd_req;
         rd_ack_d0 <= ram_ro_val_rack;
       when "0000011" =>
         -- Memory ram2
         rd_dat_d0 <= ram2_data_i;
         rd_ack_d0 <= ram2_rack;
-        ram2_re <= rd_req_int;
+        ram2_re <= rd_req;
       when others =>
-        rd_ack_d0 <= rd_req_int;
+        rd_ack_d0 <= rd_req;
       end case;
     when "001" =>
       -- Submap sub1_wb
-      sub1_wb_re <= rd_req_int;
+      sub1_wb_re <= rd_req;
       rd_dat_d0 <= sub1_wb_dat_i;
       rd_ack_d0 <= sub1_wb_rack;
     when "010" =>
       -- Submap sub2_axi4
-      sub2_axi4_rd <= rd_req_int;
+      sub2_axi4_rd <= rd_req;
       rd_dat_d0 <= sub2_axi4_rdata_i;
       rd_ack_d0 <= sub2_axi4_rvalid_i;
     when "011" =>
       -- Submap sub3_cernbe
-      sub3_cernbe_VMERdMem_o <= rd_req_int;
+      sub3_cernbe_VMERdMem_o <= rd_req;
       rd_dat_d0 <= sub3_cernbe_VMERdData_i;
       rd_ack_d0 <= sub3_cernbe_VMERdDone_i;
     when "100" =>
       -- Submap sub4_avalon
-      sub4_avalon_re <= rd_req_int;
+      sub4_avalon_re <= rd_req;
       rd_dat_d0 <= sub4_avalon_readdata_i;
       rd_ack_d0 <= sub4_avalon_readdatavalid_i;
     when "101" =>
       -- Submap sub5_apb
-      sub5_apb_rd_req <= rd_req_int;
+      sub5_apb_rd_req <= rd_req;
       sub5_apb_rd_ack <= rd_ack_d0;
       rd_dat_d0 <= sub5_apb_prdata_i;
       rd_ack_d0 <= sub5_apb_rd and sub5_apb_pready_i;
     when others =>
-      rd_ack_d0 <= rd_req_int;
+      rd_ack_d0 <= rd_req;
     end case;
   end process;
 end syn;

--- a/testfiles/tb/golden_files/all1_avalon_rd.vhdl
+++ b/testfiles/tb/golden_files/all1_avalon_rd.vhdl
@@ -104,13 +104,15 @@ end all1_avalon;
 
 architecture syn of all1_avalon is
   signal rst_n                          : std_logic;
-  signal rd_ack_int                     : std_logic;
-  signal wr_ack_int                     : std_logic;
-  signal rd_req_int                     : std_logic;
-  signal wr_req_int                     : std_logic;
+  signal rd_req                         : std_logic;
+  signal rd_ack                         : std_logic;
+  signal wr_req                         : std_logic;
+  signal wr_ack                         : std_logic;
+  signal wr_dat                         : std_logic_vector(31 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal wait_int                       : std_logic;
-  signal addr_int                       : std_logic_vector(14 downto 2);
-  signal dati_int                       : std_logic_vector(31 downto 0);
+  signal sel_int                        : std_logic_vector(31 downto 0);
+  signal adr                            : std_logic_vector(14 downto 2);
   signal reg1_reg                       : std_logic_vector(31 downto 0);
   signal reg1_wreq                      : std_logic;
   signal reg1_wack                      : std_logic;
@@ -159,6 +161,8 @@ architecture syn of all1_avalon is
   signal ram1_wr                        : std_logic;
   signal ram1_wreq                      : std_logic;
   signal ram1_adr_int                   : std_logic_vector(2 downto 0);
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
   signal ram2_wp                        : std_logic;
   signal ram2_we                        : std_logic;
   signal sub3_cernbe_ws                 : std_logic;
@@ -170,30 +174,37 @@ begin
       if rst_n = '0' then
         wait_int <= '0';
       else
-        wait_int <= (wait_int or (read or write)) and not (rd_ack_int or wr_ack_int);
+        wait_int <= (wait_int or (read or write)) and not (rd_ack or wr_ack);
       end if;
     end if;
+  end process;
+  process (byteenable) begin
+    sel_int(7 downto 0) <= (others => byteenable(0));
+    sel_int(15 downto 8) <= (others => byteenable(1));
+    sel_int(23 downto 16) <= (others => byteenable(2));
+    sel_int(31 downto 24) <= (others => byteenable(3));
   end process;
   process (clk) begin
     if rising_edge(clk) then
       if rst_n = '0' then
-        rd_req_int <= '0';
-        wr_req_int <= '0';
+        rd_req <= '0';
+        wr_req <= '0';
       else
         if ((read or write) and not wait_int) = '1' then
-          addr_int <= address;
+          adr <= address;
         else
         end if;
         if (write and not wait_int) = '1' then
-          dati_int <= writedata;
+          wr_sel <= sel_int;
+          wr_dat <= writedata;
         else
         end if;
-        rd_req_int <= read and not wait_int;
-        wr_req_int <= write and not wait_int;
+        rd_req <= read and not wait_int;
+        wr_req <= write and not wait_int;
       end if;
     end if;
   end process;
-  readdatavalid <= rd_ack_int;
+  readdatavalid <= rd_ack;
   waitrequest <= wait_int;
 
   -- pipelining for rd-in+rd-out
@@ -201,11 +212,11 @@ begin
     if rising_edge(clk) then
       if rst_n = '0' then
         rd_req_d0 <= '0';
-        rd_ack_int <= '0';
+        rd_ack <= '0';
       else
-        rd_req_d0 <= rd_req_int;
-        rd_adr_d0 <= addr_int;
-        rd_ack_int <= rd_ack_d0;
+        rd_req_d0 <= rd_req;
+        rd_adr_d0 <= adr;
+        rd_ack <= rd_ack_d0;
         readdata <= rd_dat_d0;
       end if;
     end if;
@@ -220,7 +231,7 @@ begin
         reg1_wack <= '0';
       else
         if reg1_wreq = '1' then
-          reg1_reg <= dati_int;
+          reg1_reg <= wr_dat;
         end if;
         reg1_wack <= reg1_wreq;
       end if;
@@ -236,7 +247,7 @@ begin
         reg2_wack <= '0';
       else
         if reg2_wreq = '1' then
-          reg2_reg <= dati_int;
+          reg2_reg <= wr_dat;
         end if;
         reg2_wack <= reg2_wreq;
       end if;
@@ -244,9 +255,9 @@ begin
   end process;
 
   -- Memory ram1
-  process (rd_adr_d0, addr_int, ram1_wr) begin
+  process (rd_adr_d0, adr, ram1_wr) begin
     if ram1_wr = '1' then
-      ram1_adr_int <= addr_int(4 downto 2);
+      ram1_adr_int <= adr(4 downto 2);
     else
       ram1_adr_int <= rd_adr_d0(4 downto 2);
     end if;
@@ -259,14 +270,14 @@ begin
       g_size               => 8,
       g_addr_width         => 3,
       g_dual_clock         => '0',
-      g_use_bwsel          => '0'
+      g_use_bwsel          => '1'
     )
     port map (
       clk_a_i              => clk,
       clk_b_i              => clk,
       addr_a_i             => ram1_adr_int,
-      bwsel_a_i            => (others => '1'),
-      data_a_i             => dati_int,
+      bwsel_a_i            => ram1_sel_int,
+      data_a_i             => wr_dat,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
       wr_a_i               => ram1_val_int_wr,
@@ -278,6 +289,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk) begin
     if rising_edge(clk) then
       if rst_n = '0' then
@@ -295,13 +321,13 @@ begin
       g_size               => 8,
       g_addr_width         => 3,
       g_dual_clock         => '0',
-      g_use_bwsel          => '0'
+      g_use_bwsel          => '1'
     )
     port map (
       clk_a_i              => clk,
       clk_b_i              => clk,
       addr_a_i             => rd_adr_d0(4 downto 2),
-      bwsel_a_i            => (others => '1'),
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -314,6 +340,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk) begin
     if rising_edge(clk) then
       if rst_n = '0' then
@@ -334,22 +375,22 @@ begin
       end if;
     end if;
   end process;
-  ram2_data_o <= dati_int;
+  ram2_data_o <= wr_dat;
   process (clk) begin
     if rising_edge(clk) then
       if rst_n = '0' then
         ram2_wp <= '0';
       else
-        ram2_wp <= (wr_req_int or ram2_wp) and rd_req_d0;
+        ram2_wp <= (wr_req or ram2_wp) and rd_req_d0;
       end if;
     end if;
   end process;
-  ram2_we <= (wr_req_int or ram2_wp) and not rd_req_d0;
-  process (rd_adr_d0, addr_int, ram2_re) begin
+  ram2_we <= (wr_req or ram2_wp) and not rd_req_d0;
+  process (rd_adr_d0, adr, ram2_re) begin
     if ram2_re = '1' then
       ram2_addr_o <= rd_adr_d0(4 downto 2);
     else
-      ram2_addr_o <= addr_int(4 downto 2);
+      ram2_addr_o <= adr(4 downto 2);
     end if;
   end process;
 
@@ -371,17 +412,45 @@ begin
   sub1_wb_wack <= sub1_wb_ack_i and sub1_wb_wt;
   sub1_wb_rack <= sub1_wb_ack_i and sub1_wb_rt;
   sub1_wb_adr_o <= rd_adr_d0(11 downto 2);
-  sub1_wb_sel_o <= (others => '1');
+  process (wr_sel) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
-  sub1_wb_dat_o <= dati_int;
+  sub1_wb_dat_o <= wr_dat;
 
   -- Interface sub2_axi4
   sub2_axi4_awvalid_o <= sub2_axi4_aw_val;
-  sub2_axi4_awaddr_o <= addr_int(11 downto 2);
+  sub2_axi4_awaddr_o <= adr(11 downto 2);
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
-  sub2_axi4_wdata_o <= dati_int;
-  sub2_axi4_wstrb_o <= (others => '1');
+  sub2_axi4_wdata_o <= wr_dat;
+  process (wr_sel) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= rd_adr_d0(11 downto 2);
@@ -402,7 +471,7 @@ begin
   end process;
 
   -- Interface sub3_cernbe
-  sub3_cernbe_VMEWrData_o <= dati_int;
+  sub3_cernbe_VMEWrData_o <= wr_dat;
   process (clk) begin
     if rising_edge(clk) then
       if rst_n = '0' then
@@ -413,9 +482,9 @@ begin
     end if;
   end process;
   sub3_cernbe_VMEWrMem_o <= sub3_cernbe_ws;
-  process (rd_adr_d0, addr_int, sub3_cernbe_wt, sub3_cernbe_ws) begin
+  process (rd_adr_d0, adr, sub3_cernbe_wt, sub3_cernbe_ws) begin
     if (sub3_cernbe_ws or sub3_cernbe_wt) = '1' then
-      sub3_cernbe_VMEAddr_o <= addr_int(11 downto 2);
+      sub3_cernbe_VMEAddr_o <= adr(11 downto 2);
     else
       sub3_cernbe_VMEAddr_o <= rd_adr_d0(11 downto 2);
     end if;
@@ -434,10 +503,24 @@ begin
     end if;
   end process;
   sub4_avalon_address_o <= rd_adr_d0(11 downto 2);
-  sub4_avalon_byteenable_o <= (others => '1');
+  process (wr_sel) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
-  sub4_avalon_writedata_o <= dati_int;
+  sub4_avalon_writedata_o <= wr_dat;
 
   -- Interface sub5_apb
   process (clk) begin
@@ -462,22 +545,36 @@ begin
   sub5_apb_wr <= sub5_apb_wr_reg or sub5_apb_wr_req;
   sub5_apb_rd <= sub5_apb_rd_reg or sub5_apb_rd_req;
   sub5_apb_psel_o <= sub5_apb_wr or sub5_apb_rd;
-  sub5_apb_penable_o <= (not wr_req_int and sub5_apb_wr) or (not rd_req_d0 and sub5_apb_rd);
+  sub5_apb_penable_o <= (not wr_req and sub5_apb_wr) or (not rd_req_d0 and sub5_apb_rd);
   sub5_apb_pwrite_o <= sub5_apb_wr;
-  process (sub5_apb_wr, addr_int, rd_adr_d0) begin
+  process (sub5_apb_wr, adr, rd_adr_d0) begin
     if sub5_apb_wr = '1' then
-      sub5_apb_paddr_o <= addr_int(11 downto 2);
+      sub5_apb_paddr_o <= adr(11 downto 2);
     else
       sub5_apb_paddr_o <= rd_adr_d0(11 downto 2);
     end if;
   end process;
-  sub5_apb_pwdata_o <= dati_int;
-  sub5_apb_pstrb_o <= (others => '1');
+  sub5_apb_pwdata_o <= wr_dat;
+  process (wr_sel) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
-  process (addr_int, wr_req_int, reg1_wack, reg2_wack, ram2_we, sub1_wb_wack,
+  process (adr, wr_req, reg1_wack, reg2_wack, ram2_we, sub1_wb_wack,
            sub2_axi4_bvalid_i, sub3_cernbe_VMEWrDone_i, sub4_avalon_wr,
-           sub4_avalon_waitrequest_i, wr_ack_int, sub5_apb_wr, sub5_apb_pready_i,
+           sub4_avalon_waitrequest_i, wr_ack, sub5_apb_wr, sub5_apb_pready_i,
            sub5_apb_pslverr_i) begin
     reg1_wreq <= '0';
     reg2_wreq <= '0';
@@ -489,59 +586,59 @@ begin
     sub4_avalon_we <= '0';
     sub5_apb_wr_req <= '0';
     sub5_apb_wr_ack <= '0';
-    case addr_int(14 downto 12) is
+    case adr(14 downto 12) is
     when "000" =>
-      case addr_int(11 downto 5) is
+      case adr(11 downto 5) is
       when "0000000" =>
-        case addr_int(4 downto 2) is
+        case adr(4 downto 2) is
         when "000" =>
           -- Reg reg1
-          reg1_wreq <= wr_req_int;
-          wr_ack_int <= reg1_wack;
+          reg1_wreq <= wr_req;
+          wr_ack <= reg1_wack;
         when "001" =>
           -- Reg reg2
-          reg2_wreq <= wr_req_int;
-          wr_ack_int <= reg2_wack;
+          reg2_wreq <= wr_req;
+          wr_ack <= reg2_wack;
         when others =>
-          wr_ack_int <= wr_req_int;
+          wr_ack <= wr_req;
         end case;
       when "0000001" =>
         -- Memory ram1
-        ram1_val_int_wr <= wr_req_int;
-        wr_ack_int <= wr_req_int;
+        ram1_val_int_wr <= wr_req;
+        wr_ack <= wr_req;
       when "0000010" =>
         -- Memory ram_ro
-        wr_ack_int <= wr_req_int;
+        wr_ack <= wr_req;
       when "0000011" =>
         -- Memory ram2
         ram2_wr_o <= ram2_we;
-        wr_ack_int <= ram2_we;
+        wr_ack <= ram2_we;
       when others =>
-        wr_ack_int <= wr_req_int;
+        wr_ack <= wr_req;
       end case;
     when "001" =>
       -- Submap sub1_wb
-      sub1_wb_we <= wr_req_int;
-      wr_ack_int <= sub1_wb_wack;
+      sub1_wb_we <= wr_req;
+      wr_ack <= sub1_wb_wack;
     when "010" =>
       -- Submap sub2_axi4
-      sub2_axi4_wr <= wr_req_int;
-      wr_ack_int <= sub2_axi4_bvalid_i;
+      sub2_axi4_wr <= wr_req;
+      wr_ack <= sub2_axi4_bvalid_i;
     when "011" =>
       -- Submap sub3_cernbe
-      sub3_cernbe_ws <= wr_req_int;
-      wr_ack_int <= sub3_cernbe_VMEWrDone_i;
+      sub3_cernbe_ws <= wr_req;
+      wr_ack <= sub3_cernbe_VMEWrDone_i;
     when "100" =>
       -- Submap sub4_avalon
-      sub4_avalon_we <= wr_req_int;
-      wr_ack_int <= sub4_avalon_wr and not sub4_avalon_waitrequest_i;
+      sub4_avalon_we <= wr_req;
+      wr_ack <= sub4_avalon_wr and not sub4_avalon_waitrequest_i;
     when "101" =>
       -- Submap sub5_apb
-      sub5_apb_wr_req <= wr_req_int;
-      sub5_apb_wr_ack <= wr_ack_int;
-      wr_ack_int <= sub5_apb_wr and sub5_apb_pready_i;
+      sub5_apb_wr_req <= wr_req;
+      sub5_apb_wr_ack <= wr_ack;
+      wr_ack <= sub5_apb_wr and sub5_apb_pready_i;
     when others =>
-      wr_ack_int <= wr_req_int;
+      wr_ack <= wr_req;
     end case;
   end process;
 

--- a/testfiles/tb/golden_files/all1_avalon_wr-in,rd-out.vhdl
+++ b/testfiles/tb/golden_files/all1_avalon_wr-in,rd-out.vhdl
@@ -104,13 +104,15 @@ end all1_avalon;
 
 architecture syn of all1_avalon is
   signal rst_n                          : std_logic;
-  signal rd_ack_int                     : std_logic;
-  signal wr_ack_int                     : std_logic;
-  signal rd_req_int                     : std_logic;
-  signal wr_req_int                     : std_logic;
+  signal rd_req                         : std_logic;
+  signal rd_ack                         : std_logic;
+  signal wr_req                         : std_logic;
+  signal wr_ack                         : std_logic;
+  signal wr_dat                         : std_logic_vector(31 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal wait_int                       : std_logic;
-  signal addr_int                       : std_logic_vector(14 downto 2);
-  signal dati_int                       : std_logic_vector(31 downto 0);
+  signal sel_int                        : std_logic_vector(31 downto 0);
+  signal adr                            : std_logic_vector(14 downto 2);
   signal reg1_reg                       : std_logic_vector(31 downto 0);
   signal reg1_wreq                      : std_logic;
   signal reg1_wack                      : std_logic;
@@ -157,9 +159,12 @@ architecture syn of all1_avalon is
   signal wr_req_d0                      : std_logic;
   signal wr_adr_d0                      : std_logic_vector(14 downto 2);
   signal wr_dat_d0                      : std_logic_vector(31 downto 0);
+  signal wr_sel_d0                      : std_logic_vector(31 downto 0);
   signal ram1_wr                        : std_logic;
   signal ram1_wreq                      : std_logic;
   signal ram1_adr_int                   : std_logic_vector(2 downto 0);
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
   signal ram2_wp                        : std_logic;
   signal ram2_we                        : std_logic;
   signal sub3_cernbe_ws                 : std_logic;
@@ -171,44 +176,52 @@ begin
       if rst_n = '0' then
         wait_int <= '0';
       else
-        wait_int <= (wait_int or (read or write)) and not (rd_ack_int or wr_ack_int);
+        wait_int <= (wait_int or (read or write)) and not (rd_ack or wr_ack);
       end if;
     end if;
+  end process;
+  process (byteenable) begin
+    sel_int(7 downto 0) <= (others => byteenable(0));
+    sel_int(15 downto 8) <= (others => byteenable(1));
+    sel_int(23 downto 16) <= (others => byteenable(2));
+    sel_int(31 downto 24) <= (others => byteenable(3));
   end process;
   process (clk) begin
     if rising_edge(clk) then
       if rst_n = '0' then
-        rd_req_int <= '0';
-        wr_req_int <= '0';
+        rd_req <= '0';
+        wr_req <= '0';
       else
         if ((read or write) and not wait_int) = '1' then
-          addr_int <= address;
+          adr <= address;
         else
         end if;
         if (write and not wait_int) = '1' then
-          dati_int <= writedata;
+          wr_sel <= sel_int;
+          wr_dat <= writedata;
         else
         end if;
-        rd_req_int <= read and not wait_int;
-        wr_req_int <= write and not wait_int;
+        rd_req <= read and not wait_int;
+        wr_req <= write and not wait_int;
       end if;
     end if;
   end process;
-  readdatavalid <= rd_ack_int;
+  readdatavalid <= rd_ack;
   waitrequest <= wait_int;
 
   -- pipelining for rd-out+wr-in
   process (clk) begin
     if rising_edge(clk) then
       if rst_n = '0' then
-        rd_ack_int <= '0';
+        rd_ack <= '0';
         wr_req_d0 <= '0';
       else
-        rd_ack_int <= rd_ack_d0;
+        rd_ack <= rd_ack_d0;
         readdata <= rd_dat_d0;
-        wr_req_d0 <= wr_req_int;
-        wr_adr_d0 <= addr_int;
-        wr_dat_d0 <= dati_int;
+        wr_req_d0 <= wr_req;
+        wr_adr_d0 <= adr;
+        wr_dat_d0 <= wr_dat;
+        wr_sel_d0 <= wr_sel;
       end if;
     end if;
   end process;
@@ -246,11 +259,11 @@ begin
   end process;
 
   -- Memory ram1
-  process (addr_int, wr_adr_d0, ram1_wr) begin
+  process (adr, wr_adr_d0, ram1_wr) begin
     if ram1_wr = '1' then
       ram1_adr_int <= wr_adr_d0(4 downto 2);
     else
-      ram1_adr_int <= addr_int(4 downto 2);
+      ram1_adr_int <= adr(4 downto 2);
     end if;
   end process;
   ram1_wreq <= ram1_val_int_wr;
@@ -261,13 +274,13 @@ begin
       g_size               => 8,
       g_addr_width         => 3,
       g_dual_clock         => '0',
-      g_use_bwsel          => '0'
+      g_use_bwsel          => '1'
     )
     port map (
       clk_a_i              => clk,
       clk_b_i              => clk,
       addr_a_i             => ram1_adr_int,
-      bwsel_a_i            => (others => '1'),
+      bwsel_a_i            => ram1_sel_int,
       data_a_i             => wr_dat_d0,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
@@ -280,6 +293,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel_d0) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk) begin
     if rising_edge(clk) then
       if rst_n = '0' then
@@ -297,13 +325,13 @@ begin
       g_size               => 8,
       g_addr_width         => 3,
       g_dual_clock         => '0',
-      g_use_bwsel          => '0'
+      g_use_bwsel          => '1'
     )
     port map (
       clk_a_i              => clk,
       clk_b_i              => clk,
-      addr_a_i             => addr_int(4 downto 2),
-      bwsel_a_i            => (others => '1'),
+      addr_a_i             => adr(4 downto 2),
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -316,6 +344,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel_d0) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk) begin
     if rising_edge(clk) then
       if rst_n = '0' then
@@ -342,14 +385,14 @@ begin
       if rst_n = '0' then
         ram2_wp <= '0';
       else
-        ram2_wp <= (wr_req_d0 or ram2_wp) and rd_req_int;
+        ram2_wp <= (wr_req_d0 or ram2_wp) and rd_req;
       end if;
     end if;
   end process;
-  ram2_we <= (wr_req_d0 or ram2_wp) and not rd_req_int;
-  process (addr_int, wr_adr_d0, ram2_re) begin
+  ram2_we <= (wr_req_d0 or ram2_wp) and not rd_req;
+  process (adr, wr_adr_d0, ram2_re) begin
     if ram2_re = '1' then
-      ram2_addr_o <= addr_int(4 downto 2);
+      ram2_addr_o <= adr(4 downto 2);
     else
       ram2_addr_o <= wr_adr_d0(4 downto 2);
     end if;
@@ -372,8 +415,22 @@ begin
   sub1_wb_stb_o <= sub1_wb_tr;
   sub1_wb_wack <= sub1_wb_ack_i and sub1_wb_wt;
   sub1_wb_rack <= sub1_wb_ack_i and sub1_wb_rt;
-  sub1_wb_adr_o <= addr_int(11 downto 2);
-  sub1_wb_sel_o <= (others => '1');
+  sub1_wb_adr_o <= adr(11 downto 2);
+  process (wr_sel_d0) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
   sub1_wb_dat_o <= wr_dat_d0;
 
@@ -383,10 +440,24 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wr_dat_d0;
-  sub2_axi4_wstrb_o <= (others => '1');
+  process (wr_sel_d0) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
-  sub2_axi4_araddr_o <= addr_int(11 downto 2);
+  sub2_axi4_araddr_o <= adr(11 downto 2);
   sub2_axi4_arprot_o <= "000";
   sub2_axi4_rready_o <= '1';
   process (clk) begin
@@ -415,11 +486,11 @@ begin
     end if;
   end process;
   sub3_cernbe_VMEWrMem_o <= sub3_cernbe_ws;
-  process (addr_int, wr_adr_d0, sub3_cernbe_wt, sub3_cernbe_ws) begin
+  process (adr, wr_adr_d0, sub3_cernbe_wt, sub3_cernbe_ws) begin
     if (sub3_cernbe_ws or sub3_cernbe_wt) = '1' then
       sub3_cernbe_VMEAddr_o <= wr_adr_d0(11 downto 2);
     else
-      sub3_cernbe_VMEAddr_o <= addr_int(11 downto 2);
+      sub3_cernbe_VMEAddr_o <= adr(11 downto 2);
     end if;
   end process;
 
@@ -435,8 +506,22 @@ begin
       end if;
     end if;
   end process;
-  sub4_avalon_address_o <= addr_int(11 downto 2);
-  sub4_avalon_byteenable_o <= (others => '1');
+  sub4_avalon_address_o <= adr(11 downto 2);
+  process (wr_sel_d0) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
   sub4_avalon_writedata_o <= wr_dat_d0;
@@ -464,22 +549,36 @@ begin
   sub5_apb_wr <= sub5_apb_wr_reg or sub5_apb_wr_req;
   sub5_apb_rd <= sub5_apb_rd_reg or sub5_apb_rd_req;
   sub5_apb_psel_o <= sub5_apb_wr or sub5_apb_rd;
-  sub5_apb_penable_o <= (not wr_req_d0 and sub5_apb_wr) or (not rd_req_int and sub5_apb_rd);
+  sub5_apb_penable_o <= (not wr_req_d0 and sub5_apb_wr) or (not rd_req and sub5_apb_rd);
   sub5_apb_pwrite_o <= sub5_apb_wr;
-  process (sub5_apb_wr, wr_adr_d0, addr_int) begin
+  process (sub5_apb_wr, wr_adr_d0, adr) begin
     if sub5_apb_wr = '1' then
       sub5_apb_paddr_o <= wr_adr_d0(11 downto 2);
     else
-      sub5_apb_paddr_o <= addr_int(11 downto 2);
+      sub5_apb_paddr_o <= adr(11 downto 2);
     end if;
   end process;
   sub5_apb_pwdata_o <= wr_dat_d0;
-  sub5_apb_pstrb_o <= (others => '1');
+  process (wr_sel_d0) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
   process (wr_adr_d0, wr_req_d0, reg1_wack, reg2_wack, ram2_we, sub1_wb_wack,
            sub2_axi4_bvalid_i, sub3_cernbe_VMEWrDone_i, sub4_avalon_wr,
-           sub4_avalon_waitrequest_i, wr_ack_int, sub5_apb_wr, sub5_apb_pready_i,
+           sub4_avalon_waitrequest_i, wr_ack, sub5_apb_wr, sub5_apb_pready_i,
            sub5_apb_pslverr_i) begin
     reg1_wreq <= '0';
     reg2_wreq <= '0';
@@ -499,62 +598,61 @@ begin
         when "000" =>
           -- Reg reg1
           reg1_wreq <= wr_req_d0;
-          wr_ack_int <= reg1_wack;
+          wr_ack <= reg1_wack;
         when "001" =>
           -- Reg reg2
           reg2_wreq <= wr_req_d0;
-          wr_ack_int <= reg2_wack;
+          wr_ack <= reg2_wack;
         when others =>
-          wr_ack_int <= wr_req_d0;
+          wr_ack <= wr_req_d0;
         end case;
       when "0000001" =>
         -- Memory ram1
         ram1_val_int_wr <= wr_req_d0;
-        wr_ack_int <= wr_req_d0;
+        wr_ack <= wr_req_d0;
       when "0000010" =>
         -- Memory ram_ro
-        wr_ack_int <= wr_req_d0;
+        wr_ack <= wr_req_d0;
       when "0000011" =>
         -- Memory ram2
         ram2_wr_o <= ram2_we;
-        wr_ack_int <= ram2_we;
+        wr_ack <= ram2_we;
       when others =>
-        wr_ack_int <= wr_req_d0;
+        wr_ack <= wr_req_d0;
       end case;
     when "001" =>
       -- Submap sub1_wb
       sub1_wb_we <= wr_req_d0;
-      wr_ack_int <= sub1_wb_wack;
+      wr_ack <= sub1_wb_wack;
     when "010" =>
       -- Submap sub2_axi4
       sub2_axi4_wr <= wr_req_d0;
-      wr_ack_int <= sub2_axi4_bvalid_i;
+      wr_ack <= sub2_axi4_bvalid_i;
     when "011" =>
       -- Submap sub3_cernbe
       sub3_cernbe_ws <= wr_req_d0;
-      wr_ack_int <= sub3_cernbe_VMEWrDone_i;
+      wr_ack <= sub3_cernbe_VMEWrDone_i;
     when "100" =>
       -- Submap sub4_avalon
       sub4_avalon_we <= wr_req_d0;
-      wr_ack_int <= sub4_avalon_wr and not sub4_avalon_waitrequest_i;
+      wr_ack <= sub4_avalon_wr and not sub4_avalon_waitrequest_i;
     when "101" =>
       -- Submap sub5_apb
       sub5_apb_wr_req <= wr_req_d0;
-      sub5_apb_wr_ack <= wr_ack_int;
-      wr_ack_int <= sub5_apb_wr and sub5_apb_pready_i;
+      sub5_apb_wr_ack <= wr_ack;
+      wr_ack <= sub5_apb_wr and sub5_apb_pready_i;
     when others =>
-      wr_ack_int <= wr_req_d0;
+      wr_ack <= wr_req_d0;
     end case;
   end process;
 
   -- Process for read requests.
-  process (addr_int, rd_req_int, reg1_reg, reg2_reg, ram1_val_int_dato,
-           ram1_val_rack, ram_ro_val_int_dato, ram_ro_val_rack, ram2_data_i,
-           ram2_rack, sub1_wb_dat_i, sub1_wb_rack, sub2_axi4_rdata_i,
-           sub2_axi4_rvalid_i, sub3_cernbe_VMERdData_i,
-           sub3_cernbe_VMERdDone_i, sub4_avalon_readdata_i,
-           sub4_avalon_readdatavalid_i, rd_ack_d0, sub5_apb_prdata_i,
-           sub5_apb_rd, sub5_apb_pready_i, sub5_apb_pslverr_i) begin
+  process (adr, rd_req, reg1_reg, reg2_reg, ram1_val_int_dato, ram1_val_rack,
+           ram_ro_val_int_dato, ram_ro_val_rack, ram2_data_i, ram2_rack,
+           sub1_wb_dat_i, sub1_wb_rack, sub2_axi4_rdata_i, sub2_axi4_rvalid_i,
+           sub3_cernbe_VMERdData_i, sub3_cernbe_VMERdDone_i,
+           sub4_avalon_readdata_i, sub4_avalon_readdatavalid_i, rd_ack_d0,
+           sub5_apb_prdata_i, sub5_apb_rd, sub5_apb_pready_i, sub5_apb_pslverr_i) begin
     -- By default ack read requests
     rd_dat_d0 <= (others => 'X');
     ram1_val_rreq <= '0';
@@ -566,68 +664,68 @@ begin
     sub4_avalon_re <= '0';
     sub5_apb_rd_req <= '0';
     sub5_apb_rd_ack <= '0';
-    case addr_int(14 downto 12) is
+    case adr(14 downto 12) is
     when "000" =>
-      case addr_int(11 downto 5) is
+      case adr(11 downto 5) is
       when "0000000" =>
-        case addr_int(4 downto 2) is
+        case adr(4 downto 2) is
         when "000" =>
           -- Reg reg1
-          rd_ack_d0 <= rd_req_int;
+          rd_ack_d0 <= rd_req;
           rd_dat_d0 <= reg1_reg;
         when "001" =>
           -- Reg reg2
-          rd_ack_d0 <= rd_req_int;
+          rd_ack_d0 <= rd_req;
           rd_dat_d0 <= reg2_reg;
         when others =>
-          rd_ack_d0 <= rd_req_int;
+          rd_ack_d0 <= rd_req;
         end case;
       when "0000001" =>
         -- Memory ram1
         rd_dat_d0 <= ram1_val_int_dato;
-        ram1_val_rreq <= rd_req_int;
+        ram1_val_rreq <= rd_req;
         rd_ack_d0 <= ram1_val_rack;
       when "0000010" =>
         -- Memory ram_ro
         rd_dat_d0 <= ram_ro_val_int_dato;
-        ram_ro_val_rreq <= rd_req_int;
+        ram_ro_val_rreq <= rd_req;
         rd_ack_d0 <= ram_ro_val_rack;
       when "0000011" =>
         -- Memory ram2
         rd_dat_d0 <= ram2_data_i;
         rd_ack_d0 <= ram2_rack;
-        ram2_re <= rd_req_int;
+        ram2_re <= rd_req;
       when others =>
-        rd_ack_d0 <= rd_req_int;
+        rd_ack_d0 <= rd_req;
       end case;
     when "001" =>
       -- Submap sub1_wb
-      sub1_wb_re <= rd_req_int;
+      sub1_wb_re <= rd_req;
       rd_dat_d0 <= sub1_wb_dat_i;
       rd_ack_d0 <= sub1_wb_rack;
     when "010" =>
       -- Submap sub2_axi4
-      sub2_axi4_rd <= rd_req_int;
+      sub2_axi4_rd <= rd_req;
       rd_dat_d0 <= sub2_axi4_rdata_i;
       rd_ack_d0 <= sub2_axi4_rvalid_i;
     when "011" =>
       -- Submap sub3_cernbe
-      sub3_cernbe_VMERdMem_o <= rd_req_int;
+      sub3_cernbe_VMERdMem_o <= rd_req;
       rd_dat_d0 <= sub3_cernbe_VMERdData_i;
       rd_ack_d0 <= sub3_cernbe_VMERdDone_i;
     when "100" =>
       -- Submap sub4_avalon
-      sub4_avalon_re <= rd_req_int;
+      sub4_avalon_re <= rd_req;
       rd_dat_d0 <= sub4_avalon_readdata_i;
       rd_ack_d0 <= sub4_avalon_readdatavalid_i;
     when "101" =>
       -- Submap sub5_apb
-      sub5_apb_rd_req <= rd_req_int;
+      sub5_apb_rd_req <= rd_req;
       sub5_apb_rd_ack <= rd_ack_d0;
       rd_dat_d0 <= sub5_apb_prdata_i;
       rd_ack_d0 <= sub5_apb_rd and sub5_apb_pready_i;
     when others =>
-      rd_ack_d0 <= rd_req_int;
+      rd_ack_d0 <= rd_req;
     end case;
   end process;
 end syn;

--- a/testfiles/tb/golden_files/all1_avalon_wr.vhdl
+++ b/testfiles/tb/golden_files/all1_avalon_wr.vhdl
@@ -104,13 +104,15 @@ end all1_avalon;
 
 architecture syn of all1_avalon is
   signal rst_n                          : std_logic;
-  signal rd_ack_int                     : std_logic;
-  signal wr_ack_int                     : std_logic;
-  signal rd_req_int                     : std_logic;
-  signal wr_req_int                     : std_logic;
+  signal rd_req                         : std_logic;
+  signal rd_ack                         : std_logic;
+  signal wr_req                         : std_logic;
+  signal wr_ack                         : std_logic;
+  signal wr_dat                         : std_logic_vector(31 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal wait_int                       : std_logic;
-  signal addr_int                       : std_logic_vector(14 downto 2);
-  signal dati_int                       : std_logic_vector(31 downto 0);
+  signal sel_int                        : std_logic_vector(31 downto 0);
+  signal adr                            : std_logic_vector(14 downto 2);
   signal reg1_reg                       : std_logic_vector(31 downto 0);
   signal reg1_wreq                      : std_logic;
   signal reg1_wack                      : std_logic;
@@ -155,10 +157,13 @@ architecture syn of all1_avalon is
   signal wr_req_d0                      : std_logic;
   signal wr_adr_d0                      : std_logic_vector(14 downto 2);
   signal wr_dat_d0                      : std_logic_vector(31 downto 0);
+  signal wr_sel_d0                      : std_logic_vector(31 downto 0);
   signal wr_ack_d0                      : std_logic;
   signal ram1_wr                        : std_logic;
   signal ram1_wreq                      : std_logic;
   signal ram1_adr_int                   : std_logic_vector(2 downto 0);
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
   signal ram2_wp                        : std_logic;
   signal ram2_we                        : std_logic;
   signal sub3_cernbe_ws                 : std_logic;
@@ -170,30 +175,37 @@ begin
       if rst_n = '0' then
         wait_int <= '0';
       else
-        wait_int <= (wait_int or (read or write)) and not (rd_ack_int or wr_ack_int);
+        wait_int <= (wait_int or (read or write)) and not (rd_ack or wr_ack);
       end if;
     end if;
+  end process;
+  process (byteenable) begin
+    sel_int(7 downto 0) <= (others => byteenable(0));
+    sel_int(15 downto 8) <= (others => byteenable(1));
+    sel_int(23 downto 16) <= (others => byteenable(2));
+    sel_int(31 downto 24) <= (others => byteenable(3));
   end process;
   process (clk) begin
     if rising_edge(clk) then
       if rst_n = '0' then
-        rd_req_int <= '0';
-        wr_req_int <= '0';
+        rd_req <= '0';
+        wr_req <= '0';
       else
         if ((read or write) and not wait_int) = '1' then
-          addr_int <= address;
+          adr <= address;
         else
         end if;
         if (write and not wait_int) = '1' then
-          dati_int <= writedata;
+          wr_sel <= sel_int;
+          wr_dat <= writedata;
         else
         end if;
-        rd_req_int <= read and not wait_int;
-        wr_req_int <= write and not wait_int;
+        rd_req <= read and not wait_int;
+        wr_req <= write and not wait_int;
       end if;
     end if;
   end process;
-  readdatavalid <= rd_ack_int;
+  readdatavalid <= rd_ack;
   waitrequest <= wait_int;
 
   -- pipelining for wr-in+wr-out
@@ -201,12 +213,13 @@ begin
     if rising_edge(clk) then
       if rst_n = '0' then
         wr_req_d0 <= '0';
-        wr_ack_int <= '0';
+        wr_ack <= '0';
       else
-        wr_req_d0 <= wr_req_int;
-        wr_adr_d0 <= addr_int;
-        wr_dat_d0 <= dati_int;
-        wr_ack_int <= wr_ack_d0;
+        wr_req_d0 <= wr_req;
+        wr_adr_d0 <= adr;
+        wr_dat_d0 <= wr_dat;
+        wr_sel_d0 <= wr_sel;
+        wr_ack <= wr_ack_d0;
       end if;
     end if;
   end process;
@@ -244,11 +257,11 @@ begin
   end process;
 
   -- Memory ram1
-  process (addr_int, wr_adr_d0, ram1_wr) begin
+  process (adr, wr_adr_d0, ram1_wr) begin
     if ram1_wr = '1' then
       ram1_adr_int <= wr_adr_d0(4 downto 2);
     else
-      ram1_adr_int <= addr_int(4 downto 2);
+      ram1_adr_int <= adr(4 downto 2);
     end if;
   end process;
   ram1_wreq <= ram1_val_int_wr;
@@ -259,13 +272,13 @@ begin
       g_size               => 8,
       g_addr_width         => 3,
       g_dual_clock         => '0',
-      g_use_bwsel          => '0'
+      g_use_bwsel          => '1'
     )
     port map (
       clk_a_i              => clk,
       clk_b_i              => clk,
       addr_a_i             => ram1_adr_int,
-      bwsel_a_i            => (others => '1'),
+      bwsel_a_i            => ram1_sel_int,
       data_a_i             => wr_dat_d0,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
@@ -278,6 +291,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel_d0) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk) begin
     if rising_edge(clk) then
       if rst_n = '0' then
@@ -295,13 +323,13 @@ begin
       g_size               => 8,
       g_addr_width         => 3,
       g_dual_clock         => '0',
-      g_use_bwsel          => '0'
+      g_use_bwsel          => '1'
     )
     port map (
       clk_a_i              => clk,
       clk_b_i              => clk,
-      addr_a_i             => addr_int(4 downto 2),
-      bwsel_a_i            => (others => '1'),
+      addr_a_i             => adr(4 downto 2),
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -314,6 +342,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel_d0) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk) begin
     if rising_edge(clk) then
       if rst_n = '0' then
@@ -340,14 +383,14 @@ begin
       if rst_n = '0' then
         ram2_wp <= '0';
       else
-        ram2_wp <= (wr_req_d0 or ram2_wp) and rd_req_int;
+        ram2_wp <= (wr_req_d0 or ram2_wp) and rd_req;
       end if;
     end if;
   end process;
-  ram2_we <= (wr_req_d0 or ram2_wp) and not rd_req_int;
-  process (addr_int, wr_adr_d0, ram2_re) begin
+  ram2_we <= (wr_req_d0 or ram2_wp) and not rd_req;
+  process (adr, wr_adr_d0, ram2_re) begin
     if ram2_re = '1' then
-      ram2_addr_o <= addr_int(4 downto 2);
+      ram2_addr_o <= adr(4 downto 2);
     else
       ram2_addr_o <= wr_adr_d0(4 downto 2);
     end if;
@@ -370,8 +413,22 @@ begin
   sub1_wb_stb_o <= sub1_wb_tr;
   sub1_wb_wack <= sub1_wb_ack_i and sub1_wb_wt;
   sub1_wb_rack <= sub1_wb_ack_i and sub1_wb_rt;
-  sub1_wb_adr_o <= addr_int(11 downto 2);
-  sub1_wb_sel_o <= (others => '1');
+  sub1_wb_adr_o <= adr(11 downto 2);
+  process (wr_sel_d0) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
   sub1_wb_dat_o <= wr_dat_d0;
 
@@ -381,10 +438,24 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wr_dat_d0;
-  sub2_axi4_wstrb_o <= (others => '1');
+  process (wr_sel_d0) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
-  sub2_axi4_araddr_o <= addr_int(11 downto 2);
+  sub2_axi4_araddr_o <= adr(11 downto 2);
   sub2_axi4_arprot_o <= "000";
   sub2_axi4_rready_o <= '1';
   process (clk) begin
@@ -413,11 +484,11 @@ begin
     end if;
   end process;
   sub3_cernbe_VMEWrMem_o <= sub3_cernbe_ws;
-  process (addr_int, wr_adr_d0, sub3_cernbe_wt, sub3_cernbe_ws) begin
+  process (adr, wr_adr_d0, sub3_cernbe_wt, sub3_cernbe_ws) begin
     if (sub3_cernbe_ws or sub3_cernbe_wt) = '1' then
       sub3_cernbe_VMEAddr_o <= wr_adr_d0(11 downto 2);
     else
-      sub3_cernbe_VMEAddr_o <= addr_int(11 downto 2);
+      sub3_cernbe_VMEAddr_o <= adr(11 downto 2);
     end if;
   end process;
 
@@ -433,8 +504,22 @@ begin
       end if;
     end if;
   end process;
-  sub4_avalon_address_o <= addr_int(11 downto 2);
-  sub4_avalon_byteenable_o <= (others => '1');
+  sub4_avalon_address_o <= adr(11 downto 2);
+  process (wr_sel_d0) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
   sub4_avalon_writedata_o <= wr_dat_d0;
@@ -462,17 +547,31 @@ begin
   sub5_apb_wr <= sub5_apb_wr_reg or sub5_apb_wr_req;
   sub5_apb_rd <= sub5_apb_rd_reg or sub5_apb_rd_req;
   sub5_apb_psel_o <= sub5_apb_wr or sub5_apb_rd;
-  sub5_apb_penable_o <= (not wr_req_d0 and sub5_apb_wr) or (not rd_req_int and sub5_apb_rd);
+  sub5_apb_penable_o <= (not wr_req_d0 and sub5_apb_wr) or (not rd_req and sub5_apb_rd);
   sub5_apb_pwrite_o <= sub5_apb_wr;
-  process (sub5_apb_wr, wr_adr_d0, addr_int) begin
+  process (sub5_apb_wr, wr_adr_d0, adr) begin
     if sub5_apb_wr = '1' then
       sub5_apb_paddr_o <= wr_adr_d0(11 downto 2);
     else
-      sub5_apb_paddr_o <= addr_int(11 downto 2);
+      sub5_apb_paddr_o <= adr(11 downto 2);
     end if;
   end process;
   sub5_apb_pwdata_o <= wr_dat_d0;
-  sub5_apb_pstrb_o <= (others => '1');
+  process (wr_sel_d0) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
   process (wr_adr_d0, wr_req_d0, reg1_wack, reg2_wack, ram2_we, sub1_wb_wack,
@@ -546,13 +645,12 @@ begin
   end process;
 
   -- Process for read requests.
-  process (addr_int, rd_req_int, reg1_reg, reg2_reg, ram1_val_int_dato,
-           ram1_val_rack, ram_ro_val_int_dato, ram_ro_val_rack, ram2_data_i,
-           ram2_rack, sub1_wb_dat_i, sub1_wb_rack, sub2_axi4_rdata_i,
-           sub2_axi4_rvalid_i, sub3_cernbe_VMERdData_i,
-           sub3_cernbe_VMERdDone_i, sub4_avalon_readdata_i,
-           sub4_avalon_readdatavalid_i, rd_ack_int, sub5_apb_prdata_i,
-           sub5_apb_rd, sub5_apb_pready_i, sub5_apb_pslverr_i) begin
+  process (adr, rd_req, reg1_reg, reg2_reg, ram1_val_int_dato, ram1_val_rack,
+           ram_ro_val_int_dato, ram_ro_val_rack, ram2_data_i, ram2_rack,
+           sub1_wb_dat_i, sub1_wb_rack, sub2_axi4_rdata_i, sub2_axi4_rvalid_i,
+           sub3_cernbe_VMERdData_i, sub3_cernbe_VMERdDone_i,
+           sub4_avalon_readdata_i, sub4_avalon_readdatavalid_i, rd_ack,
+           sub5_apb_prdata_i, sub5_apb_rd, sub5_apb_pready_i, sub5_apb_pslverr_i) begin
     -- By default ack read requests
     readdata <= (others => 'X');
     ram1_val_rreq <= '0';
@@ -564,68 +662,68 @@ begin
     sub4_avalon_re <= '0';
     sub5_apb_rd_req <= '0';
     sub5_apb_rd_ack <= '0';
-    case addr_int(14 downto 12) is
+    case adr(14 downto 12) is
     when "000" =>
-      case addr_int(11 downto 5) is
+      case adr(11 downto 5) is
       when "0000000" =>
-        case addr_int(4 downto 2) is
+        case adr(4 downto 2) is
         when "000" =>
           -- Reg reg1
-          rd_ack_int <= rd_req_int;
+          rd_ack <= rd_req;
           readdata <= reg1_reg;
         when "001" =>
           -- Reg reg2
-          rd_ack_int <= rd_req_int;
+          rd_ack <= rd_req;
           readdata <= reg2_reg;
         when others =>
-          rd_ack_int <= rd_req_int;
+          rd_ack <= rd_req;
         end case;
       when "0000001" =>
         -- Memory ram1
         readdata <= ram1_val_int_dato;
-        ram1_val_rreq <= rd_req_int;
-        rd_ack_int <= ram1_val_rack;
+        ram1_val_rreq <= rd_req;
+        rd_ack <= ram1_val_rack;
       when "0000010" =>
         -- Memory ram_ro
         readdata <= ram_ro_val_int_dato;
-        ram_ro_val_rreq <= rd_req_int;
-        rd_ack_int <= ram_ro_val_rack;
+        ram_ro_val_rreq <= rd_req;
+        rd_ack <= ram_ro_val_rack;
       when "0000011" =>
         -- Memory ram2
         readdata <= ram2_data_i;
-        rd_ack_int <= ram2_rack;
-        ram2_re <= rd_req_int;
+        rd_ack <= ram2_rack;
+        ram2_re <= rd_req;
       when others =>
-        rd_ack_int <= rd_req_int;
+        rd_ack <= rd_req;
       end case;
     when "001" =>
       -- Submap sub1_wb
-      sub1_wb_re <= rd_req_int;
+      sub1_wb_re <= rd_req;
       readdata <= sub1_wb_dat_i;
-      rd_ack_int <= sub1_wb_rack;
+      rd_ack <= sub1_wb_rack;
     when "010" =>
       -- Submap sub2_axi4
-      sub2_axi4_rd <= rd_req_int;
+      sub2_axi4_rd <= rd_req;
       readdata <= sub2_axi4_rdata_i;
-      rd_ack_int <= sub2_axi4_rvalid_i;
+      rd_ack <= sub2_axi4_rvalid_i;
     when "011" =>
       -- Submap sub3_cernbe
-      sub3_cernbe_VMERdMem_o <= rd_req_int;
+      sub3_cernbe_VMERdMem_o <= rd_req;
       readdata <= sub3_cernbe_VMERdData_i;
-      rd_ack_int <= sub3_cernbe_VMERdDone_i;
+      rd_ack <= sub3_cernbe_VMERdDone_i;
     when "100" =>
       -- Submap sub4_avalon
-      sub4_avalon_re <= rd_req_int;
+      sub4_avalon_re <= rd_req;
       readdata <= sub4_avalon_readdata_i;
-      rd_ack_int <= sub4_avalon_readdatavalid_i;
+      rd_ack <= sub4_avalon_readdatavalid_i;
     when "101" =>
       -- Submap sub5_apb
-      sub5_apb_rd_req <= rd_req_int;
-      sub5_apb_rd_ack <= rd_ack_int;
+      sub5_apb_rd_req <= rd_req;
+      sub5_apb_rd_ack <= rd_ack;
       readdata <= sub5_apb_prdata_i;
-      rd_ack_int <= sub5_apb_rd and sub5_apb_pready_i;
+      rd_ack <= sub5_apb_rd and sub5_apb_pready_i;
     when others =>
-      rd_ack_int <= rd_req_int;
+      rd_ack <= rd_req;
     end case;
   end process;
 end syn;

--- a/testfiles/tb/golden_files/all1_axi4_all.vhdl
+++ b/testfiles/tb/golden_files/all1_axi4_all.vhdl
@@ -118,7 +118,7 @@ architecture syn of all1_axi4 is
   signal wr_ack                         : std_logic;
   signal wr_addr                        : std_logic_vector(14 downto 2);
   signal wr_data                        : std_logic_vector(31 downto 0);
-  signal wr_strb                        : std_logic_vector(3 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal axi_awset                      : std_logic;
   signal axi_wset                       : std_logic;
   signal axi_wdone                      : std_logic;
@@ -189,11 +189,13 @@ architecture syn of all1_axi4 is
   signal wr_req_d0                      : std_logic;
   signal wr_adr_d0                      : std_logic_vector(14 downto 2);
   signal wr_dat_d0                      : std_logic_vector(31 downto 0);
-  signal wr_sel_d0                      : std_logic_vector(3 downto 0);
+  signal wr_sel_d0                      : std_logic_vector(31 downto 0);
   signal wr_ack_d0                      : std_logic;
   signal ram1_wr                        : std_logic;
   signal ram1_wreq                      : std_logic;
   signal ram1_adr_int                   : std_logic_vector(2 downto 0);
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
   signal ram2_wp                        : std_logic;
   signal ram2_we                        : std_logic;
 begin
@@ -218,7 +220,10 @@ begin
         end if;
         if wvalid = '1' and axi_wset = '0' then
           wr_data <= wdata;
-          wr_strb <= wstrb;
+          wr_sel(7 downto 0) <= (others => wstrb(0));
+          wr_sel(15 downto 8) <= (others => wstrb(1));
+          wr_sel(23 downto 16) <= (others => wstrb(2));
+          wr_sel(31 downto 24) <= (others => wstrb(3));
           axi_wset <= '1';
           wr_req <= axi_awset or awvalid;
         end if;
@@ -281,7 +286,7 @@ begin
         wr_req_d0 <= wr_req;
         wr_adr_d0 <= wr_addr;
         wr_dat_d0 <= wr_data;
-        wr_sel_d0 <= wr_strb;
+        wr_sel_d0 <= wr_sel;
         wr_ack <= wr_ack_d0;
       end if;
     end if;
@@ -341,7 +346,7 @@ begin
       clk_a_i              => aclk,
       clk_b_i              => aclk,
       addr_a_i             => ram1_adr_int,
-      bwsel_a_i            => wr_sel_d0,
+      bwsel_a_i            => ram1_sel_int,
       data_a_i             => wr_dat_d0,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
@@ -354,6 +359,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel_d0) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (aclk) begin
     if rising_edge(aclk) then
       if areset_n = '0' then
@@ -377,7 +397,7 @@ begin
       clk_a_i              => aclk,
       clk_b_i              => aclk,
       addr_a_i             => rd_adr_d0(4 downto 2),
-      bwsel_a_i            => wr_sel_d0,
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -390,6 +410,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel_d0) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (aclk) begin
     if rising_edge(aclk) then
       if areset_n = '0' then
@@ -457,7 +492,21 @@ begin
       sub1_wb_adr_o <= rd_adr_d0(11 downto 2);
     end if;
   end process;
-  sub1_wb_sel_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
   sub1_wb_dat_o <= wr_dat_d0;
 
@@ -467,7 +516,21 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wr_dat_d0;
-  sub2_axi4_wstrb_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= rd_adr_d0(11 downto 2);
@@ -539,7 +602,21 @@ begin
       sub4_avalon_address_o <= rd_adr_d0(11 downto 2);
     end if;
   end process;
-  sub4_avalon_byteenable_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
   sub4_avalon_writedata_o <= wr_dat_d0;
@@ -577,7 +654,21 @@ begin
     end if;
   end process;
   sub5_apb_pwdata_o <= wr_dat_d0;
-  sub5_apb_pstrb_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
   process (wr_adr_d0, wr_req_d0, reg1_wack, reg2_wack, ram2_we, sub1_wb_wack,

--- a/testfiles/tb/golden_files/all1_axi4_in,out.vhdl
+++ b/testfiles/tb/golden_files/all1_axi4_in,out.vhdl
@@ -118,7 +118,7 @@ architecture syn of all1_axi4 is
   signal wr_ack                         : std_logic;
   signal wr_addr                        : std_logic_vector(14 downto 2);
   signal wr_data                        : std_logic_vector(31 downto 0);
-  signal wr_strb                        : std_logic_vector(3 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal axi_awset                      : std_logic;
   signal axi_wset                       : std_logic;
   signal axi_wdone                      : std_logic;
@@ -189,11 +189,13 @@ architecture syn of all1_axi4 is
   signal wr_req_d0                      : std_logic;
   signal wr_adr_d0                      : std_logic_vector(14 downto 2);
   signal wr_dat_d0                      : std_logic_vector(31 downto 0);
-  signal wr_sel_d0                      : std_logic_vector(3 downto 0);
+  signal wr_sel_d0                      : std_logic_vector(31 downto 0);
   signal wr_ack_d0                      : std_logic;
   signal ram1_wr                        : std_logic;
   signal ram1_wreq                      : std_logic;
   signal ram1_adr_int                   : std_logic_vector(2 downto 0);
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
   signal ram2_wp                        : std_logic;
   signal ram2_we                        : std_logic;
 begin
@@ -218,7 +220,10 @@ begin
         end if;
         if wvalid = '1' and axi_wset = '0' then
           wr_data <= wdata;
-          wr_strb <= wstrb;
+          wr_sel(7 downto 0) <= (others => wstrb(0));
+          wr_sel(15 downto 8) <= (others => wstrb(1));
+          wr_sel(23 downto 16) <= (others => wstrb(2));
+          wr_sel(31 downto 24) <= (others => wstrb(3));
           axi_wset <= '1';
           wr_req <= axi_awset or awvalid;
         end if;
@@ -281,7 +286,7 @@ begin
         wr_req_d0 <= wr_req;
         wr_adr_d0 <= wr_addr;
         wr_dat_d0 <= wr_data;
-        wr_sel_d0 <= wr_strb;
+        wr_sel_d0 <= wr_sel;
         wr_ack <= wr_ack_d0;
       end if;
     end if;
@@ -341,7 +346,7 @@ begin
       clk_a_i              => aclk,
       clk_b_i              => aclk,
       addr_a_i             => ram1_adr_int,
-      bwsel_a_i            => wr_sel_d0,
+      bwsel_a_i            => ram1_sel_int,
       data_a_i             => wr_dat_d0,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
@@ -354,6 +359,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel_d0) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (aclk) begin
     if rising_edge(aclk) then
       if areset_n = '0' then
@@ -377,7 +397,7 @@ begin
       clk_a_i              => aclk,
       clk_b_i              => aclk,
       addr_a_i             => rd_adr_d0(4 downto 2),
-      bwsel_a_i            => wr_sel_d0,
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -390,6 +410,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel_d0) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (aclk) begin
     if rising_edge(aclk) then
       if areset_n = '0' then
@@ -457,7 +492,21 @@ begin
       sub1_wb_adr_o <= rd_adr_d0(11 downto 2);
     end if;
   end process;
-  sub1_wb_sel_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
   sub1_wb_dat_o <= wr_dat_d0;
 
@@ -467,7 +516,21 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wr_dat_d0;
-  sub2_axi4_wstrb_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= rd_adr_d0(11 downto 2);
@@ -539,7 +602,21 @@ begin
       sub4_avalon_address_o <= rd_adr_d0(11 downto 2);
     end if;
   end process;
-  sub4_avalon_byteenable_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
   sub4_avalon_writedata_o <= wr_dat_d0;
@@ -577,7 +654,21 @@ begin
     end if;
   end process;
   sub5_apb_pwdata_o <= wr_dat_d0;
-  sub5_apb_pstrb_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
   process (wr_adr_d0, wr_req_d0, reg1_wack, reg2_wack, ram2_we, sub1_wb_wack,

--- a/testfiles/tb/golden_files/all1_axi4_in.vhdl
+++ b/testfiles/tb/golden_files/all1_axi4_in.vhdl
@@ -118,7 +118,7 @@ architecture syn of all1_axi4 is
   signal wr_ack                         : std_logic;
   signal wr_addr                        : std_logic_vector(14 downto 2);
   signal wr_data                        : std_logic_vector(31 downto 0);
-  signal wr_strb                        : std_logic_vector(3 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal axi_awset                      : std_logic;
   signal axi_wset                       : std_logic;
   signal axi_wdone                      : std_logic;
@@ -187,10 +187,12 @@ architecture syn of all1_axi4 is
   signal wr_req_d0                      : std_logic;
   signal wr_adr_d0                      : std_logic_vector(14 downto 2);
   signal wr_dat_d0                      : std_logic_vector(31 downto 0);
-  signal wr_sel_d0                      : std_logic_vector(3 downto 0);
+  signal wr_sel_d0                      : std_logic_vector(31 downto 0);
   signal ram1_wr                        : std_logic;
   signal ram1_wreq                      : std_logic;
   signal ram1_adr_int                   : std_logic_vector(2 downto 0);
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
   signal ram2_wp                        : std_logic;
   signal ram2_we                        : std_logic;
 begin
@@ -215,7 +217,10 @@ begin
         end if;
         if wvalid = '1' and axi_wset = '0' then
           wr_data <= wdata;
-          wr_strb <= wstrb;
+          wr_sel(7 downto 0) <= (others => wstrb(0));
+          wr_sel(15 downto 8) <= (others => wstrb(1));
+          wr_sel(23 downto 16) <= (others => wstrb(2));
+          wr_sel(31 downto 24) <= (others => wstrb(3));
           axi_wset <= '1';
           wr_req <= axi_awset or awvalid;
         end if;
@@ -274,7 +279,7 @@ begin
         wr_req_d0 <= wr_req;
         wr_adr_d0 <= wr_addr;
         wr_dat_d0 <= wr_data;
-        wr_sel_d0 <= wr_strb;
+        wr_sel_d0 <= wr_sel;
       end if;
     end if;
   end process;
@@ -333,7 +338,7 @@ begin
       clk_a_i              => aclk,
       clk_b_i              => aclk,
       addr_a_i             => ram1_adr_int,
-      bwsel_a_i            => wr_sel_d0,
+      bwsel_a_i            => ram1_sel_int,
       data_a_i             => wr_dat_d0,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
@@ -346,6 +351,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel_d0) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (aclk) begin
     if rising_edge(aclk) then
       if areset_n = '0' then
@@ -369,7 +389,7 @@ begin
       clk_a_i              => aclk,
       clk_b_i              => aclk,
       addr_a_i             => rd_adr_d0(4 downto 2),
-      bwsel_a_i            => wr_sel_d0,
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -382,6 +402,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel_d0) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (aclk) begin
     if rising_edge(aclk) then
       if areset_n = '0' then
@@ -449,7 +484,21 @@ begin
       sub1_wb_adr_o <= rd_adr_d0(11 downto 2);
     end if;
   end process;
-  sub1_wb_sel_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
   sub1_wb_dat_o <= wr_dat_d0;
 
@@ -459,7 +508,21 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wr_dat_d0;
-  sub2_axi4_wstrb_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= rd_adr_d0(11 downto 2);
@@ -531,7 +594,21 @@ begin
       sub4_avalon_address_o <= rd_adr_d0(11 downto 2);
     end if;
   end process;
-  sub4_avalon_byteenable_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
   sub4_avalon_writedata_o <= wr_dat_d0;
@@ -569,7 +646,21 @@ begin
     end if;
   end process;
   sub5_apb_pwdata_o <= wr_dat_d0;
-  sub5_apb_pstrb_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
   process (wr_adr_d0, wr_req_d0, reg1_wack, reg2_wack, ram2_we, sub1_wb_wack,

--- a/testfiles/tb/golden_files/all1_axi4_none.vhdl
+++ b/testfiles/tb/golden_files/all1_axi4_none.vhdl
@@ -118,7 +118,7 @@ architecture syn of all1_axi4 is
   signal wr_ack                         : std_logic;
   signal wr_addr                        : std_logic_vector(14 downto 2);
   signal wr_data                        : std_logic_vector(31 downto 0);
-  signal wr_strb                        : std_logic_vector(3 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal axi_awset                      : std_logic;
   signal axi_wset                       : std_logic;
   signal axi_wdone                      : std_logic;
@@ -185,6 +185,8 @@ architecture syn of all1_axi4 is
   signal ram1_wr                        : std_logic;
   signal ram1_wreq                      : std_logic;
   signal ram1_adr_int                   : std_logic_vector(2 downto 0);
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
   signal ram2_wp                        : std_logic;
   signal ram2_we                        : std_logic;
 begin
@@ -209,7 +211,10 @@ begin
         end if;
         if wvalid = '1' and axi_wset = '0' then
           wr_data <= wdata;
-          wr_strb <= wstrb;
+          wr_sel(7 downto 0) <= (others => wstrb(0));
+          wr_sel(15 downto 8) <= (others => wstrb(1));
+          wr_sel(23 downto 16) <= (others => wstrb(2));
+          wr_sel(31 downto 24) <= (others => wstrb(3));
           axi_wset <= '1';
           wr_req <= axi_awset or awvalid;
         end if;
@@ -310,7 +315,7 @@ begin
       clk_a_i              => aclk,
       clk_b_i              => aclk,
       addr_a_i             => ram1_adr_int,
-      bwsel_a_i            => wr_strb,
+      bwsel_a_i            => ram1_sel_int,
       data_a_i             => wr_data,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
@@ -323,6 +328,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (aclk) begin
     if rising_edge(aclk) then
       if areset_n = '0' then
@@ -346,7 +366,7 @@ begin
       clk_a_i              => aclk,
       clk_b_i              => aclk,
       addr_a_i             => rd_addr(4 downto 2),
-      bwsel_a_i            => wr_strb,
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -359,6 +379,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (aclk) begin
     if rising_edge(aclk) then
       if areset_n = '0' then
@@ -426,7 +461,21 @@ begin
       sub1_wb_adr_o <= rd_addr(11 downto 2);
     end if;
   end process;
-  sub1_wb_sel_o <= wr_strb;
+  process (wr_sel) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
   sub1_wb_dat_o <= wr_data;
 
@@ -436,7 +485,21 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wr_data;
-  sub2_axi4_wstrb_o <= wr_strb;
+  process (wr_sel) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= rd_addr(11 downto 2);
@@ -508,7 +571,21 @@ begin
       sub4_avalon_address_o <= rd_addr(11 downto 2);
     end if;
   end process;
-  sub4_avalon_byteenable_o <= wr_strb;
+  process (wr_sel) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
   sub4_avalon_writedata_o <= wr_data;
@@ -546,7 +623,21 @@ begin
     end if;
   end process;
   sub5_apb_pwdata_o <= wr_data;
-  sub5_apb_pstrb_o <= wr_strb;
+  process (wr_sel) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
   process (wr_addr, wr_req, reg1_wack, reg2_wack, ram2_we, sub1_wb_wack,

--- a/testfiles/tb/golden_files/all1_axi4_out.vhdl
+++ b/testfiles/tb/golden_files/all1_axi4_out.vhdl
@@ -118,7 +118,7 @@ architecture syn of all1_axi4 is
   signal wr_ack                         : std_logic;
   signal wr_addr                        : std_logic_vector(14 downto 2);
   signal wr_data                        : std_logic_vector(31 downto 0);
-  signal wr_strb                        : std_logic_vector(3 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal axi_awset                      : std_logic;
   signal axi_wset                       : std_logic;
   signal axi_wdone                      : std_logic;
@@ -188,6 +188,8 @@ architecture syn of all1_axi4 is
   signal ram1_wr                        : std_logic;
   signal ram1_wreq                      : std_logic;
   signal ram1_adr_int                   : std_logic_vector(2 downto 0);
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
   signal ram2_wp                        : std_logic;
   signal ram2_we                        : std_logic;
 begin
@@ -212,7 +214,10 @@ begin
         end if;
         if wvalid = '1' and axi_wset = '0' then
           wr_data <= wdata;
-          wr_strb <= wstrb;
+          wr_sel(7 downto 0) <= (others => wstrb(0));
+          wr_sel(15 downto 8) <= (others => wstrb(1));
+          wr_sel(23 downto 16) <= (others => wstrb(2));
+          wr_sel(31 downto 24) <= (others => wstrb(3));
           axi_wset <= '1';
           wr_req <= axi_awset or awvalid;
         end if;
@@ -327,7 +332,7 @@ begin
       clk_a_i              => aclk,
       clk_b_i              => aclk,
       addr_a_i             => ram1_adr_int,
-      bwsel_a_i            => wr_strb,
+      bwsel_a_i            => ram1_sel_int,
       data_a_i             => wr_data,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
@@ -340,6 +345,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (aclk) begin
     if rising_edge(aclk) then
       if areset_n = '0' then
@@ -363,7 +383,7 @@ begin
       clk_a_i              => aclk,
       clk_b_i              => aclk,
       addr_a_i             => rd_addr(4 downto 2),
-      bwsel_a_i            => wr_strb,
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -376,6 +396,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (aclk) begin
     if rising_edge(aclk) then
       if areset_n = '0' then
@@ -443,7 +478,21 @@ begin
       sub1_wb_adr_o <= rd_addr(11 downto 2);
     end if;
   end process;
-  sub1_wb_sel_o <= wr_strb;
+  process (wr_sel) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
   sub1_wb_dat_o <= wr_data;
 
@@ -453,7 +502,21 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wr_data;
-  sub2_axi4_wstrb_o <= wr_strb;
+  process (wr_sel) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= rd_addr(11 downto 2);
@@ -525,7 +588,21 @@ begin
       sub4_avalon_address_o <= rd_addr(11 downto 2);
     end if;
   end process;
-  sub4_avalon_byteenable_o <= wr_strb;
+  process (wr_sel) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
   sub4_avalon_writedata_o <= wr_data;
@@ -563,7 +640,21 @@ begin
     end if;
   end process;
   sub5_apb_pwdata_o <= wr_data;
-  sub5_apb_pstrb_o <= wr_strb;
+  process (wr_sel) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
   process (wr_addr, wr_req, reg1_wack, reg2_wack, ram2_we, sub1_wb_wack,

--- a/testfiles/tb/golden_files/all1_axi4_rd-in,wr-out.vhdl
+++ b/testfiles/tb/golden_files/all1_axi4_rd-in,wr-out.vhdl
@@ -118,7 +118,7 @@ architecture syn of all1_axi4 is
   signal wr_ack                         : std_logic;
   signal wr_addr                        : std_logic_vector(14 downto 2);
   signal wr_data                        : std_logic_vector(31 downto 0);
-  signal wr_strb                        : std_logic_vector(3 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal axi_awset                      : std_logic;
   signal axi_wset                       : std_logic;
   signal axi_wdone                      : std_logic;
@@ -188,6 +188,8 @@ architecture syn of all1_axi4 is
   signal ram1_wr                        : std_logic;
   signal ram1_wreq                      : std_logic;
   signal ram1_adr_int                   : std_logic_vector(2 downto 0);
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
   signal ram2_wp                        : std_logic;
   signal ram2_we                        : std_logic;
 begin
@@ -212,7 +214,10 @@ begin
         end if;
         if wvalid = '1' and axi_wset = '0' then
           wr_data <= wdata;
-          wr_strb <= wstrb;
+          wr_sel(7 downto 0) <= (others => wstrb(0));
+          wr_sel(15 downto 8) <= (others => wstrb(1));
+          wr_sel(23 downto 16) <= (others => wstrb(2));
+          wr_sel(31 downto 24) <= (others => wstrb(3));
           axi_wset <= '1';
           wr_req <= axi_awset or awvalid;
         end if;
@@ -327,7 +332,7 @@ begin
       clk_a_i              => aclk,
       clk_b_i              => aclk,
       addr_a_i             => ram1_adr_int,
-      bwsel_a_i            => wr_strb,
+      bwsel_a_i            => ram1_sel_int,
       data_a_i             => wr_data,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
@@ -340,6 +345,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (aclk) begin
     if rising_edge(aclk) then
       if areset_n = '0' then
@@ -363,7 +383,7 @@ begin
       clk_a_i              => aclk,
       clk_b_i              => aclk,
       addr_a_i             => rd_adr_d0(4 downto 2),
-      bwsel_a_i            => wr_strb,
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -376,6 +396,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (aclk) begin
     if rising_edge(aclk) then
       if areset_n = '0' then
@@ -443,7 +478,21 @@ begin
       sub1_wb_adr_o <= rd_adr_d0(11 downto 2);
     end if;
   end process;
-  sub1_wb_sel_o <= wr_strb;
+  process (wr_sel) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
   sub1_wb_dat_o <= wr_data;
 
@@ -453,7 +502,21 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wr_data;
-  sub2_axi4_wstrb_o <= wr_strb;
+  process (wr_sel) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= rd_adr_d0(11 downto 2);
@@ -525,7 +588,21 @@ begin
       sub4_avalon_address_o <= rd_adr_d0(11 downto 2);
     end if;
   end process;
-  sub4_avalon_byteenable_o <= wr_strb;
+  process (wr_sel) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
   sub4_avalon_writedata_o <= wr_data;
@@ -563,7 +640,21 @@ begin
     end if;
   end process;
   sub5_apb_pwdata_o <= wr_data;
-  sub5_apb_pstrb_o <= wr_strb;
+  process (wr_sel) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
   process (wr_addr, wr_req, reg1_wack, reg2_wack, ram2_we, sub1_wb_wack,

--- a/testfiles/tb/golden_files/all1_axi4_rd-in.vhdl
+++ b/testfiles/tb/golden_files/all1_axi4_rd-in.vhdl
@@ -118,7 +118,7 @@ architecture syn of all1_axi4 is
   signal wr_ack                         : std_logic;
   signal wr_addr                        : std_logic_vector(14 downto 2);
   signal wr_data                        : std_logic_vector(31 downto 0);
-  signal wr_strb                        : std_logic_vector(3 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal axi_awset                      : std_logic;
   signal axi_wset                       : std_logic;
   signal axi_wdone                      : std_logic;
@@ -187,6 +187,8 @@ architecture syn of all1_axi4 is
   signal ram1_wr                        : std_logic;
   signal ram1_wreq                      : std_logic;
   signal ram1_adr_int                   : std_logic_vector(2 downto 0);
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
   signal ram2_wp                        : std_logic;
   signal ram2_we                        : std_logic;
 begin
@@ -211,7 +213,10 @@ begin
         end if;
         if wvalid = '1' and axi_wset = '0' then
           wr_data <= wdata;
-          wr_strb <= wstrb;
+          wr_sel(7 downto 0) <= (others => wstrb(0));
+          wr_sel(15 downto 8) <= (others => wstrb(1));
+          wr_sel(23 downto 16) <= (others => wstrb(2));
+          wr_sel(31 downto 24) <= (others => wstrb(3));
           axi_wset <= '1';
           wr_req <= axi_awset or awvalid;
         end if;
@@ -324,7 +329,7 @@ begin
       clk_a_i              => aclk,
       clk_b_i              => aclk,
       addr_a_i             => ram1_adr_int,
-      bwsel_a_i            => wr_strb,
+      bwsel_a_i            => ram1_sel_int,
       data_a_i             => wr_data,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
@@ -337,6 +342,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (aclk) begin
     if rising_edge(aclk) then
       if areset_n = '0' then
@@ -360,7 +380,7 @@ begin
       clk_a_i              => aclk,
       clk_b_i              => aclk,
       addr_a_i             => rd_adr_d0(4 downto 2),
-      bwsel_a_i            => wr_strb,
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -373,6 +393,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (aclk) begin
     if rising_edge(aclk) then
       if areset_n = '0' then
@@ -440,7 +475,21 @@ begin
       sub1_wb_adr_o <= rd_adr_d0(11 downto 2);
     end if;
   end process;
-  sub1_wb_sel_o <= wr_strb;
+  process (wr_sel) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
   sub1_wb_dat_o <= wr_data;
 
@@ -450,7 +499,21 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wr_data;
-  sub2_axi4_wstrb_o <= wr_strb;
+  process (wr_sel) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= rd_adr_d0(11 downto 2);
@@ -522,7 +585,21 @@ begin
       sub4_avalon_address_o <= rd_adr_d0(11 downto 2);
     end if;
   end process;
-  sub4_avalon_byteenable_o <= wr_strb;
+  process (wr_sel) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
   sub4_avalon_writedata_o <= wr_data;
@@ -560,7 +637,21 @@ begin
     end if;
   end process;
   sub5_apb_pwdata_o <= wr_data;
-  sub5_apb_pstrb_o <= wr_strb;
+  process (wr_sel) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
   process (wr_addr, wr_req, reg1_wack, reg2_wack, ram2_we, sub1_wb_wack,

--- a/testfiles/tb/golden_files/all1_axi4_rd-out.vhdl
+++ b/testfiles/tb/golden_files/all1_axi4_rd-out.vhdl
@@ -118,7 +118,7 @@ architecture syn of all1_axi4 is
   signal wr_ack                         : std_logic;
   signal wr_addr                        : std_logic_vector(14 downto 2);
   signal wr_data                        : std_logic_vector(31 downto 0);
-  signal wr_strb                        : std_logic_vector(3 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal axi_awset                      : std_logic;
   signal axi_wset                       : std_logic;
   signal axi_wdone                      : std_logic;
@@ -187,6 +187,8 @@ architecture syn of all1_axi4 is
   signal ram1_wr                        : std_logic;
   signal ram1_wreq                      : std_logic;
   signal ram1_adr_int                   : std_logic_vector(2 downto 0);
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
   signal ram2_wp                        : std_logic;
   signal ram2_we                        : std_logic;
 begin
@@ -211,7 +213,10 @@ begin
         end if;
         if wvalid = '1' and axi_wset = '0' then
           wr_data <= wdata;
-          wr_strb <= wstrb;
+          wr_sel(7 downto 0) <= (others => wstrb(0));
+          wr_sel(15 downto 8) <= (others => wstrb(1));
+          wr_sel(23 downto 16) <= (others => wstrb(2));
+          wr_sel(31 downto 24) <= (others => wstrb(3));
           axi_wset <= '1';
           wr_req <= axi_awset or awvalid;
         end if;
@@ -324,7 +329,7 @@ begin
       clk_a_i              => aclk,
       clk_b_i              => aclk,
       addr_a_i             => ram1_adr_int,
-      bwsel_a_i            => wr_strb,
+      bwsel_a_i            => ram1_sel_int,
       data_a_i             => wr_data,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
@@ -337,6 +342,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (aclk) begin
     if rising_edge(aclk) then
       if areset_n = '0' then
@@ -360,7 +380,7 @@ begin
       clk_a_i              => aclk,
       clk_b_i              => aclk,
       addr_a_i             => rd_addr(4 downto 2),
-      bwsel_a_i            => wr_strb,
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -373,6 +393,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (aclk) begin
     if rising_edge(aclk) then
       if areset_n = '0' then
@@ -440,7 +475,21 @@ begin
       sub1_wb_adr_o <= rd_addr(11 downto 2);
     end if;
   end process;
-  sub1_wb_sel_o <= wr_strb;
+  process (wr_sel) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
   sub1_wb_dat_o <= wr_data;
 
@@ -450,7 +499,21 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wr_data;
-  sub2_axi4_wstrb_o <= wr_strb;
+  process (wr_sel) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= rd_addr(11 downto 2);
@@ -522,7 +585,21 @@ begin
       sub4_avalon_address_o <= rd_addr(11 downto 2);
     end if;
   end process;
-  sub4_avalon_byteenable_o <= wr_strb;
+  process (wr_sel) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
   sub4_avalon_writedata_o <= wr_data;
@@ -560,7 +637,21 @@ begin
     end if;
   end process;
   sub5_apb_pwdata_o <= wr_data;
-  sub5_apb_pstrb_o <= wr_strb;
+  process (wr_sel) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
   process (wr_addr, wr_req, reg1_wack, reg2_wack, ram2_we, sub1_wb_wack,

--- a/testfiles/tb/golden_files/all1_axi4_rd.vhdl
+++ b/testfiles/tb/golden_files/all1_axi4_rd.vhdl
@@ -118,7 +118,7 @@ architecture syn of all1_axi4 is
   signal wr_ack                         : std_logic;
   signal wr_addr                        : std_logic_vector(14 downto 2);
   signal wr_data                        : std_logic_vector(31 downto 0);
-  signal wr_strb                        : std_logic_vector(3 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal axi_awset                      : std_logic;
   signal axi_wset                       : std_logic;
   signal axi_wdone                      : std_logic;
@@ -189,6 +189,8 @@ architecture syn of all1_axi4 is
   signal ram1_wr                        : std_logic;
   signal ram1_wreq                      : std_logic;
   signal ram1_adr_int                   : std_logic_vector(2 downto 0);
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
   signal ram2_wp                        : std_logic;
   signal ram2_we                        : std_logic;
 begin
@@ -213,7 +215,10 @@ begin
         end if;
         if wvalid = '1' and axi_wset = '0' then
           wr_data <= wdata;
-          wr_strb <= wstrb;
+          wr_sel(7 downto 0) <= (others => wstrb(0));
+          wr_sel(15 downto 8) <= (others => wstrb(1));
+          wr_sel(23 downto 16) <= (others => wstrb(2));
+          wr_sel(31 downto 24) <= (others => wstrb(3));
           axi_wset <= '1';
           wr_req <= axi_awset or awvalid;
         end if;
@@ -329,7 +334,7 @@ begin
       clk_a_i              => aclk,
       clk_b_i              => aclk,
       addr_a_i             => ram1_adr_int,
-      bwsel_a_i            => wr_strb,
+      bwsel_a_i            => ram1_sel_int,
       data_a_i             => wr_data,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
@@ -342,6 +347,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (aclk) begin
     if rising_edge(aclk) then
       if areset_n = '0' then
@@ -365,7 +385,7 @@ begin
       clk_a_i              => aclk,
       clk_b_i              => aclk,
       addr_a_i             => rd_adr_d0(4 downto 2),
-      bwsel_a_i            => wr_strb,
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -378,6 +398,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (aclk) begin
     if rising_edge(aclk) then
       if areset_n = '0' then
@@ -445,7 +480,21 @@ begin
       sub1_wb_adr_o <= rd_adr_d0(11 downto 2);
     end if;
   end process;
-  sub1_wb_sel_o <= wr_strb;
+  process (wr_sel) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
   sub1_wb_dat_o <= wr_data;
 
@@ -455,7 +504,21 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wr_data;
-  sub2_axi4_wstrb_o <= wr_strb;
+  process (wr_sel) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= rd_adr_d0(11 downto 2);
@@ -527,7 +590,21 @@ begin
       sub4_avalon_address_o <= rd_adr_d0(11 downto 2);
     end if;
   end process;
-  sub4_avalon_byteenable_o <= wr_strb;
+  process (wr_sel) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
   sub4_avalon_writedata_o <= wr_data;
@@ -565,7 +642,21 @@ begin
     end if;
   end process;
   sub5_apb_pwdata_o <= wr_data;
-  sub5_apb_pstrb_o <= wr_strb;
+  process (wr_sel) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
   process (wr_addr, wr_req, reg1_wack, reg2_wack, ram2_we, sub1_wb_wack,

--- a/testfiles/tb/golden_files/all1_axi4_wr-in,rd-out.vhdl
+++ b/testfiles/tb/golden_files/all1_axi4_wr-in,rd-out.vhdl
@@ -118,7 +118,7 @@ architecture syn of all1_axi4 is
   signal wr_ack                         : std_logic;
   signal wr_addr                        : std_logic_vector(14 downto 2);
   signal wr_data                        : std_logic_vector(31 downto 0);
-  signal wr_strb                        : std_logic_vector(3 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal axi_awset                      : std_logic;
   signal axi_wset                       : std_logic;
   signal axi_wdone                      : std_logic;
@@ -187,10 +187,12 @@ architecture syn of all1_axi4 is
   signal wr_req_d0                      : std_logic;
   signal wr_adr_d0                      : std_logic_vector(14 downto 2);
   signal wr_dat_d0                      : std_logic_vector(31 downto 0);
-  signal wr_sel_d0                      : std_logic_vector(3 downto 0);
+  signal wr_sel_d0                      : std_logic_vector(31 downto 0);
   signal ram1_wr                        : std_logic;
   signal ram1_wreq                      : std_logic;
   signal ram1_adr_int                   : std_logic_vector(2 downto 0);
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
   signal ram2_wp                        : std_logic;
   signal ram2_we                        : std_logic;
 begin
@@ -215,7 +217,10 @@ begin
         end if;
         if wvalid = '1' and axi_wset = '0' then
           wr_data <= wdata;
-          wr_strb <= wstrb;
+          wr_sel(7 downto 0) <= (others => wstrb(0));
+          wr_sel(15 downto 8) <= (others => wstrb(1));
+          wr_sel(23 downto 16) <= (others => wstrb(2));
+          wr_sel(31 downto 24) <= (others => wstrb(3));
           axi_wset <= '1';
           wr_req <= axi_awset or awvalid;
         end if;
@@ -274,7 +279,7 @@ begin
         wr_req_d0 <= wr_req;
         wr_adr_d0 <= wr_addr;
         wr_dat_d0 <= wr_data;
-        wr_sel_d0 <= wr_strb;
+        wr_sel_d0 <= wr_sel;
       end if;
     end if;
   end process;
@@ -333,7 +338,7 @@ begin
       clk_a_i              => aclk,
       clk_b_i              => aclk,
       addr_a_i             => ram1_adr_int,
-      bwsel_a_i            => wr_sel_d0,
+      bwsel_a_i            => ram1_sel_int,
       data_a_i             => wr_dat_d0,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
@@ -346,6 +351,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel_d0) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (aclk) begin
     if rising_edge(aclk) then
       if areset_n = '0' then
@@ -369,7 +389,7 @@ begin
       clk_a_i              => aclk,
       clk_b_i              => aclk,
       addr_a_i             => rd_addr(4 downto 2),
-      bwsel_a_i            => wr_sel_d0,
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -382,6 +402,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel_d0) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (aclk) begin
     if rising_edge(aclk) then
       if areset_n = '0' then
@@ -449,7 +484,21 @@ begin
       sub1_wb_adr_o <= rd_addr(11 downto 2);
     end if;
   end process;
-  sub1_wb_sel_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
   sub1_wb_dat_o <= wr_dat_d0;
 
@@ -459,7 +508,21 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wr_dat_d0;
-  sub2_axi4_wstrb_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= rd_addr(11 downto 2);
@@ -531,7 +594,21 @@ begin
       sub4_avalon_address_o <= rd_addr(11 downto 2);
     end if;
   end process;
-  sub4_avalon_byteenable_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
   sub4_avalon_writedata_o <= wr_dat_d0;
@@ -569,7 +646,21 @@ begin
     end if;
   end process;
   sub5_apb_pwdata_o <= wr_dat_d0;
-  sub5_apb_pstrb_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
   process (wr_adr_d0, wr_req_d0, reg1_wack, reg2_wack, ram2_we, sub1_wb_wack,

--- a/testfiles/tb/golden_files/all1_axi4_wr-in.vhdl
+++ b/testfiles/tb/golden_files/all1_axi4_wr-in.vhdl
@@ -118,7 +118,7 @@ architecture syn of all1_axi4 is
   signal wr_ack                         : std_logic;
   signal wr_addr                        : std_logic_vector(14 downto 2);
   signal wr_data                        : std_logic_vector(31 downto 0);
-  signal wr_strb                        : std_logic_vector(3 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal axi_awset                      : std_logic;
   signal axi_wset                       : std_logic;
   signal axi_wdone                      : std_logic;
@@ -185,10 +185,12 @@ architecture syn of all1_axi4 is
   signal wr_req_d0                      : std_logic;
   signal wr_adr_d0                      : std_logic_vector(14 downto 2);
   signal wr_dat_d0                      : std_logic_vector(31 downto 0);
-  signal wr_sel_d0                      : std_logic_vector(3 downto 0);
+  signal wr_sel_d0                      : std_logic_vector(31 downto 0);
   signal ram1_wr                        : std_logic;
   signal ram1_wreq                      : std_logic;
   signal ram1_adr_int                   : std_logic_vector(2 downto 0);
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
   signal ram2_wp                        : std_logic;
   signal ram2_we                        : std_logic;
 begin
@@ -213,7 +215,10 @@ begin
         end if;
         if wvalid = '1' and axi_wset = '0' then
           wr_data <= wdata;
-          wr_strb <= wstrb;
+          wr_sel(7 downto 0) <= (others => wstrb(0));
+          wr_sel(15 downto 8) <= (others => wstrb(1));
+          wr_sel(23 downto 16) <= (others => wstrb(2));
+          wr_sel(31 downto 24) <= (others => wstrb(3));
           axi_wset <= '1';
           wr_req <= axi_awset or awvalid;
         end if;
@@ -269,7 +274,7 @@ begin
         wr_req_d0 <= wr_req;
         wr_adr_d0 <= wr_addr;
         wr_dat_d0 <= wr_data;
-        wr_sel_d0 <= wr_strb;
+        wr_sel_d0 <= wr_sel;
       end if;
     end if;
   end process;
@@ -328,7 +333,7 @@ begin
       clk_a_i              => aclk,
       clk_b_i              => aclk,
       addr_a_i             => ram1_adr_int,
-      bwsel_a_i            => wr_sel_d0,
+      bwsel_a_i            => ram1_sel_int,
       data_a_i             => wr_dat_d0,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
@@ -341,6 +346,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel_d0) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (aclk) begin
     if rising_edge(aclk) then
       if areset_n = '0' then
@@ -364,7 +384,7 @@ begin
       clk_a_i              => aclk,
       clk_b_i              => aclk,
       addr_a_i             => rd_addr(4 downto 2),
-      bwsel_a_i            => wr_sel_d0,
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -377,6 +397,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel_d0) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (aclk) begin
     if rising_edge(aclk) then
       if areset_n = '0' then
@@ -444,7 +479,21 @@ begin
       sub1_wb_adr_o <= rd_addr(11 downto 2);
     end if;
   end process;
-  sub1_wb_sel_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
   sub1_wb_dat_o <= wr_dat_d0;
 
@@ -454,7 +503,21 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wr_dat_d0;
-  sub2_axi4_wstrb_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= rd_addr(11 downto 2);
@@ -526,7 +589,21 @@ begin
       sub4_avalon_address_o <= rd_addr(11 downto 2);
     end if;
   end process;
-  sub4_avalon_byteenable_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
   sub4_avalon_writedata_o <= wr_dat_d0;
@@ -564,7 +641,21 @@ begin
     end if;
   end process;
   sub5_apb_pwdata_o <= wr_dat_d0;
-  sub5_apb_pstrb_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
   process (wr_adr_d0, wr_req_d0, reg1_wack, reg2_wack, ram2_we, sub1_wb_wack,

--- a/testfiles/tb/golden_files/all1_axi4_wr-out.vhdl
+++ b/testfiles/tb/golden_files/all1_axi4_wr-out.vhdl
@@ -118,7 +118,7 @@ architecture syn of all1_axi4 is
   signal wr_ack                         : std_logic;
   signal wr_addr                        : std_logic_vector(14 downto 2);
   signal wr_data                        : std_logic_vector(31 downto 0);
-  signal wr_strb                        : std_logic_vector(3 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal axi_awset                      : std_logic;
   signal axi_wset                       : std_logic;
   signal axi_wdone                      : std_logic;
@@ -186,6 +186,8 @@ architecture syn of all1_axi4 is
   signal ram1_wr                        : std_logic;
   signal ram1_wreq                      : std_logic;
   signal ram1_adr_int                   : std_logic_vector(2 downto 0);
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
   signal ram2_wp                        : std_logic;
   signal ram2_we                        : std_logic;
 begin
@@ -210,7 +212,10 @@ begin
         end if;
         if wvalid = '1' and axi_wset = '0' then
           wr_data <= wdata;
-          wr_strb <= wstrb;
+          wr_sel(7 downto 0) <= (others => wstrb(0));
+          wr_sel(15 downto 8) <= (others => wstrb(1));
+          wr_sel(23 downto 16) <= (others => wstrb(2));
+          wr_sel(31 downto 24) <= (others => wstrb(3));
           axi_wset <= '1';
           wr_req <= axi_awset or awvalid;
         end if;
@@ -322,7 +327,7 @@ begin
       clk_a_i              => aclk,
       clk_b_i              => aclk,
       addr_a_i             => ram1_adr_int,
-      bwsel_a_i            => wr_strb,
+      bwsel_a_i            => ram1_sel_int,
       data_a_i             => wr_data,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
@@ -335,6 +340,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (aclk) begin
     if rising_edge(aclk) then
       if areset_n = '0' then
@@ -358,7 +378,7 @@ begin
       clk_a_i              => aclk,
       clk_b_i              => aclk,
       addr_a_i             => rd_addr(4 downto 2),
-      bwsel_a_i            => wr_strb,
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -371,6 +391,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (aclk) begin
     if rising_edge(aclk) then
       if areset_n = '0' then
@@ -438,7 +473,21 @@ begin
       sub1_wb_adr_o <= rd_addr(11 downto 2);
     end if;
   end process;
-  sub1_wb_sel_o <= wr_strb;
+  process (wr_sel) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
   sub1_wb_dat_o <= wr_data;
 
@@ -448,7 +497,21 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wr_data;
-  sub2_axi4_wstrb_o <= wr_strb;
+  process (wr_sel) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= rd_addr(11 downto 2);
@@ -520,7 +583,21 @@ begin
       sub4_avalon_address_o <= rd_addr(11 downto 2);
     end if;
   end process;
-  sub4_avalon_byteenable_o <= wr_strb;
+  process (wr_sel) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
   sub4_avalon_writedata_o <= wr_data;
@@ -558,7 +635,21 @@ begin
     end if;
   end process;
   sub5_apb_pwdata_o <= wr_data;
-  sub5_apb_pstrb_o <= wr_strb;
+  process (wr_sel) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
   process (wr_addr, wr_req, reg1_wack, reg2_wack, ram2_we, sub1_wb_wack,

--- a/testfiles/tb/golden_files/all1_axi4_wr.vhdl
+++ b/testfiles/tb/golden_files/all1_axi4_wr.vhdl
@@ -118,7 +118,7 @@ architecture syn of all1_axi4 is
   signal wr_ack                         : std_logic;
   signal wr_addr                        : std_logic_vector(14 downto 2);
   signal wr_data                        : std_logic_vector(31 downto 0);
-  signal wr_strb                        : std_logic_vector(3 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal axi_awset                      : std_logic;
   signal axi_wset                       : std_logic;
   signal axi_wdone                      : std_logic;
@@ -185,11 +185,13 @@ architecture syn of all1_axi4 is
   signal wr_req_d0                      : std_logic;
   signal wr_adr_d0                      : std_logic_vector(14 downto 2);
   signal wr_dat_d0                      : std_logic_vector(31 downto 0);
-  signal wr_sel_d0                      : std_logic_vector(3 downto 0);
+  signal wr_sel_d0                      : std_logic_vector(31 downto 0);
   signal wr_ack_d0                      : std_logic;
   signal ram1_wr                        : std_logic;
   signal ram1_wreq                      : std_logic;
   signal ram1_adr_int                   : std_logic_vector(2 downto 0);
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
   signal ram2_wp                        : std_logic;
   signal ram2_we                        : std_logic;
 begin
@@ -214,7 +216,10 @@ begin
         end if;
         if wvalid = '1' and axi_wset = '0' then
           wr_data <= wdata;
-          wr_strb <= wstrb;
+          wr_sel(7 downto 0) <= (others => wstrb(0));
+          wr_sel(15 downto 8) <= (others => wstrb(1));
+          wr_sel(23 downto 16) <= (others => wstrb(2));
+          wr_sel(31 downto 24) <= (others => wstrb(3));
           axi_wset <= '1';
           wr_req <= axi_awset or awvalid;
         end if;
@@ -271,7 +276,7 @@ begin
         wr_req_d0 <= wr_req;
         wr_adr_d0 <= wr_addr;
         wr_dat_d0 <= wr_data;
-        wr_sel_d0 <= wr_strb;
+        wr_sel_d0 <= wr_sel;
         wr_ack <= wr_ack_d0;
       end if;
     end if;
@@ -331,7 +336,7 @@ begin
       clk_a_i              => aclk,
       clk_b_i              => aclk,
       addr_a_i             => ram1_adr_int,
-      bwsel_a_i            => wr_sel_d0,
+      bwsel_a_i            => ram1_sel_int,
       data_a_i             => wr_dat_d0,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
@@ -344,6 +349,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel_d0) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (aclk) begin
     if rising_edge(aclk) then
       if areset_n = '0' then
@@ -367,7 +387,7 @@ begin
       clk_a_i              => aclk,
       clk_b_i              => aclk,
       addr_a_i             => rd_addr(4 downto 2),
-      bwsel_a_i            => wr_sel_d0,
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -380,6 +400,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel_d0) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (aclk) begin
     if rising_edge(aclk) then
       if areset_n = '0' then
@@ -447,7 +482,21 @@ begin
       sub1_wb_adr_o <= rd_addr(11 downto 2);
     end if;
   end process;
-  sub1_wb_sel_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
   sub1_wb_dat_o <= wr_dat_d0;
 
@@ -457,7 +506,21 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wr_dat_d0;
-  sub2_axi4_wstrb_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= rd_addr(11 downto 2);
@@ -529,7 +592,21 @@ begin
       sub4_avalon_address_o <= rd_addr(11 downto 2);
     end if;
   end process;
-  sub4_avalon_byteenable_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
   sub4_avalon_writedata_o <= wr_dat_d0;
@@ -567,7 +644,21 @@ begin
     end if;
   end process;
   sub5_apb_pwdata_o <= wr_dat_d0;
-  sub5_apb_pstrb_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
   process (wr_adr_d0, wr_req_d0, reg1_wack, reg2_wack, ram2_we, sub1_wb_wack,

--- a/testfiles/tb/golden_files/all1_wb_all.vhdl
+++ b/testfiles/tb/golden_files/all1_wb_all.vhdl
@@ -98,6 +98,7 @@ entity all1_wb is
 end all1_wb;
 
 architecture syn of all1_wb is
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal adr_int                        : std_logic_vector(14 downto 2);
   signal rd_req_int                     : std_logic;
   signal wr_req_int                     : std_logic;
@@ -154,11 +155,19 @@ architecture syn of all1_wb is
   signal rd_dat_d0                      : std_logic_vector(31 downto 0);
   signal wr_req_d0                      : std_logic;
   signal wr_dat_d0                      : std_logic_vector(31 downto 0);
-  signal wr_sel_d0                      : std_logic_vector(3 downto 0);
+  signal wr_sel_d0                      : std_logic_vector(31 downto 0);
   signal wr_ack_d0                      : std_logic;
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
 begin
 
   -- WB decode signals
+  process (wb_i.sel) begin
+    wr_sel(7 downto 0) <= (others => wb_i.sel(0));
+    wr_sel(15 downto 8) <= (others => wb_i.sel(1));
+    wr_sel(23 downto 16) <= (others => wb_i.sel(2));
+    wr_sel(31 downto 24) <= (others => wb_i.sel(3));
+  end process;
   adr_int <= wb_i.adr(14 downto 2);
   wb_en <= wb_i.cyc and wb_i.stb;
 
@@ -205,7 +214,7 @@ begin
         wb_o.dat <= rd_dat_d0;
         wr_req_d0 <= wr_req_int;
         wr_dat_d0 <= wb_i.dat;
-        wr_sel_d0 <= wb_i.sel;
+        wr_sel_d0 <= wr_sel;
         wr_ack_int <= wr_ack_d0;
       end if;
     end if;
@@ -256,7 +265,7 @@ begin
       clk_a_i              => clk_i,
       clk_b_i              => clk_i,
       addr_a_i             => rd_adr_d0(4 downto 2),
-      bwsel_a_i            => wr_sel_d0,
+      bwsel_a_i            => ram1_sel_int,
       data_a_i             => wr_dat_d0,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
@@ -269,6 +278,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel_d0) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk_i) begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
@@ -292,7 +316,7 @@ begin
       clk_a_i              => clk_i,
       clk_b_i              => clk_i,
       addr_a_i             => rd_adr_d0(4 downto 2),
-      bwsel_a_i            => wr_sel_d0,
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -305,6 +329,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel_d0) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk_i) begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
@@ -346,7 +385,21 @@ begin
   sub1_wb_wack <= sub1_wb_ack_i and sub1_wb_wt;
   sub1_wb_rack <= sub1_wb_ack_i and sub1_wb_rt;
   sub1_wb_adr_o <= rd_adr_d0(11 downto 2);
-  sub1_wb_sel_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
   sub1_wb_dat_o <= wr_dat_d0;
 
@@ -356,7 +409,21 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wr_dat_d0;
-  sub2_axi4_wstrb_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= rd_adr_d0(11 downto 2);
@@ -393,7 +460,21 @@ begin
     end if;
   end process;
   sub4_avalon_address_o <= rd_adr_d0(11 downto 2);
-  sub4_avalon_byteenable_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
   sub4_avalon_writedata_o <= wr_dat_d0;
@@ -431,7 +512,21 @@ begin
     end if;
   end process;
   sub5_apb_pwdata_o <= wr_dat_d0;
-  sub5_apb_pstrb_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
   process (rd_adr_d0, wr_req_d0, reg1_wack, reg2_wack, sub1_wb_wack,

--- a/testfiles/tb/golden_files/all1_wb_in,out.vhdl
+++ b/testfiles/tb/golden_files/all1_wb_in,out.vhdl
@@ -98,6 +98,7 @@ entity all1_wb is
 end all1_wb;
 
 architecture syn of all1_wb is
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal adr_int                        : std_logic_vector(14 downto 2);
   signal rd_req_int                     : std_logic;
   signal wr_req_int                     : std_logic;
@@ -154,11 +155,19 @@ architecture syn of all1_wb is
   signal rd_dat_d0                      : std_logic_vector(31 downto 0);
   signal wr_req_d0                      : std_logic;
   signal wr_dat_d0                      : std_logic_vector(31 downto 0);
-  signal wr_sel_d0                      : std_logic_vector(3 downto 0);
+  signal wr_sel_d0                      : std_logic_vector(31 downto 0);
   signal wr_ack_d0                      : std_logic;
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
 begin
 
   -- WB decode signals
+  process (wb_i.sel) begin
+    wr_sel(7 downto 0) <= (others => wb_i.sel(0));
+    wr_sel(15 downto 8) <= (others => wb_i.sel(1));
+    wr_sel(23 downto 16) <= (others => wb_i.sel(2));
+    wr_sel(31 downto 24) <= (others => wb_i.sel(3));
+  end process;
   adr_int <= wb_i.adr(14 downto 2);
   wb_en <= wb_i.cyc and wb_i.stb;
 
@@ -205,7 +214,7 @@ begin
         wb_o.dat <= rd_dat_d0;
         wr_req_d0 <= wr_req_int;
         wr_dat_d0 <= wb_i.dat;
-        wr_sel_d0 <= wb_i.sel;
+        wr_sel_d0 <= wr_sel;
         wr_ack_int <= wr_ack_d0;
       end if;
     end if;
@@ -256,7 +265,7 @@ begin
       clk_a_i              => clk_i,
       clk_b_i              => clk_i,
       addr_a_i             => rd_adr_d0(4 downto 2),
-      bwsel_a_i            => wr_sel_d0,
+      bwsel_a_i            => ram1_sel_int,
       data_a_i             => wr_dat_d0,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
@@ -269,6 +278,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel_d0) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk_i) begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
@@ -292,7 +316,7 @@ begin
       clk_a_i              => clk_i,
       clk_b_i              => clk_i,
       addr_a_i             => rd_adr_d0(4 downto 2),
-      bwsel_a_i            => wr_sel_d0,
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -305,6 +329,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel_d0) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk_i) begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
@@ -346,7 +385,21 @@ begin
   sub1_wb_wack <= sub1_wb_ack_i and sub1_wb_wt;
   sub1_wb_rack <= sub1_wb_ack_i and sub1_wb_rt;
   sub1_wb_adr_o <= rd_adr_d0(11 downto 2);
-  sub1_wb_sel_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
   sub1_wb_dat_o <= wr_dat_d0;
 
@@ -356,7 +409,21 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wr_dat_d0;
-  sub2_axi4_wstrb_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= rd_adr_d0(11 downto 2);
@@ -393,7 +460,21 @@ begin
     end if;
   end process;
   sub4_avalon_address_o <= rd_adr_d0(11 downto 2);
-  sub4_avalon_byteenable_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
   sub4_avalon_writedata_o <= wr_dat_d0;
@@ -431,7 +512,21 @@ begin
     end if;
   end process;
   sub5_apb_pwdata_o <= wr_dat_d0;
-  sub5_apb_pstrb_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
   process (rd_adr_d0, wr_req_d0, reg1_wack, reg2_wack, sub1_wb_wack,

--- a/testfiles/tb/golden_files/all1_wb_in.vhdl
+++ b/testfiles/tb/golden_files/all1_wb_in.vhdl
@@ -98,6 +98,7 @@ entity all1_wb is
 end all1_wb;
 
 architecture syn of all1_wb is
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal adr_int                        : std_logic_vector(14 downto 2);
   signal rd_req_int                     : std_logic;
   signal wr_req_int                     : std_logic;
@@ -152,10 +153,18 @@ architecture syn of all1_wb is
   signal rd_adr_d0                      : std_logic_vector(14 downto 2);
   signal wr_req_d0                      : std_logic;
   signal wr_dat_d0                      : std_logic_vector(31 downto 0);
-  signal wr_sel_d0                      : std_logic_vector(3 downto 0);
+  signal wr_sel_d0                      : std_logic_vector(31 downto 0);
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
 begin
 
   -- WB decode signals
+  process (wb_i.sel) begin
+    wr_sel(7 downto 0) <= (others => wb_i.sel(0));
+    wr_sel(15 downto 8) <= (others => wb_i.sel(1));
+    wr_sel(23 downto 16) <= (others => wb_i.sel(2));
+    wr_sel(31 downto 24) <= (others => wb_i.sel(3));
+  end process;
   adr_int <= wb_i.adr(14 downto 2);
   wb_en <= wb_i.cyc and wb_i.stb;
 
@@ -198,7 +207,7 @@ begin
         rd_adr_d0 <= adr_int;
         wr_req_d0 <= wr_req_int;
         wr_dat_d0 <= wb_i.dat;
-        wr_sel_d0 <= wb_i.sel;
+        wr_sel_d0 <= wr_sel;
       end if;
     end if;
   end process;
@@ -248,7 +257,7 @@ begin
       clk_a_i              => clk_i,
       clk_b_i              => clk_i,
       addr_a_i             => rd_adr_d0(4 downto 2),
-      bwsel_a_i            => wr_sel_d0,
+      bwsel_a_i            => ram1_sel_int,
       data_a_i             => wr_dat_d0,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
@@ -261,6 +270,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel_d0) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk_i) begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
@@ -284,7 +308,7 @@ begin
       clk_a_i              => clk_i,
       clk_b_i              => clk_i,
       addr_a_i             => rd_adr_d0(4 downto 2),
-      bwsel_a_i            => wr_sel_d0,
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -297,6 +321,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel_d0) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk_i) begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
@@ -338,7 +377,21 @@ begin
   sub1_wb_wack <= sub1_wb_ack_i and sub1_wb_wt;
   sub1_wb_rack <= sub1_wb_ack_i and sub1_wb_rt;
   sub1_wb_adr_o <= rd_adr_d0(11 downto 2);
-  sub1_wb_sel_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
   sub1_wb_dat_o <= wr_dat_d0;
 
@@ -348,7 +401,21 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wr_dat_d0;
-  sub2_axi4_wstrb_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= rd_adr_d0(11 downto 2);
@@ -385,7 +452,21 @@ begin
     end if;
   end process;
   sub4_avalon_address_o <= rd_adr_d0(11 downto 2);
-  sub4_avalon_byteenable_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
   sub4_avalon_writedata_o <= wr_dat_d0;
@@ -423,7 +504,21 @@ begin
     end if;
   end process;
   sub5_apb_pwdata_o <= wr_dat_d0;
-  sub5_apb_pstrb_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
   process (rd_adr_d0, wr_req_d0, reg1_wack, reg2_wack, sub1_wb_wack,

--- a/testfiles/tb/golden_files/all1_wb_none.vhdl
+++ b/testfiles/tb/golden_files/all1_wb_none.vhdl
@@ -98,6 +98,7 @@ entity all1_wb is
 end all1_wb;
 
 architecture syn of all1_wb is
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal adr_int                        : std_logic_vector(14 downto 2);
   signal rd_req_int                     : std_logic;
   signal wr_req_int                     : std_logic;
@@ -148,9 +149,17 @@ architecture syn of all1_wb is
   signal sub5_apb_rd_ack                : std_logic;
   signal sub5_apb_rd                    : std_logic;
   signal sub5_apb_rd_reg                : std_logic;
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
 begin
 
   -- WB decode signals
+  process (wb_i.sel) begin
+    wr_sel(7 downto 0) <= (others => wb_i.sel(0));
+    wr_sel(15 downto 8) <= (others => wb_i.sel(1));
+    wr_sel(23 downto 16) <= (others => wb_i.sel(2));
+    wr_sel(31 downto 24) <= (others => wb_i.sel(3));
+  end process;
   adr_int <= wb_i.adr(14 downto 2);
   wb_en <= wb_i.cyc and wb_i.stb;
 
@@ -227,7 +236,7 @@ begin
       clk_a_i              => clk_i,
       clk_b_i              => clk_i,
       addr_a_i             => adr_int(4 downto 2),
-      bwsel_a_i            => wb_i.sel,
+      bwsel_a_i            => ram1_sel_int,
       data_a_i             => wb_i.dat,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
@@ -240,6 +249,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk_i) begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
@@ -263,7 +287,7 @@ begin
       clk_a_i              => clk_i,
       clk_b_i              => clk_i,
       addr_a_i             => adr_int(4 downto 2),
-      bwsel_a_i            => wb_i.sel,
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -276,6 +300,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk_i) begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
@@ -317,7 +356,21 @@ begin
   sub1_wb_wack <= sub1_wb_ack_i and sub1_wb_wt;
   sub1_wb_rack <= sub1_wb_ack_i and sub1_wb_rt;
   sub1_wb_adr_o <= adr_int(11 downto 2);
-  sub1_wb_sel_o <= wb_i.sel;
+  process (wr_sel) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
   sub1_wb_dat_o <= wb_i.dat;
 
@@ -327,7 +380,21 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wb_i.dat;
-  sub2_axi4_wstrb_o <= wb_i.sel;
+  process (wr_sel) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= adr_int(11 downto 2);
@@ -364,7 +431,21 @@ begin
     end if;
   end process;
   sub4_avalon_address_o <= adr_int(11 downto 2);
-  sub4_avalon_byteenable_o <= wb_i.sel;
+  process (wr_sel) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
   sub4_avalon_writedata_o <= wb_i.dat;
@@ -402,7 +483,21 @@ begin
     end if;
   end process;
   sub5_apb_pwdata_o <= wb_i.dat;
-  sub5_apb_pstrb_o <= wb_i.sel;
+  process (wr_sel) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
   process (adr_int, wr_req_int, reg1_wack, reg2_wack, sub1_wb_wack,

--- a/testfiles/tb/golden_files/all1_wb_out.vhdl
+++ b/testfiles/tb/golden_files/all1_wb_out.vhdl
@@ -98,6 +98,7 @@ entity all1_wb is
 end all1_wb;
 
 architecture syn of all1_wb is
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal adr_int                        : std_logic_vector(14 downto 2);
   signal rd_req_int                     : std_logic;
   signal wr_req_int                     : std_logic;
@@ -151,9 +152,17 @@ architecture syn of all1_wb is
   signal rd_ack_d0                      : std_logic;
   signal rd_dat_d0                      : std_logic_vector(31 downto 0);
   signal wr_ack_d0                      : std_logic;
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
 begin
 
   -- WB decode signals
+  process (wb_i.sel) begin
+    wr_sel(7 downto 0) <= (others => wb_i.sel(0));
+    wr_sel(15 downto 8) <= (others => wb_i.sel(1));
+    wr_sel(23 downto 16) <= (others => wb_i.sel(2));
+    wr_sel(31 downto 24) <= (others => wb_i.sel(3));
+  end process;
   adr_int <= wb_i.adr(14 downto 2);
   wb_en <= wb_i.cyc and wb_i.stb;
 
@@ -244,7 +253,7 @@ begin
       clk_a_i              => clk_i,
       clk_b_i              => clk_i,
       addr_a_i             => adr_int(4 downto 2),
-      bwsel_a_i            => wb_i.sel,
+      bwsel_a_i            => ram1_sel_int,
       data_a_i             => wb_i.dat,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
@@ -257,6 +266,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk_i) begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
@@ -280,7 +304,7 @@ begin
       clk_a_i              => clk_i,
       clk_b_i              => clk_i,
       addr_a_i             => adr_int(4 downto 2),
-      bwsel_a_i            => wb_i.sel,
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -293,6 +317,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk_i) begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
@@ -334,7 +373,21 @@ begin
   sub1_wb_wack <= sub1_wb_ack_i and sub1_wb_wt;
   sub1_wb_rack <= sub1_wb_ack_i and sub1_wb_rt;
   sub1_wb_adr_o <= adr_int(11 downto 2);
-  sub1_wb_sel_o <= wb_i.sel;
+  process (wr_sel) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
   sub1_wb_dat_o <= wb_i.dat;
 
@@ -344,7 +397,21 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wb_i.dat;
-  sub2_axi4_wstrb_o <= wb_i.sel;
+  process (wr_sel) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= adr_int(11 downto 2);
@@ -381,7 +448,21 @@ begin
     end if;
   end process;
   sub4_avalon_address_o <= adr_int(11 downto 2);
-  sub4_avalon_byteenable_o <= wb_i.sel;
+  process (wr_sel) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
   sub4_avalon_writedata_o <= wb_i.dat;
@@ -419,7 +500,21 @@ begin
     end if;
   end process;
   sub5_apb_pwdata_o <= wb_i.dat;
-  sub5_apb_pstrb_o <= wb_i.sel;
+  process (wr_sel) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
   process (adr_int, wr_req_int, reg1_wack, reg2_wack, sub1_wb_wack,

--- a/testfiles/tb/golden_files/all1_wb_rd-in,wr-out.vhdl
+++ b/testfiles/tb/golden_files/all1_wb_rd-in,wr-out.vhdl
@@ -98,6 +98,7 @@ entity all1_wb is
 end all1_wb;
 
 architecture syn of all1_wb is
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal adr_int                        : std_logic_vector(14 downto 2);
   signal rd_req_int                     : std_logic;
   signal wr_req_int                     : std_logic;
@@ -154,6 +155,8 @@ architecture syn of all1_wb is
   signal ram1_wr                        : std_logic;
   signal ram1_wreq                      : std_logic;
   signal ram1_adr_int                   : std_logic_vector(2 downto 0);
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
   signal ram2_wp                        : std_logic;
   signal ram2_we                        : std_logic;
   signal sub3_cernbe_ws                 : std_logic;
@@ -161,6 +164,12 @@ architecture syn of all1_wb is
 begin
 
   -- WB decode signals
+  process (wb_i.sel) begin
+    wr_sel(7 downto 0) <= (others => wb_i.sel(0));
+    wr_sel(15 downto 8) <= (others => wb_i.sel(1));
+    wr_sel(23 downto 16) <= (others => wb_i.sel(2));
+    wr_sel(31 downto 24) <= (others => wb_i.sel(3));
+  end process;
   adr_int <= wb_i.adr(14 downto 2);
   wb_en <= wb_i.cyc and wb_i.stb;
 
@@ -260,7 +269,7 @@ begin
       clk_a_i              => clk_i,
       clk_b_i              => clk_i,
       addr_a_i             => ram1_adr_int,
-      bwsel_a_i            => wb_i.sel,
+      bwsel_a_i            => ram1_sel_int,
       data_a_i             => wb_i.dat,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
@@ -273,6 +282,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk_i) begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
@@ -296,7 +320,7 @@ begin
       clk_a_i              => clk_i,
       clk_b_i              => clk_i,
       addr_a_i             => rd_adr_d0(4 downto 2),
-      bwsel_a_i            => wb_i.sel,
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -309,6 +333,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk_i) begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
@@ -366,7 +405,21 @@ begin
   sub1_wb_wack <= sub1_wb_ack_i and sub1_wb_wt;
   sub1_wb_rack <= sub1_wb_ack_i and sub1_wb_rt;
   sub1_wb_adr_o <= rd_adr_d0(11 downto 2);
-  sub1_wb_sel_o <= wb_i.sel;
+  process (wr_sel) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
   sub1_wb_dat_o <= wb_i.dat;
 
@@ -376,7 +429,21 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wb_i.dat;
-  sub2_axi4_wstrb_o <= wb_i.sel;
+  process (wr_sel) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= rd_adr_d0(11 downto 2);
@@ -429,7 +496,21 @@ begin
     end if;
   end process;
   sub4_avalon_address_o <= rd_adr_d0(11 downto 2);
-  sub4_avalon_byteenable_o <= wb_i.sel;
+  process (wr_sel) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
   sub4_avalon_writedata_o <= wb_i.dat;
@@ -467,7 +548,21 @@ begin
     end if;
   end process;
   sub5_apb_pwdata_o <= wb_i.dat;
-  sub5_apb_pstrb_o <= wb_i.sel;
+  process (wr_sel) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
   process (adr_int, wr_req_int, reg1_wack, reg2_wack, ram2_we, sub1_wb_wack,

--- a/testfiles/tb/golden_files/all1_wb_rd-in.vhdl
+++ b/testfiles/tb/golden_files/all1_wb_rd-in.vhdl
@@ -98,6 +98,7 @@ entity all1_wb is
 end all1_wb;
 
 architecture syn of all1_wb is
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal adr_int                        : std_logic_vector(14 downto 2);
   signal rd_req_int                     : std_logic;
   signal wr_req_int                     : std_logic;
@@ -153,6 +154,8 @@ architecture syn of all1_wb is
   signal ram1_wr                        : std_logic;
   signal ram1_wreq                      : std_logic;
   signal ram1_adr_int                   : std_logic_vector(2 downto 0);
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
   signal ram2_wp                        : std_logic;
   signal ram2_we                        : std_logic;
   signal sub3_cernbe_ws                 : std_logic;
@@ -160,6 +163,12 @@ architecture syn of all1_wb is
 begin
 
   -- WB decode signals
+  process (wb_i.sel) begin
+    wr_sel(7 downto 0) <= (others => wb_i.sel(0));
+    wr_sel(15 downto 8) <= (others => wb_i.sel(1));
+    wr_sel(23 downto 16) <= (others => wb_i.sel(2));
+    wr_sel(31 downto 24) <= (others => wb_i.sel(3));
+  end process;
   adr_int <= wb_i.adr(14 downto 2);
   wb_en <= wb_i.cyc and wb_i.stb;
 
@@ -257,7 +266,7 @@ begin
       clk_a_i              => clk_i,
       clk_b_i              => clk_i,
       addr_a_i             => ram1_adr_int,
-      bwsel_a_i            => wb_i.sel,
+      bwsel_a_i            => ram1_sel_int,
       data_a_i             => wb_i.dat,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
@@ -270,6 +279,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk_i) begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
@@ -293,7 +317,7 @@ begin
       clk_a_i              => clk_i,
       clk_b_i              => clk_i,
       addr_a_i             => rd_adr_d0(4 downto 2),
-      bwsel_a_i            => wb_i.sel,
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -306,6 +330,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk_i) begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
@@ -363,7 +402,21 @@ begin
   sub1_wb_wack <= sub1_wb_ack_i and sub1_wb_wt;
   sub1_wb_rack <= sub1_wb_ack_i and sub1_wb_rt;
   sub1_wb_adr_o <= rd_adr_d0(11 downto 2);
-  sub1_wb_sel_o <= wb_i.sel;
+  process (wr_sel) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
   sub1_wb_dat_o <= wb_i.dat;
 
@@ -373,7 +426,21 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wb_i.dat;
-  sub2_axi4_wstrb_o <= wb_i.sel;
+  process (wr_sel) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= rd_adr_d0(11 downto 2);
@@ -426,7 +493,21 @@ begin
     end if;
   end process;
   sub4_avalon_address_o <= rd_adr_d0(11 downto 2);
-  sub4_avalon_byteenable_o <= wb_i.sel;
+  process (wr_sel) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
   sub4_avalon_writedata_o <= wb_i.dat;
@@ -464,7 +545,21 @@ begin
     end if;
   end process;
   sub5_apb_pwdata_o <= wb_i.dat;
-  sub5_apb_pstrb_o <= wb_i.sel;
+  process (wr_sel) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
   process (adr_int, wr_req_int, reg1_wack, reg2_wack, ram2_we, sub1_wb_wack,

--- a/testfiles/tb/golden_files/all1_wb_rd-out.vhdl
+++ b/testfiles/tb/golden_files/all1_wb_rd-out.vhdl
@@ -98,6 +98,7 @@ entity all1_wb is
 end all1_wb;
 
 architecture syn of all1_wb is
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal adr_int                        : std_logic_vector(14 downto 2);
   signal rd_req_int                     : std_logic;
   signal wr_req_int                     : std_logic;
@@ -150,9 +151,17 @@ architecture syn of all1_wb is
   signal sub5_apb_rd_reg                : std_logic;
   signal rd_ack_d0                      : std_logic;
   signal rd_dat_d0                      : std_logic_vector(31 downto 0);
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
 begin
 
   -- WB decode signals
+  process (wb_i.sel) begin
+    wr_sel(7 downto 0) <= (others => wb_i.sel(0));
+    wr_sel(15 downto 8) <= (others => wb_i.sel(1));
+    wr_sel(23 downto 16) <= (others => wb_i.sel(2));
+    wr_sel(31 downto 24) <= (others => wb_i.sel(3));
+  end process;
   adr_int <= wb_i.adr(14 downto 2);
   wb_en <= wb_i.cyc and wb_i.stb;
 
@@ -241,7 +250,7 @@ begin
       clk_a_i              => clk_i,
       clk_b_i              => clk_i,
       addr_a_i             => adr_int(4 downto 2),
-      bwsel_a_i            => wb_i.sel,
+      bwsel_a_i            => ram1_sel_int,
       data_a_i             => wb_i.dat,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
@@ -254,6 +263,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk_i) begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
@@ -277,7 +301,7 @@ begin
       clk_a_i              => clk_i,
       clk_b_i              => clk_i,
       addr_a_i             => adr_int(4 downto 2),
-      bwsel_a_i            => wb_i.sel,
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -290,6 +314,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk_i) begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
@@ -331,7 +370,21 @@ begin
   sub1_wb_wack <= sub1_wb_ack_i and sub1_wb_wt;
   sub1_wb_rack <= sub1_wb_ack_i and sub1_wb_rt;
   sub1_wb_adr_o <= adr_int(11 downto 2);
-  sub1_wb_sel_o <= wb_i.sel;
+  process (wr_sel) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
   sub1_wb_dat_o <= wb_i.dat;
 
@@ -341,7 +394,21 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wb_i.dat;
-  sub2_axi4_wstrb_o <= wb_i.sel;
+  process (wr_sel) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= adr_int(11 downto 2);
@@ -378,7 +445,21 @@ begin
     end if;
   end process;
   sub4_avalon_address_o <= adr_int(11 downto 2);
-  sub4_avalon_byteenable_o <= wb_i.sel;
+  process (wr_sel) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
   sub4_avalon_writedata_o <= wb_i.dat;
@@ -416,7 +497,21 @@ begin
     end if;
   end process;
   sub5_apb_pwdata_o <= wb_i.dat;
-  sub5_apb_pstrb_o <= wb_i.sel;
+  process (wr_sel) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
   process (adr_int, wr_req_int, reg1_wack, reg2_wack, sub1_wb_wack,

--- a/testfiles/tb/golden_files/all1_wb_rd.vhdl
+++ b/testfiles/tb/golden_files/all1_wb_rd.vhdl
@@ -98,6 +98,7 @@ entity all1_wb is
 end all1_wb;
 
 architecture syn of all1_wb is
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal adr_int                        : std_logic_vector(14 downto 2);
   signal rd_req_int                     : std_logic;
   signal wr_req_int                     : std_logic;
@@ -155,6 +156,8 @@ architecture syn of all1_wb is
   signal ram1_wr                        : std_logic;
   signal ram1_wreq                      : std_logic;
   signal ram1_adr_int                   : std_logic_vector(2 downto 0);
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
   signal ram2_wp                        : std_logic;
   signal ram2_we                        : std_logic;
   signal sub3_cernbe_ws                 : std_logic;
@@ -162,6 +165,12 @@ architecture syn of all1_wb is
 begin
 
   -- WB decode signals
+  process (wb_i.sel) begin
+    wr_sel(7 downto 0) <= (others => wb_i.sel(0));
+    wr_sel(15 downto 8) <= (others => wb_i.sel(1));
+    wr_sel(23 downto 16) <= (others => wb_i.sel(2));
+    wr_sel(31 downto 24) <= (others => wb_i.sel(3));
+  end process;
   adr_int <= wb_i.adr(14 downto 2);
   wb_en <= wb_i.cyc and wb_i.stb;
 
@@ -262,7 +271,7 @@ begin
       clk_a_i              => clk_i,
       clk_b_i              => clk_i,
       addr_a_i             => ram1_adr_int,
-      bwsel_a_i            => wb_i.sel,
+      bwsel_a_i            => ram1_sel_int,
       data_a_i             => wb_i.dat,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
@@ -275,6 +284,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk_i) begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
@@ -298,7 +322,7 @@ begin
       clk_a_i              => clk_i,
       clk_b_i              => clk_i,
       addr_a_i             => rd_adr_d0(4 downto 2),
-      bwsel_a_i            => wb_i.sel,
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -311,6 +335,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk_i) begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
@@ -368,7 +407,21 @@ begin
   sub1_wb_wack <= sub1_wb_ack_i and sub1_wb_wt;
   sub1_wb_rack <= sub1_wb_ack_i and sub1_wb_rt;
   sub1_wb_adr_o <= rd_adr_d0(11 downto 2);
-  sub1_wb_sel_o <= wb_i.sel;
+  process (wr_sel) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
   sub1_wb_dat_o <= wb_i.dat;
 
@@ -378,7 +431,21 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wb_i.dat;
-  sub2_axi4_wstrb_o <= wb_i.sel;
+  process (wr_sel) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= rd_adr_d0(11 downto 2);
@@ -431,7 +498,21 @@ begin
     end if;
   end process;
   sub4_avalon_address_o <= rd_adr_d0(11 downto 2);
-  sub4_avalon_byteenable_o <= wb_i.sel;
+  process (wr_sel) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
   sub4_avalon_writedata_o <= wb_i.dat;
@@ -469,7 +550,21 @@ begin
     end if;
   end process;
   sub5_apb_pwdata_o <= wb_i.dat;
-  sub5_apb_pstrb_o <= wb_i.sel;
+  process (wr_sel) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
   process (adr_int, wr_req_int, reg1_wack, reg2_wack, ram2_we, sub1_wb_wack,

--- a/testfiles/tb/golden_files/all1_wb_wr-in,rd-out.vhdl
+++ b/testfiles/tb/golden_files/all1_wb_wr-in,rd-out.vhdl
@@ -98,6 +98,7 @@ entity all1_wb is
 end all1_wb;
 
 architecture syn of all1_wb is
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal adr_int                        : std_logic_vector(14 downto 2);
   signal rd_req_int                     : std_logic;
   signal wr_req_int                     : std_logic;
@@ -153,10 +154,12 @@ architecture syn of all1_wb is
   signal wr_req_d0                      : std_logic;
   signal wr_adr_d0                      : std_logic_vector(14 downto 2);
   signal wr_dat_d0                      : std_logic_vector(31 downto 0);
-  signal wr_sel_d0                      : std_logic_vector(3 downto 0);
+  signal wr_sel_d0                      : std_logic_vector(31 downto 0);
   signal ram1_wr                        : std_logic;
   signal ram1_wreq                      : std_logic;
   signal ram1_adr_int                   : std_logic_vector(2 downto 0);
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
   signal ram2_wp                        : std_logic;
   signal ram2_we                        : std_logic;
   signal sub3_cernbe_ws                 : std_logic;
@@ -164,6 +167,12 @@ architecture syn of all1_wb is
 begin
 
   -- WB decode signals
+  process (wb_i.sel) begin
+    wr_sel(7 downto 0) <= (others => wb_i.sel(0));
+    wr_sel(15 downto 8) <= (others => wb_i.sel(1));
+    wr_sel(23 downto 16) <= (others => wb_i.sel(2));
+    wr_sel(31 downto 24) <= (others => wb_i.sel(3));
+  end process;
   adr_int <= wb_i.adr(14 downto 2);
   wb_en <= wb_i.cyc and wb_i.stb;
 
@@ -207,7 +216,7 @@ begin
         wr_req_d0 <= wr_req_int;
         wr_adr_d0 <= adr_int;
         wr_dat_d0 <= wb_i.dat;
-        wr_sel_d0 <= wb_i.sel;
+        wr_sel_d0 <= wr_sel;
       end if;
     end if;
   end process;
@@ -266,7 +275,7 @@ begin
       clk_a_i              => clk_i,
       clk_b_i              => clk_i,
       addr_a_i             => ram1_adr_int,
-      bwsel_a_i            => wr_sel_d0,
+      bwsel_a_i            => ram1_sel_int,
       data_a_i             => wr_dat_d0,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
@@ -279,6 +288,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel_d0) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk_i) begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
@@ -302,7 +326,7 @@ begin
       clk_a_i              => clk_i,
       clk_b_i              => clk_i,
       addr_a_i             => adr_int(4 downto 2),
-      bwsel_a_i            => wr_sel_d0,
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -315,6 +339,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel_d0) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk_i) begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
@@ -372,7 +411,21 @@ begin
   sub1_wb_wack <= sub1_wb_ack_i and sub1_wb_wt;
   sub1_wb_rack <= sub1_wb_ack_i and sub1_wb_rt;
   sub1_wb_adr_o <= adr_int(11 downto 2);
-  sub1_wb_sel_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
   sub1_wb_dat_o <= wr_dat_d0;
 
@@ -382,7 +435,21 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wr_dat_d0;
-  sub2_axi4_wstrb_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= adr_int(11 downto 2);
@@ -435,7 +502,21 @@ begin
     end if;
   end process;
   sub4_avalon_address_o <= adr_int(11 downto 2);
-  sub4_avalon_byteenable_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
   sub4_avalon_writedata_o <= wr_dat_d0;
@@ -473,7 +554,21 @@ begin
     end if;
   end process;
   sub5_apb_pwdata_o <= wr_dat_d0;
-  sub5_apb_pstrb_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
   process (wr_adr_d0, wr_req_d0, reg1_wack, reg2_wack, ram2_we, sub1_wb_wack,

--- a/testfiles/tb/golden_files/all1_wb_wr-in.vhdl
+++ b/testfiles/tb/golden_files/all1_wb_wr-in.vhdl
@@ -98,6 +98,7 @@ entity all1_wb is
 end all1_wb;
 
 architecture syn of all1_wb is
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal adr_int                        : std_logic_vector(14 downto 2);
   signal rd_req_int                     : std_logic;
   signal wr_req_int                     : std_logic;
@@ -151,10 +152,12 @@ architecture syn of all1_wb is
   signal wr_req_d0                      : std_logic;
   signal wr_adr_d0                      : std_logic_vector(14 downto 2);
   signal wr_dat_d0                      : std_logic_vector(31 downto 0);
-  signal wr_sel_d0                      : std_logic_vector(3 downto 0);
+  signal wr_sel_d0                      : std_logic_vector(31 downto 0);
   signal ram1_wr                        : std_logic;
   signal ram1_wreq                      : std_logic;
   signal ram1_adr_int                   : std_logic_vector(2 downto 0);
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
   signal ram2_wp                        : std_logic;
   signal ram2_we                        : std_logic;
   signal sub3_cernbe_ws                 : std_logic;
@@ -162,6 +165,12 @@ architecture syn of all1_wb is
 begin
 
   -- WB decode signals
+  process (wb_i.sel) begin
+    wr_sel(7 downto 0) <= (others => wb_i.sel(0));
+    wr_sel(15 downto 8) <= (others => wb_i.sel(1));
+    wr_sel(23 downto 16) <= (others => wb_i.sel(2));
+    wr_sel(31 downto 24) <= (others => wb_i.sel(3));
+  end process;
   adr_int <= wb_i.adr(14 downto 2);
   wb_en <= wb_i.cyc and wb_i.stb;
 
@@ -202,7 +211,7 @@ begin
         wr_req_d0 <= wr_req_int;
         wr_adr_d0 <= adr_int;
         wr_dat_d0 <= wb_i.dat;
-        wr_sel_d0 <= wb_i.sel;
+        wr_sel_d0 <= wr_sel;
       end if;
     end if;
   end process;
@@ -261,7 +270,7 @@ begin
       clk_a_i              => clk_i,
       clk_b_i              => clk_i,
       addr_a_i             => ram1_adr_int,
-      bwsel_a_i            => wr_sel_d0,
+      bwsel_a_i            => ram1_sel_int,
       data_a_i             => wr_dat_d0,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
@@ -274,6 +283,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel_d0) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk_i) begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
@@ -297,7 +321,7 @@ begin
       clk_a_i              => clk_i,
       clk_b_i              => clk_i,
       addr_a_i             => adr_int(4 downto 2),
-      bwsel_a_i            => wr_sel_d0,
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -310,6 +334,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel_d0) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk_i) begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
@@ -367,7 +406,21 @@ begin
   sub1_wb_wack <= sub1_wb_ack_i and sub1_wb_wt;
   sub1_wb_rack <= sub1_wb_ack_i and sub1_wb_rt;
   sub1_wb_adr_o <= adr_int(11 downto 2);
-  sub1_wb_sel_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
   sub1_wb_dat_o <= wr_dat_d0;
 
@@ -377,7 +430,21 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wr_dat_d0;
-  sub2_axi4_wstrb_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= adr_int(11 downto 2);
@@ -430,7 +497,21 @@ begin
     end if;
   end process;
   sub4_avalon_address_o <= adr_int(11 downto 2);
-  sub4_avalon_byteenable_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
   sub4_avalon_writedata_o <= wr_dat_d0;
@@ -468,7 +549,21 @@ begin
     end if;
   end process;
   sub5_apb_pwdata_o <= wr_dat_d0;
-  sub5_apb_pstrb_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
   process (wr_adr_d0, wr_req_d0, reg1_wack, reg2_wack, ram2_we, sub1_wb_wack,

--- a/testfiles/tb/golden_files/all1_wb_wr-out.vhdl
+++ b/testfiles/tb/golden_files/all1_wb_wr-out.vhdl
@@ -98,6 +98,7 @@ entity all1_wb is
 end all1_wb;
 
 architecture syn of all1_wb is
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal adr_int                        : std_logic_vector(14 downto 2);
   signal rd_req_int                     : std_logic;
   signal wr_req_int                     : std_logic;
@@ -149,9 +150,17 @@ architecture syn of all1_wb is
   signal sub5_apb_rd                    : std_logic;
   signal sub5_apb_rd_reg                : std_logic;
   signal wr_ack_d0                      : std_logic;
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
 begin
 
   -- WB decode signals
+  process (wb_i.sel) begin
+    wr_sel(7 downto 0) <= (others => wb_i.sel(0));
+    wr_sel(15 downto 8) <= (others => wb_i.sel(1));
+    wr_sel(23 downto 16) <= (others => wb_i.sel(2));
+    wr_sel(31 downto 24) <= (others => wb_i.sel(3));
+  end process;
   adr_int <= wb_i.adr(14 downto 2);
   wb_en <= wb_i.cyc and wb_i.stb;
 
@@ -239,7 +248,7 @@ begin
       clk_a_i              => clk_i,
       clk_b_i              => clk_i,
       addr_a_i             => adr_int(4 downto 2),
-      bwsel_a_i            => wb_i.sel,
+      bwsel_a_i            => ram1_sel_int,
       data_a_i             => wb_i.dat,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
@@ -252,6 +261,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk_i) begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
@@ -275,7 +299,7 @@ begin
       clk_a_i              => clk_i,
       clk_b_i              => clk_i,
       addr_a_i             => adr_int(4 downto 2),
-      bwsel_a_i            => wb_i.sel,
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -288,6 +312,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk_i) begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
@@ -329,7 +368,21 @@ begin
   sub1_wb_wack <= sub1_wb_ack_i and sub1_wb_wt;
   sub1_wb_rack <= sub1_wb_ack_i and sub1_wb_rt;
   sub1_wb_adr_o <= adr_int(11 downto 2);
-  sub1_wb_sel_o <= wb_i.sel;
+  process (wr_sel) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
   sub1_wb_dat_o <= wb_i.dat;
 
@@ -339,7 +392,21 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wb_i.dat;
-  sub2_axi4_wstrb_o <= wb_i.sel;
+  process (wr_sel) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= adr_int(11 downto 2);
@@ -376,7 +443,21 @@ begin
     end if;
   end process;
   sub4_avalon_address_o <= adr_int(11 downto 2);
-  sub4_avalon_byteenable_o <= wb_i.sel;
+  process (wr_sel) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
   sub4_avalon_writedata_o <= wb_i.dat;
@@ -414,7 +495,21 @@ begin
     end if;
   end process;
   sub5_apb_pwdata_o <= wb_i.dat;
-  sub5_apb_pstrb_o <= wb_i.sel;
+  process (wr_sel) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
   process (adr_int, wr_req_int, reg1_wack, reg2_wack, sub1_wb_wack,

--- a/testfiles/tb/golden_files/all1_wb_wr.vhdl
+++ b/testfiles/tb/golden_files/all1_wb_wr.vhdl
@@ -98,6 +98,7 @@ entity all1_wb is
 end all1_wb;
 
 architecture syn of all1_wb is
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal adr_int                        : std_logic_vector(14 downto 2);
   signal rd_req_int                     : std_logic;
   signal wr_req_int                     : std_logic;
@@ -151,11 +152,13 @@ architecture syn of all1_wb is
   signal wr_req_d0                      : std_logic;
   signal wr_adr_d0                      : std_logic_vector(14 downto 2);
   signal wr_dat_d0                      : std_logic_vector(31 downto 0);
-  signal wr_sel_d0                      : std_logic_vector(3 downto 0);
+  signal wr_sel_d0                      : std_logic_vector(31 downto 0);
   signal wr_ack_d0                      : std_logic;
   signal ram1_wr                        : std_logic;
   signal ram1_wreq                      : std_logic;
   signal ram1_adr_int                   : std_logic_vector(2 downto 0);
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+  signal ram_ro_sel_int                 : std_logic_vector(3 downto 0);
   signal ram2_wp                        : std_logic;
   signal ram2_we                        : std_logic;
   signal sub3_cernbe_ws                 : std_logic;
@@ -163,6 +166,12 @@ architecture syn of all1_wb is
 begin
 
   -- WB decode signals
+  process (wb_i.sel) begin
+    wr_sel(7 downto 0) <= (others => wb_i.sel(0));
+    wr_sel(15 downto 8) <= (others => wb_i.sel(1));
+    wr_sel(23 downto 16) <= (others => wb_i.sel(2));
+    wr_sel(31 downto 24) <= (others => wb_i.sel(3));
+  end process;
   adr_int <= wb_i.adr(14 downto 2);
   wb_en <= wb_i.cyc and wb_i.stb;
 
@@ -204,7 +213,7 @@ begin
         wr_req_d0 <= wr_req_int;
         wr_adr_d0 <= adr_int;
         wr_dat_d0 <= wb_i.dat;
-        wr_sel_d0 <= wb_i.sel;
+        wr_sel_d0 <= wr_sel;
         wr_ack_int <= wr_ack_d0;
       end if;
     end if;
@@ -264,7 +273,7 @@ begin
       clk_a_i              => clk_i,
       clk_b_i              => clk_i,
       addr_a_i             => ram1_adr_int,
-      bwsel_a_i            => wr_sel_d0,
+      bwsel_a_i            => ram1_sel_int,
       data_a_i             => wr_dat_d0,
       data_a_o             => ram1_val_int_dato,
       rd_a_i               => ram1_val_rreq,
@@ -277,6 +286,21 @@ begin
       wr_b_i               => '0'
     );
   
+  process (wr_sel_d0) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk_i) begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
@@ -300,7 +324,7 @@ begin
       clk_a_i              => clk_i,
       clk_b_i              => clk_i,
       addr_a_i             => adr_int(4 downto 2),
-      bwsel_a_i            => wr_sel_d0,
+      bwsel_a_i            => ram_ro_sel_int,
       data_a_i             => (others => 'X'),
       data_a_o             => ram_ro_val_int_dato,
       rd_a_i               => ram_ro_val_rreq,
@@ -313,6 +337,21 @@ begin
       wr_b_i               => ram_ro_val_we_i
     );
   
+  process (wr_sel_d0) begin
+    ram_ro_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      ram_ro_sel_int(3) <= '1';
+    end if;
+  end process;
   process (clk_i) begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
@@ -370,7 +409,21 @@ begin
   sub1_wb_wack <= sub1_wb_ack_i and sub1_wb_wt;
   sub1_wb_rack <= sub1_wb_ack_i and sub1_wb_rt;
   sub1_wb_adr_o <= adr_int(11 downto 2);
-  sub1_wb_sel_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub1_wb_sel_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub1_wb_sel_o(3) <= '1';
+    end if;
+  end process;
   sub1_wb_we_o <= sub1_wb_wt;
   sub1_wb_dat_o <= wr_dat_d0;
 
@@ -380,7 +433,21 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wr_dat_d0;
-  sub2_axi4_wstrb_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= adr_int(11 downto 2);
@@ -433,7 +500,21 @@ begin
     end if;
   end process;
   sub4_avalon_address_o <= adr_int(11 downto 2);
-  sub4_avalon_byteenable_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub4_avalon_byteenable_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub4_avalon_byteenable_o(3) <= '1';
+    end if;
+  end process;
   sub4_avalon_write_o <= sub4_avalon_wr;
   sub4_avalon_read_o <= sub4_avalon_rr;
   sub4_avalon_writedata_o <= wr_dat_d0;
@@ -471,7 +552,21 @@ begin
     end if;
   end process;
   sub5_apb_pwdata_o <= wr_dat_d0;
-  sub5_apb_pstrb_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub5_apb_pstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub5_apb_pstrb_o(3) <= '1';
+    end if;
+  end process;
 
   -- Process for write requests.
   process (wr_adr_d0, wr_req_d0, reg1_wack, reg2_wack, ram2_we, sub1_wb_wack,

--- a/testfiles/tb/golden_files/all2_axi4.vhdl
+++ b/testfiles/tb/golden_files/all2_axi4.vhdl
@@ -57,7 +57,7 @@ architecture syn of all2_axi4 is
   signal wr_ack                         : std_logic;
   signal wr_addr                        : std_logic_vector(6 downto 2);
   signal wr_data                        : std_logic_vector(31 downto 0);
-  signal wr_strb                        : std_logic_vector(3 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
   signal axi_awset                      : std_logic;
   signal axi_wset                       : std_logic;
   signal axi_wdone                      : std_logic;
@@ -80,7 +80,7 @@ architecture syn of all2_axi4 is
   signal wr_req_d0                      : std_logic;
   signal wr_adr_d0                      : std_logic_vector(6 downto 2);
   signal wr_dat_d0                      : std_logic_vector(31 downto 0);
-  signal wr_sel_d0                      : std_logic_vector(3 downto 0);
+  signal wr_sel_d0                      : std_logic_vector(31 downto 0);
 begin
 
   -- AW, W and B channels
@@ -103,7 +103,10 @@ begin
         end if;
         if wvalid = '1' and axi_wset = '0' then
           wr_data <= wdata;
-          wr_strb <= wstrb;
+          wr_sel(7 downto 0) <= (others => wstrb(0));
+          wr_sel(15 downto 8) <= (others => wstrb(1));
+          wr_sel(23 downto 16) <= (others => wstrb(2));
+          wr_sel(31 downto 24) <= (others => wstrb(3));
           axi_wset <= '1';
           wr_req <= axi_awset or awvalid;
         end if;
@@ -162,7 +165,7 @@ begin
         wr_req_d0 <= wr_req;
         wr_adr_d0 <= wr_addr;
         wr_dat_d0 <= wr_data;
-        wr_sel_d0 <= wr_strb;
+        wr_sel_d0 <= wr_sel;
       end if;
     end if;
   end process;
@@ -189,7 +192,21 @@ begin
   sub2_axi4_awprot_o <= "000";
   sub2_axi4_wvalid_o <= sub2_axi4_w_val;
   sub2_axi4_wdata_o <= wr_dat_d0;
-  sub2_axi4_wstrb_o <= wr_sel_d0;
+  process (wr_sel_d0) begin
+    sub2_axi4_wstrb_o <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      sub2_axi4_wstrb_o(3) <= '1';
+    end if;
+  end process;
   sub2_axi4_bready_o <= '1';
   sub2_axi4_arvalid_o <= sub2_axi4_ar_val;
   sub2_axi4_araddr_o <= rd_addr(5 downto 2);

--- a/testfiles/tb/golden_files/wmask_apb.vhdl
+++ b/testfiles/tb/golden_files/wmask_apb.vhdl
@@ -1,0 +1,218 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+use work.cheby_pkg.all;
+
+entity wmask_apb is
+  port (
+    pclk                 : in    std_logic;
+    presetn              : in    std_logic;
+    paddr                : in    std_logic_vector(5 downto 2);
+    psel                 : in    std_logic;
+    pwrite               : in    std_logic;
+    penable              : in    std_logic;
+    pready               : out   std_logic;
+    pwdata               : in    std_logic_vector(31 downto 0);
+    pstrb                : in    std_logic_vector(3 downto 0);
+    prdata               : out   std_logic_vector(31 downto 0);
+    pslverr              : out   std_logic;
+
+    -- REG reg1
+    reg1_o               : out   std_logic_vector(31 downto 0);
+
+    -- RAM port for ram1
+    ram1_adr_i           : in    std_logic_vector(2 downto 0);
+    ram1_row1_rd_i       : in    std_logic;
+    ram1_row1_dat_o      : out   std_logic_vector(31 downto 0)
+  );
+end wmask_apb;
+
+architecture syn of wmask_apb is
+  signal wr_req                         : std_logic;
+  signal wr_addr                        : std_logic_vector(5 downto 2);
+  signal wr_data                        : std_logic_vector(31 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
+  signal rd_req                         : std_logic;
+  signal rd_addr                        : std_logic_vector(5 downto 2);
+  signal rd_data                        : std_logic_vector(31 downto 0);
+  signal wr_ack                         : std_logic;
+  signal rd_ack                         : std_logic;
+  signal reg1_reg                       : std_logic_vector(31 downto 0);
+  signal reg1_wreq                      : std_logic;
+  signal reg1_wack                      : std_logic;
+  signal ram1_row1_int_dato             : std_logic_vector(31 downto 0);
+  signal ram1_row1_ext_dat              : std_logic_vector(31 downto 0);
+  signal ram1_row1_rreq                 : std_logic;
+  signal ram1_row1_rack                 : std_logic;
+  signal ram1_row1_int_wr               : std_logic;
+  signal rd_ack_d0                      : std_logic;
+  signal rd_dat_d0                      : std_logic_vector(31 downto 0);
+  signal wr_req_d0                      : std_logic;
+  signal wr_adr_d0                      : std_logic_vector(5 downto 2);
+  signal wr_dat_d0                      : std_logic_vector(31 downto 0);
+  signal wr_sel_d0                      : std_logic_vector(31 downto 0);
+  signal ram1_wr                        : std_logic;
+  signal ram1_wreq                      : std_logic;
+  signal ram1_adr_int                   : std_logic_vector(2 downto 0);
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+begin
+
+  -- Write Channel
+  wr_req <= (psel and pwrite) and not penable;
+  wr_addr <= paddr;
+  wr_data <= pwdata;
+  process (pstrb) begin
+    wr_sel(7 downto 0) <= (others => pstrb(0));
+    wr_sel(15 downto 8) <= (others => pstrb(1));
+    wr_sel(23 downto 16) <= (others => pstrb(2));
+    wr_sel(31 downto 24) <= (others => pstrb(3));
+  end process;
+
+  -- Read Channel
+  rd_req <= (psel and not pwrite) and not penable;
+  rd_addr <= paddr;
+  prdata <= rd_data;
+  pready <= wr_ack or rd_ack;
+  pslverr <= '0';
+
+  -- pipelining for wr-in+rd-out
+  process (pclk) begin
+    if rising_edge(pclk) then
+      if presetn = '0' then
+        rd_ack <= '0';
+        wr_req_d0 <= '0';
+      else
+        rd_ack <= rd_ack_d0;
+        rd_data <= rd_dat_d0;
+        wr_req_d0 <= wr_req;
+        wr_adr_d0 <= wr_addr;
+        wr_dat_d0 <= wr_data;
+        wr_sel_d0 <= wr_sel;
+      end if;
+    end if;
+  end process;
+
+  -- Register reg1
+  reg1_o <= reg1_reg;
+  process (pclk) begin
+    if rising_edge(pclk) then
+      if presetn = '0' then
+        reg1_reg <= "00000000000000000000000000000000";
+        reg1_wack <= '0';
+      else
+        if reg1_wreq = '1' then
+          reg1_reg <= (reg1_reg and not wr_sel_d0) or (wr_dat_d0 and wr_sel_d0);
+        end if;
+        reg1_wack <= reg1_wreq;
+      end if;
+    end if;
+  end process;
+
+  -- Memory ram1
+  process (rd_addr, wr_adr_d0, ram1_wr) begin
+    if ram1_wr = '1' then
+      ram1_adr_int <= wr_adr_d0(4 downto 2);
+    else
+      ram1_adr_int <= rd_addr(4 downto 2);
+    end if;
+  end process;
+  ram1_wreq <= ram1_row1_int_wr;
+  ram1_wr <= ram1_wreq;
+  ram1_row1_raminst: cheby_dpssram
+    generic map (
+      g_data_width         => 32,
+      g_size               => 8,
+      g_addr_width         => 3,
+      g_dual_clock         => '0',
+      g_use_bwsel          => '1'
+    )
+    port map (
+      clk_a_i              => pclk,
+      clk_b_i              => pclk,
+      addr_a_i             => ram1_adr_int,
+      bwsel_a_i            => ram1_sel_int,
+      data_a_i             => wr_dat_d0,
+      data_a_o             => ram1_row1_int_dato,
+      rd_a_i               => ram1_row1_rreq,
+      wr_a_i               => ram1_row1_int_wr,
+      addr_b_i             => ram1_adr_i,
+      bwsel_b_i            => (others => '1'),
+      data_b_i             => ram1_row1_ext_dat,
+      data_b_o             => ram1_row1_dat_o,
+      rd_b_i               => ram1_row1_rd_i,
+      wr_b_i               => '0'
+    );
+  
+  process (wr_sel_d0) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
+  process (pclk) begin
+    if rising_edge(pclk) then
+      if presetn = '0' then
+        ram1_row1_rack <= '0';
+      else
+        ram1_row1_rack <= (ram1_row1_rreq and not ram1_wreq) and not ram1_row1_rack;
+      end if;
+    end if;
+  end process;
+
+  -- Process for write requests.
+  process (wr_adr_d0, wr_req_d0, reg1_wack) begin
+    reg1_wreq <= '0';
+    ram1_row1_int_wr <= '0';
+    case wr_adr_d0(5 downto 5) is
+    when "0" =>
+      case wr_adr_d0(4 downto 2) is
+      when "000" =>
+        -- Reg reg1
+        reg1_wreq <= wr_req_d0;
+        wr_ack <= reg1_wack;
+      when others =>
+        wr_ack <= wr_req_d0;
+      end case;
+    when "1" =>
+      -- Memory ram1
+      ram1_row1_int_wr <= wr_req_d0;
+      wr_ack <= wr_req_d0;
+    when others =>
+      wr_ack <= wr_req_d0;
+    end case;
+  end process;
+
+  -- Process for read requests.
+  process (rd_addr, rd_req, reg1_reg, ram1_row1_int_dato, ram1_wreq, ram1_row1_rack) begin
+    -- By default ack read requests
+    rd_dat_d0 <= (others => 'X');
+    ram1_row1_rreq <= '0';
+    case rd_addr(5 downto 5) is
+    when "0" =>
+      case rd_addr(4 downto 2) is
+      when "000" =>
+        -- Reg reg1
+        rd_ack_d0 <= rd_req;
+        rd_dat_d0 <= reg1_reg;
+      when others =>
+        rd_ack_d0 <= rd_req;
+      end case;
+    when "1" =>
+      -- Memory ram1
+      rd_dat_d0 <= ram1_row1_int_dato;
+      ram1_row1_rreq <= rd_req and not ram1_wreq;
+      rd_ack_d0 <= ram1_row1_rack;
+    when others =>
+      rd_ack_d0 <= rd_req;
+    end case;
+  end process;
+end syn;

--- a/testfiles/tb/golden_files/wmask_avalon.vhdl
+++ b/testfiles/tb/golden_files/wmask_avalon.vhdl
@@ -1,0 +1,203 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+use work.cheby_pkg.all;
+
+entity wmask_avalon is
+  port (
+    clk                  : in    std_logic;
+    reset                : in    std_logic;
+    address              : in    std_logic_vector(5 downto 2);
+    readdata             : out   std_logic_vector(31 downto 0);
+    writedata            : in    std_logic_vector(31 downto 0);
+    byteenable           : in    std_logic_vector(3 downto 0);
+    read                 : in    std_logic;
+    write                : in    std_logic;
+    readdatavalid        : out   std_logic;
+    waitrequest          : out   std_logic;
+
+    -- REG reg1
+    reg1_o               : out   std_logic_vector(31 downto 0);
+
+    -- RAM port for ram1
+    ram1_adr_i           : in    std_logic_vector(2 downto 0);
+    ram1_row1_rd_i       : in    std_logic;
+    ram1_row1_dat_o      : out   std_logic_vector(31 downto 0)
+  );
+end wmask_avalon;
+
+architecture syn of wmask_avalon is
+  signal rst_n                          : std_logic;
+  signal rd_req                         : std_logic;
+  signal rd_ack                         : std_logic;
+  signal wr_req                         : std_logic;
+  signal wr_ack                         : std_logic;
+  signal wr_dat                         : std_logic_vector(31 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
+  signal wait_int                       : std_logic;
+  signal sel_int                        : std_logic_vector(31 downto 0);
+  signal adr                            : std_logic_vector(5 downto 2);
+  signal reg1_reg                       : std_logic_vector(31 downto 0);
+  signal reg1_wreq                      : std_logic;
+  signal reg1_wack                      : std_logic;
+  signal ram1_row1_int_dato             : std_logic_vector(31 downto 0);
+  signal ram1_row1_ext_dat              : std_logic_vector(31 downto 0);
+  signal ram1_row1_rreq                 : std_logic;
+  signal ram1_row1_rack                 : std_logic;
+  signal ram1_row1_int_wr               : std_logic;
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+begin
+  rst_n <= not reset;
+  process (clk) begin
+    if rising_edge(clk) then
+      if rst_n = '0' then
+        wait_int <= '0';
+      else
+        wait_int <= (wait_int or (read or write)) and not (rd_ack or wr_ack);
+      end if;
+    end if;
+  end process;
+  process (byteenable) begin
+    sel_int(7 downto 0) <= (others => byteenable(0));
+    sel_int(15 downto 8) <= (others => byteenable(1));
+    sel_int(23 downto 16) <= (others => byteenable(2));
+    sel_int(31 downto 24) <= (others => byteenable(3));
+  end process;
+  process (clk) begin
+    if rising_edge(clk) then
+      if rst_n = '0' then
+        rd_req <= '0';
+        wr_req <= '0';
+      else
+        if ((read or write) and not wait_int) = '1' then
+          adr <= address;
+        else
+        end if;
+        if (write and not wait_int) = '1' then
+          wr_sel <= sel_int;
+          wr_dat <= writedata;
+        else
+        end if;
+        rd_req <= read and not wait_int;
+        wr_req <= write and not wait_int;
+      end if;
+    end if;
+  end process;
+  readdatavalid <= rd_ack;
+  waitrequest <= wait_int;
+
+  -- Register reg1
+  reg1_o <= reg1_reg;
+  process (clk) begin
+    if rising_edge(clk) then
+      if rst_n = '0' then
+        reg1_reg <= "00000000000000000000000000000000";
+        reg1_wack <= '0';
+      else
+        if reg1_wreq = '1' then
+          reg1_reg <= (reg1_reg and not wr_sel) or (wr_dat and wr_sel);
+        end if;
+        reg1_wack <= reg1_wreq;
+      end if;
+    end if;
+  end process;
+
+  -- Memory ram1
+  ram1_row1_raminst: cheby_dpssram
+    generic map (
+      g_data_width         => 32,
+      g_size               => 8,
+      g_addr_width         => 3,
+      g_dual_clock         => '0',
+      g_use_bwsel          => '1'
+    )
+    port map (
+      clk_a_i              => clk,
+      clk_b_i              => clk,
+      addr_a_i             => adr(4 downto 2),
+      bwsel_a_i            => ram1_sel_int,
+      data_a_i             => wr_dat,
+      data_a_o             => ram1_row1_int_dato,
+      rd_a_i               => ram1_row1_rreq,
+      wr_a_i               => ram1_row1_int_wr,
+      addr_b_i             => ram1_adr_i,
+      bwsel_b_i            => (others => '1'),
+      data_b_i             => ram1_row1_ext_dat,
+      data_b_o             => ram1_row1_dat_o,
+      rd_b_i               => ram1_row1_rd_i,
+      wr_b_i               => '0'
+    );
+  
+  process (wr_sel) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
+  process (clk) begin
+    if rising_edge(clk) then
+      if rst_n = '0' then
+        ram1_row1_rack <= '0';
+      else
+        ram1_row1_rack <= ram1_row1_rreq;
+      end if;
+    end if;
+  end process;
+
+  -- Process for write requests.
+  process (adr, wr_req, reg1_wack) begin
+    reg1_wreq <= '0';
+    ram1_row1_int_wr <= '0';
+    case adr(5 downto 5) is
+    when "0" =>
+      case adr(4 downto 2) is
+      when "000" =>
+        -- Reg reg1
+        reg1_wreq <= wr_req;
+        wr_ack <= reg1_wack;
+      when others =>
+        wr_ack <= wr_req;
+      end case;
+    when "1" =>
+      -- Memory ram1
+      ram1_row1_int_wr <= wr_req;
+      wr_ack <= wr_req;
+    when others =>
+      wr_ack <= wr_req;
+    end case;
+  end process;
+
+  -- Process for read requests.
+  process (adr, rd_req, reg1_reg, ram1_row1_int_dato, ram1_row1_rack) begin
+    -- By default ack read requests
+    readdata <= (others => 'X');
+    ram1_row1_rreq <= '0';
+    case adr(5 downto 5) is
+    when "0" =>
+      case adr(4 downto 2) is
+      when "000" =>
+        -- Reg reg1
+        rd_ack <= rd_req;
+        readdata <= reg1_reg;
+      when others =>
+        rd_ack <= rd_req;
+      end case;
+    when "1" =>
+      -- Memory ram1
+      readdata <= ram1_row1_int_dato;
+      ram1_row1_rreq <= rd_req;
+      rd_ack <= ram1_row1_rack;
+    when others =>
+      rd_ack <= rd_req;
+    end case;
+  end process;
+end syn;

--- a/testfiles/tb/golden_files/wmask_wb.vhdl
+++ b/testfiles/tb/golden_files/wmask_wb.vhdl
@@ -1,0 +1,239 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+use work.cheby_pkg.all;
+
+entity wmask_wb is
+  port (
+    rst_n_i              : in    std_logic;
+    clk_i                : in    std_logic;
+    wb_cyc_i             : in    std_logic;
+    wb_stb_i             : in    std_logic;
+    wb_adr_i             : in    std_logic_vector(5 downto 2);
+    wb_sel_i             : in    std_logic_vector(3 downto 0);
+    wb_we_i              : in    std_logic;
+    wb_dat_i             : in    std_logic_vector(31 downto 0);
+    wb_ack_o             : out   std_logic;
+    wb_err_o             : out   std_logic;
+    wb_rty_o             : out   std_logic;
+    wb_stall_o           : out   std_logic;
+    wb_dat_o             : out   std_logic_vector(31 downto 0);
+
+    -- REG reg1
+    reg1_o               : out   std_logic_vector(31 downto 0);
+
+    -- RAM port for ram1
+    ram1_adr_i           : in    std_logic_vector(2 downto 0);
+    ram1_row1_rd_i       : in    std_logic;
+    ram1_row1_dat_o      : out   std_logic_vector(31 downto 0)
+  );
+end wmask_wb;
+
+architecture syn of wmask_wb is
+  signal wr_sel                         : std_logic_vector(31 downto 0);
+  signal rd_req_int                     : std_logic;
+  signal wr_req_int                     : std_logic;
+  signal rd_ack_int                     : std_logic;
+  signal wr_ack_int                     : std_logic;
+  signal wb_en                          : std_logic;
+  signal ack_int                        : std_logic;
+  signal wb_rip                         : std_logic;
+  signal wb_wip                         : std_logic;
+  signal reg1_reg                       : std_logic_vector(31 downto 0);
+  signal reg1_wreq                      : std_logic;
+  signal reg1_wack                      : std_logic;
+  signal ram1_row1_int_dato             : std_logic_vector(31 downto 0);
+  signal ram1_row1_ext_dat              : std_logic_vector(31 downto 0);
+  signal ram1_row1_rreq                 : std_logic;
+  signal ram1_row1_rack                 : std_logic;
+  signal ram1_row1_int_wr               : std_logic;
+  signal rd_ack_d0                      : std_logic;
+  signal rd_dat_d0                      : std_logic_vector(31 downto 0);
+  signal wr_req_d0                      : std_logic;
+  signal wr_adr_d0                      : std_logic_vector(5 downto 2);
+  signal wr_dat_d0                      : std_logic_vector(31 downto 0);
+  signal wr_sel_d0                      : std_logic_vector(31 downto 0);
+  signal ram1_wr                        : std_logic;
+  signal ram1_wreq                      : std_logic;
+  signal ram1_adr_int                   : std_logic_vector(2 downto 0);
+  signal ram1_sel_int                   : std_logic_vector(3 downto 0);
+begin
+
+  -- WB decode signals
+  process (wb_sel_i) begin
+    wr_sel(7 downto 0) <= (others => wb_sel_i(0));
+    wr_sel(15 downto 8) <= (others => wb_sel_i(1));
+    wr_sel(23 downto 16) <= (others => wb_sel_i(2));
+    wr_sel(31 downto 24) <= (others => wb_sel_i(3));
+  end process;
+  wb_en <= wb_cyc_i and wb_stb_i;
+
+  process (clk_i) begin
+    if rising_edge(clk_i) then
+      if rst_n_i = '0' then
+        wb_rip <= '0';
+      else
+        wb_rip <= (wb_rip or (wb_en and not wb_we_i)) and not rd_ack_int;
+      end if;
+    end if;
+  end process;
+  rd_req_int <= (wb_en and not wb_we_i) and not wb_rip;
+
+  process (clk_i) begin
+    if rising_edge(clk_i) then
+      if rst_n_i = '0' then
+        wb_wip <= '0';
+      else
+        wb_wip <= (wb_wip or (wb_en and wb_we_i)) and not wr_ack_int;
+      end if;
+    end if;
+  end process;
+  wr_req_int <= (wb_en and wb_we_i) and not wb_wip;
+
+  ack_int <= rd_ack_int or wr_ack_int;
+  wb_ack_o <= ack_int;
+  wb_stall_o <= not ack_int and wb_en;
+  wb_rty_o <= '0';
+  wb_err_o <= '0';
+
+  -- pipelining for wr-in+rd-out
+  process (clk_i) begin
+    if rising_edge(clk_i) then
+      if rst_n_i = '0' then
+        rd_ack_int <= '0';
+        wr_req_d0 <= '0';
+      else
+        rd_ack_int <= rd_ack_d0;
+        wb_dat_o <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_adr_d0 <= wb_adr_i;
+        wr_dat_d0 <= wb_dat_i;
+        wr_sel_d0 <= wr_sel;
+      end if;
+    end if;
+  end process;
+
+  -- Register reg1
+  reg1_o <= reg1_reg;
+  process (clk_i) begin
+    if rising_edge(clk_i) then
+      if rst_n_i = '0' then
+        reg1_reg <= "00000000000000000000000000000000";
+        reg1_wack <= '0';
+      else
+        if reg1_wreq = '1' then
+          reg1_reg <= (reg1_reg and not wr_sel_d0) or (wr_dat_d0 and wr_sel_d0);
+        end if;
+        reg1_wack <= reg1_wreq;
+      end if;
+    end if;
+  end process;
+
+  -- Memory ram1
+  process (wb_adr_i, wr_adr_d0, ram1_wr) begin
+    if ram1_wr = '1' then
+      ram1_adr_int <= wr_adr_d0(4 downto 2);
+    else
+      ram1_adr_int <= wb_adr_i(4 downto 2);
+    end if;
+  end process;
+  ram1_wreq <= ram1_row1_int_wr;
+  ram1_wr <= ram1_wreq;
+  ram1_row1_raminst: cheby_dpssram
+    generic map (
+      g_data_width         => 32,
+      g_size               => 8,
+      g_addr_width         => 3,
+      g_dual_clock         => '0',
+      g_use_bwsel          => '1'
+    )
+    port map (
+      clk_a_i              => clk_i,
+      clk_b_i              => clk_i,
+      addr_a_i             => ram1_adr_int,
+      bwsel_a_i            => ram1_sel_int,
+      data_a_i             => wr_dat_d0,
+      data_a_o             => ram1_row1_int_dato,
+      rd_a_i               => ram1_row1_rreq,
+      wr_a_i               => ram1_row1_int_wr,
+      addr_b_i             => ram1_adr_i,
+      bwsel_b_i            => (others => '1'),
+      data_b_i             => ram1_row1_ext_dat,
+      data_b_o             => ram1_row1_dat_o,
+      rd_b_i               => ram1_row1_rd_i,
+      wr_b_i               => '0'
+    );
+  
+  process (wr_sel_d0) begin
+    ram1_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      ram1_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      ram1_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      ram1_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      ram1_sel_int(3) <= '1';
+    end if;
+  end process;
+  process (clk_i) begin
+    if rising_edge(clk_i) then
+      if rst_n_i = '0' then
+        ram1_row1_rack <= '0';
+      else
+        ram1_row1_rack <= ram1_row1_rreq;
+      end if;
+    end if;
+  end process;
+
+  -- Process for write requests.
+  process (wr_adr_d0, wr_req_d0, reg1_wack) begin
+    reg1_wreq <= '0';
+    ram1_row1_int_wr <= '0';
+    case wr_adr_d0(5 downto 5) is
+    when "0" =>
+      case wr_adr_d0(4 downto 2) is
+      when "000" =>
+        -- Reg reg1
+        reg1_wreq <= wr_req_d0;
+        wr_ack_int <= reg1_wack;
+      when others =>
+        wr_ack_int <= wr_req_d0;
+      end case;
+    when "1" =>
+      -- Memory ram1
+      ram1_row1_int_wr <= wr_req_d0;
+      wr_ack_int <= wr_req_d0;
+    when others =>
+      wr_ack_int <= wr_req_d0;
+    end case;
+  end process;
+
+  -- Process for read requests.
+  process (wb_adr_i, rd_req_int, reg1_reg, ram1_row1_int_dato, ram1_row1_rack) begin
+    -- By default ack read requests
+    rd_dat_d0 <= (others => 'X');
+    ram1_row1_rreq <= '0';
+    case wb_adr_i(5 downto 5) is
+    when "0" =>
+      case wb_adr_i(4 downto 2) is
+      when "000" =>
+        -- Reg reg1
+        rd_ack_d0 <= rd_req_int;
+        rd_dat_d0 <= reg1_reg;
+      when others =>
+        rd_ack_d0 <= rd_req_int;
+      end case;
+    when "1" =>
+      -- Memory ram1
+      rd_dat_d0 <= ram1_row1_int_dato;
+      ram1_row1_rreq <= rd_req_int;
+      rd_ack_d0 <= ram1_row1_rack;
+    when others =>
+      rd_ack_d0 <= rd_req_int;
+    end case;
+  end process;
+end syn;

--- a/testfiles/tb/run.sh
+++ b/testfiles/tb/run.sh
@@ -170,6 +170,17 @@ build_buserr_any()
     build_any "buserr_${name_short}"
 }
 
+build_wmask_any()
+{
+    name="$1"
+    name_short="$2"
+
+    echo "## Testing register write mask for interface '${name}'"
+    sed -e '/bus:/s/BUS/'"${name}"'/' -e '/name:/s/NAME/'"${name_short}"'/' < wmask.cheby > wmask_${name_short}.cheby
+
+    build_any "wmask_${name_short}"
+}
+
 # Build packages
 build_infra
 
@@ -206,5 +217,11 @@ build_all2
 build_buserr_any "apb-32" "apb"
 build_buserr_any "axi4-lite-32" "axi4"
 build_buserr_any "wb-32-be" "wb"
+
+# Test buses with register write mask
+build_wmask_any "apb-32" "apb"
+build_wmask_any "avalon-lite-32" "avalon"
+build_wmask_any "axi4-lite-32" "axi4"
+build_wmask_any "wb-32-be" "wb"
 
 echo "SUCCESS"

--- a/testfiles/tb/run.sh
+++ b/testfiles/tb/run.sh
@@ -175,10 +175,24 @@ build_wmask_any()
     name="$1"
     name_short="$2"
 
+    local file="../../proto/cheby/layout.py"
+    local setting="root\.c_wmask_reg"
+
+    # Change default setting temporarily to enable write mask for all supporting interfaces
+    local prev_setting=$(grep "${setting}" "${file}" | awk '{print $NF}')
+    if [[ -n "${prev_setting}" && "${prev_setting}" == "False" ]]; then
+        sed -i "s|${setting} = ${prev_setting}|${setting} = True|" "${file}"
+    fi
+
     echo "## Testing register write mask for interface '${name}'"
     sed -e '/bus:/s/BUS/'"${name}"'/' -e '/name:/s/NAME/'"${name_short}"'/' < wmask.cheby > wmask_${name_short}.cheby
 
     build_any "wmask_${name_short}"
+
+    # Restore previous write mask setting
+    if [[ -n "${prev_setting}" && "${prev_setting}" == "False" ]]; then
+        sed -i "s|${setting} = True|${setting} = ${prev_setting}|" "${file}"
+    fi
 }
 
 # Build packages

--- a/testfiles/tb/wb_tb_pkg.vhdl
+++ b/testfiles/tb/wb_tb_pkg.vhdl
@@ -15,6 +15,23 @@ package wb_tb_pkg is
     signal wb_in   : inout t_wishbone_slave_in;
     addr           : in    std_logic_vector (31 downto 0);
     data           : in    std_logic_vector (31 downto 0);
+    mask           : in    std_logic_vector (3 downto 0);
+    err            : in    std_logic);
+
+  procedure wb_writel (
+    signal clk     : in    std_logic;
+    signal wb_out  : in    t_wishbone_slave_out;
+    signal wb_in   : inout t_wishbone_slave_in;
+    addr           : in    std_logic_vector (31 downto 0);
+    data           : in    std_logic_vector (31 downto 0);
+    mask           : in    std_logic_vector (3 downto 0));
+
+  procedure wb_writel (
+    signal clk     : in    std_logic;
+    signal wb_out  : in    t_wishbone_slave_out;
+    signal wb_in   : inout t_wishbone_slave_in;
+    addr           : in    std_logic_vector (31 downto 0);
+    data           : in    std_logic_vector (31 downto 0);
     err            : in    std_logic);
 
   procedure wb_writel (
@@ -56,12 +73,13 @@ package body wb_tb_pkg is
     signal wb_out  : in    t_wishbone_slave_out;
     addr           : in    std_logic_vector (31 downto 0);
     rdata          : out   std_logic_vector (31 downto 0);
+    mask           : in    std_logic_vector (3 downto 0);
     err            : in    std_logic) is
   begin
     wb_in.cyc <= '1';
     wb_in.stb <= '1';
     wb_in.adr <= addr;
-    wb_in.sel <= "1111";
+    wb_in.sel <= mask;
 
     wait until rising_edge(clk);
 
@@ -92,15 +110,39 @@ package body wb_tb_pkg is
     signal wb_in   : inout t_wishbone_slave_in;
     addr           : in    std_logic_vector (31 downto 0);
     data           : in    std_logic_vector (31 downto 0);
+    mask           : in    std_logic_vector (3 downto 0);
     err            : in    std_logic)
   is
     variable rdata : std_logic_vector (31 downto 0);
   begin
     --  W transfer
-    wb_in.we <= '1';
+    wb_in.we  <= '1';
     wb_in.dat <= data;
+    wb_in.sel <= mask;
 
-    wb_cycle(clk, wb_in, wb_out, addr, rdata, err);
+    wb_cycle(clk, wb_in, wb_out, addr, rdata, mask, err);
+  end wb_writel;
+
+  procedure wb_writel (
+    signal clk     : in    std_logic;
+    signal wb_out  : in    t_wishbone_slave_out;
+    signal wb_in   : inout t_wishbone_slave_in;
+    addr           : in    std_logic_vector (31 downto 0);
+    data           : in    std_logic_vector (31 downto 0);
+    mask           : in    std_logic_vector (3 downto 0)) is
+  begin
+    wb_writel(clk, wb_out, wb_in, addr, data, mask, '0');
+  end wb_writel;
+
+  procedure wb_writel (
+    signal clk     : in    std_logic;
+    signal wb_out  : in    t_wishbone_slave_out;
+    signal wb_in   : inout t_wishbone_slave_in;
+    addr           : in    std_logic_vector (31 downto 0);
+    data           : in    std_logic_vector (31 downto 0);
+    err            : in    std_logic) is
+  begin
+    wb_writel(clk, wb_out, wb_in, addr, data, (others => '1'), err);
   end wb_writel;
 
   procedure wb_writel (
@@ -110,7 +152,7 @@ package body wb_tb_pkg is
     addr           : in    std_logic_vector (31 downto 0);
     data           : in    std_logic_vector (31 downto 0)) is
   begin
-    wb_writel(clk, wb_out, wb_in, addr, data, '0');
+    wb_writel(clk, wb_out, wb_in, addr, data, (others => '1'), '0');
   end wb_writel;
 
   procedure wb_readl (
@@ -124,7 +166,7 @@ package body wb_tb_pkg is
     --  R transfer
     wb_in.we <= '0';
 
-    wb_cycle(clk, wb_in, wb_out, addr, data, err);
+    wb_cycle(clk, wb_in, wb_out, addr, data, (others => '1'), err);
   end wb_readl;
 
   procedure wb_readl (

--- a/testfiles/tb/wmask.cheby
+++ b/testfiles/tb/wmask.cheby
@@ -1,0 +1,18 @@
+memory-map:
+  bus: BUS
+  name: wmask_NAME
+  children:
+  - reg:
+      name: reg1
+      type: unsigned
+      width: 32
+      access: rw
+      preset: 0x00000000
+  - memory:
+      name: ram1
+      memsize: 32
+      children:
+      - reg:
+          name: row1
+          access: rw
+          width: 32

--- a/testfiles/tb/wmask_apb_tb.vhdl
+++ b/testfiles/tb/wmask_apb_tb.vhdl
@@ -1,0 +1,114 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+use work.apb_tb_pkg.all;
+
+
+entity wmask_apb_tb is
+end wmask_apb_tb;
+
+
+architecture tb of wmask_apb_tb is
+  signal rst_n   : std_logic;
+  signal clk     : std_logic;
+  signal apb_in  : t_apb_master_in;
+  signal apb_out : t_apb_master_out;
+
+  signal reg1   : std_logic_vector(31 downto 0);
+
+  signal end_of_test : boolean := False;
+begin
+  --  Clock and reset
+  clk_rst : process is
+  begin
+    clk <= '0';
+    wait for 5 ns;
+    clk <= '1';
+    wait for 5 ns;
+
+    if end_of_test then
+      wait;
+    end if;
+  end process clk_rst;
+
+  rst_n <= '0' after 0 ns, '1' after 20 ns;
+
+  dut : entity work.wmask_apb
+    port map (
+      pclk            => clk,
+      presetn         => rst_n,
+      paddr           => apb_out.paddr(5 downto 2),
+      psel            => apb_out.psel,
+      pwrite          => apb_out.pwrite,
+      penable         => apb_out.penable,
+      pready          => apb_in.pready,
+      pwdata          => apb_out.pwdata,
+      pstrb           => apb_out.pstrb,
+      prdata          => apb_in.prdata,
+      pslverr         => apb_in.pslverr,
+
+      reg1_o          => reg1,
+      ram1_adr_i      => (others => '0'),
+      ram1_row1_rd_i  => '0',
+      ram1_row1_dat_o => open
+    );
+
+  main : process is
+    variable v : std_logic_vector(31 downto 0);
+  begin
+    apb_init(apb_out);
+
+    -- Wait after reset.
+    wait until rising_edge(clk) and rst_n = '1';
+
+    -- Register
+    -- Testing regular register read
+    report "Testing regular register read" severity note;
+    apb_read(clk, apb_out, apb_in, x"0000_0000", v);
+    assert reg1 = x"0000_0000" severity error;
+    assert v = x"0000_0000" severity error;
+
+    -- Testing regular register write
+    report "Testing regular register write" severity note;
+    apb_write(clk, apb_out, apb_in, x"0000_0000", x"1234_5678", "1111");
+    assert reg1 = x"1234_5678" severity error;
+    apb_read(clk, apb_out, apb_in, x"0000_0000", v);
+    assert v = x"1234_5678" severity error;
+
+    --  Testing register write with mask
+    report "Testing register write with mask" severity note;
+    apb_write(clk, apb_out, apb_in, x"0000_0000", x"9abc_def0", "1010");
+    assert reg1 = x"9a34_de78" severity error;
+    apb_read(clk, apb_out, apb_in, x"0000_0000", v);
+    assert v = x"9a34_de78" severity error;
+
+    -- Memory
+    -- Testing regular memory write
+    report "Testing regular memory write" severity note;
+    apb_write(clk, apb_out, apb_in, x"0010_0000", x"1234_5678", "1111");
+    assert reg1 = x"1234_5678" severity error;
+    apb_read(clk, apb_out, apb_in, x"0010_0000", v);
+    assert v = x"1234_5678" severity error;
+
+    -- Testing memory write with mask
+    report "Testing memory write with mask" severity note;
+    apb_write(clk, apb_out, apb_in, x"0010_0000", x"9abc_def0", "1010");
+    assert reg1 = x"9a34_de78" severity error;
+    apb_read(clk, apb_out, apb_in, x"0010_0000", v);
+    assert v = x"9a34_de78" severity error;
+
+    wait until rising_edge(clk);
+    wait until rising_edge(clk);
+    report "End of test" severity note;
+    end_of_test <= true;
+  end process main;
+
+  watchdog : process is
+  begin
+    wait until end_of_test for 5 us;
+    assert end_of_test report "timeout" severity failure;
+    wait;
+  end process watchdog;
+
+end tb;

--- a/testfiles/tb/wmask_avalon_tb.vhdl
+++ b/testfiles/tb/wmask_avalon_tb.vhdl
@@ -1,0 +1,113 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+use work.avalon_tb_pkg.all;
+
+
+entity wmask_avalon_tb is
+end wmask_avalon_tb;
+
+
+architecture tb of wmask_avalon_tb is
+  signal rst        : std_logic;
+  signal clk        : std_logic;
+  signal avalon_in  : t_avmm_master_in;
+  signal avalon_out : t_avmm_master_out;
+
+  signal reg1   : std_logic_vector(31 downto 0);
+
+  signal end_of_test : boolean := False;
+begin
+  --  Clock and reset
+  clk_rst : process is
+  begin
+    clk <= '0';
+    wait for 5 ns;
+    clk <= '1';
+    wait for 5 ns;
+
+    if end_of_test then
+      wait;
+    end if;
+  end process clk_rst;
+
+  rst <= '1' after 0 ns, '0' after 20 ns;
+
+  dut : entity work.wmask_avalon
+    port map (
+      clk             => clk,
+      reset           => rst,
+      address         => avalon_out.address(5 downto 2),
+      readdata        => avalon_in.readdata,
+      writedata       => avalon_out.writedata,
+      byteenable      => avalon_out.byteenable,
+      read            => avalon_out.read,
+      write           => avalon_out.write,
+      readdatavalid   => avalon_in.readdatavalid,
+      waitrequest     => avalon_in.waitrequest,
+
+      reg1_o          => reg1,
+      ram1_adr_i      => (others => '0'),
+      ram1_row1_rd_i  => '0',
+      ram1_row1_dat_o => open
+    );
+
+  main : process is
+    variable v : std_logic_vector(31 downto 0);
+  begin
+    avmm_init(clk, avalon_in, avalon_out);
+
+    -- Wait after reset.
+    wait until rising_edge(clk) and rst = '0';
+
+    -- Register
+    -- Testing regular register read
+    report "Testing regular register read" severity note;
+    avmm_readl(clk, avalon_in, avalon_out, x"0000_0000", v);
+    assert reg1 = x"0000_0000" severity error;
+    assert v = x"0000_0000" severity error;
+
+    -- Testing regular register write
+    report "Testing regular register write" severity note;
+    avmm_writel(clk, avalon_in, avalon_out, x"0000_0000", x"1234_5678", "1111");
+    assert reg1 = x"1234_5678" severity error;
+    avmm_readl(clk, avalon_in, avalon_out, x"0000_0000", v);
+    assert v = x"1234_5678" severity error;
+
+    --  Testing register write with mask
+    report "Testing register write with mask" severity note;
+    avmm_writel(clk, avalon_in, avalon_out, x"0000_0000", x"9abc_def0", "1010");
+    assert reg1 = x"9a34_de78" severity error;
+    avmm_readl(clk, avalon_in, avalon_out, x"0000_0000", v);
+    assert v = x"9a34_de78" severity error;
+
+    -- Memory
+    -- Testing regular memory write
+    report "Testing regular memory write" severity note;
+    avmm_writel(clk, avalon_in, avalon_out, x"0010_0000", x"1234_5678", "1111");
+    assert reg1 = x"1234_5678" severity error;
+    avmm_readl(clk, avalon_in, avalon_out, x"0010_0000", v);
+    assert v = x"1234_5678" severity error;
+
+    -- Testing memory write with mask
+    report "Testing memory write with mask" severity note;
+    avmm_writel(clk, avalon_in, avalon_out, x"0010_0000", x"9abc_def0", "1010");
+    assert reg1 = x"9a34_de78" severity error;
+    avmm_readl(clk, avalon_in, avalon_out, x"0010_0000", v);
+    assert v = x"9a34_de78" severity error;
+
+    wait until rising_edge(clk);
+    wait until rising_edge(clk);
+    report "End of test" severity note;
+    end_of_test <= true;
+  end process main;
+
+  watchdog : process is
+  begin
+    wait until end_of_test for 5 us;
+    assert end_of_test report "timeout" severity failure;
+    wait;
+  end process watchdog;
+
+end tb;

--- a/testfiles/tb/wmask_axi4_tb.vhdl
+++ b/testfiles/tb/wmask_axi4_tb.vhdl
@@ -1,0 +1,127 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+use work.axi4_tb_pkg.all;
+
+
+entity wmask_axi4_tb is
+end wmask_axi4_tb;
+
+
+architecture tb of wmask_axi4_tb is
+  signal rst_n  : std_logic;
+  signal clk    : std_logic;
+  signal wr_in  : t_axi4lite_write_master_in;
+  signal wr_out : t_axi4lite_write_master_out;
+  signal rd_in  : t_axi4lite_read_master_in;
+  signal rd_out : t_axi4lite_read_master_out;
+
+  signal reg1   : std_logic_vector(31 downto 0);
+
+  signal end_of_test : boolean := False;
+begin
+  --  Clock and reset
+  clk_rst : process is
+  begin
+    clk <= '0';
+    wait for 5 ns;
+    clk <= '1';
+    wait for 5 ns;
+
+    if end_of_test then
+      wait;
+    end if;
+  end process clk_rst;
+
+  rst_n <= '0' after 0 ns, '1' after 20 ns;
+
+  dut : entity work.wmask_axi4
+    port map (
+      aclk            => clk,
+      areset_n        => rst_n,
+      awvalid         => wr_out.awvalid,
+      awready         => wr_in.awready,
+      awaddr          => wr_out.awaddr(5 downto 2),
+      awprot          => "010",
+      wvalid          => wr_out.wvalid,
+      wready          => wr_in.wready,
+      wdata           => wr_out.wdata,
+      wstrb           => wr_out.wstrb,
+      bvalid          => wr_in.bvalid,
+      bready          => wr_out.bready,
+      bresp           => wr_in.bresp,
+      arvalid         => rd_out.arvalid,
+      arready         => rd_in.arready,
+      araddr          => rd_out.araddr(5 downto 2),
+      arprot          => "010",
+      rvalid          => rd_in.rvalid,
+      rready          => rd_out.rready,
+      rdata           => rd_in.rdata,
+      rresp           => rd_in.rresp,
+
+      reg1_o          => reg1,
+      ram1_adr_i      => (others => '0'),
+      ram1_row1_rd_i  => '0',
+      ram1_row1_dat_o => open
+    );
+
+  main : process is
+    variable v : std_logic_vector(31 downto 0);
+  begin
+    axi4lite_wr_init(wr_out);
+    axi4lite_rd_init(rd_out);
+
+    --  Wait after reset.
+    wait until rising_edge(clk) and rst_n = '1';
+
+    -- Register
+    -- Testing regular register read
+    report "Testing regular register read" severity note;
+    axi4lite_read(clk, rd_out, rd_in, x"0000_0000", v);
+    assert reg1 = x"0000_0000" severity error;
+    assert v = x"0000_0000" severity error;
+
+    -- Testing regular register write
+    report "Testing regular register write" severity note;
+    axi4lite_write(clk, wr_out, wr_in, x"0000_0000", x"1234_5678", "1111", C_AXI4_RESP_OK);
+    assert reg1 = x"1234_5678" severity error;
+    axi4lite_read(clk, rd_out, rd_in, x"0000_0000", v);
+    assert v = x"1234_5678" severity error;
+
+    --  Testing register write with mask
+    report "Testing register write with mask" severity note;
+    axi4lite_write(clk, wr_out, wr_in, x"0000_0000", x"9abc_def0", "1010", C_AXI4_RESP_OK);
+    assert reg1 = x"9a34_de78" severity error;
+    axi4lite_read(clk, rd_out, rd_in, x"0000_0000", v);
+    assert v = x"9a34_de78" severity error;
+
+    -- Memory
+    -- Testing regular memory write
+    report "Testing regular memory write" severity note;
+    axi4lite_write(clk, wr_out, wr_in, x"0010_0000", x"1234_5678", "1111", C_AXI4_RESP_OK);
+    assert reg1 = x"1234_5678" severity error;
+    axi4lite_read(clk, rd_out, rd_in, x"0010_0000", v);
+    assert v = x"1234_5678" severity error;
+
+    -- Testing memory write with mask
+    report "Testing memory write with mask" severity note;
+    axi4lite_write(clk, wr_out, wr_in, x"0010_0000", x"9abc_def0", "1010", C_AXI4_RESP_OK);
+    assert reg1 = x"9a34_de78" severity error;
+    axi4lite_read(clk, rd_out, rd_in, x"0010_0000", v);
+    assert v = x"9a34_de78" severity error;
+
+    wait until rising_edge(clk);
+    wait until rising_edge(clk);
+    report "End of test" severity note;
+    end_of_test <= true;
+  end process main;
+
+  watchdog : process is
+  begin
+    wait until end_of_test for 5 us;
+    assert end_of_test report "timeout" severity failure;
+    wait;
+  end process watchdog;
+
+end tb;

--- a/testfiles/tb/wmask_wb_tb.vhdl
+++ b/testfiles/tb/wmask_wb_tb.vhdl
@@ -1,0 +1,117 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+use work.wishbone_pkg.all;
+use work.wb_tb_pkg.all;
+
+
+entity wmask_wb_tb is
+end wmask_wb_tb;
+
+
+architecture tb of wmask_wb_tb is
+  signal rst_n  : std_logic;
+  signal clk    : std_logic;
+  signal wb_in  : t_wishbone_slave_in;
+  signal wb_out : t_wishbone_slave_out;
+
+  signal reg1   : std_logic_vector(31 downto 0);
+
+  signal end_of_test : boolean := False;
+begin
+  --  Clock and reset
+  clk_rst : process is
+  begin
+    clk <= '0';
+    wait for 5 ns;
+    clk <= '1';
+    wait for 5 ns;
+
+    if end_of_test then
+      wait;
+    end if;
+  end process clk_rst;
+
+  rst_n <= '0' after 0 ns, '1' after 20 ns;
+
+  dut : entity work.wmask_wb
+    port map (
+      rst_n_i         => rst_n,
+      clk_i           => clk,
+      wb_cyc_i        => wb_in.cyc,
+      wb_stb_i        => wb_in.stb,
+      wb_adr_i        => wb_in.adr(5 downto 2),
+      wb_sel_i        => wb_in.sel,
+      wb_we_i         => wb_in.we,
+      wb_dat_i        => wb_in.dat,
+      wb_ack_o        => wb_out.ack,
+      wb_err_o        => wb_out.err,
+      wb_rty_o        => wb_out.rty,
+      wb_stall_o      => wb_out.stall,
+      wb_dat_o        => wb_out.dat,
+
+      reg1_o          => reg1,
+      ram1_adr_i      => (others => '0'),
+      ram1_row1_rd_i  => '0',
+      ram1_row1_dat_o => open
+    );
+
+  main : process is
+    variable v : std_logic_vector(31 downto 0);
+  begin
+    wb_init(clk, wb_out, wb_in);
+
+    --  Wait after reset.
+    wait until rising_edge(clk) and rst_n = '1';
+
+    -- Register
+    -- Testing regular register read
+    report "Testing regular register read" severity note;
+    wb_readl(clk, wb_out, wb_in, x"0000_0000", v);
+    assert reg1 = x"0000_0000" severity error;
+    assert v = x"0000_0000" severity error;
+
+    -- Testing regular register write
+    report "Testing regular register write" severity note;
+    wb_writel(clk, wb_out, wb_in, x"0000_0000", x"1234_5678", "1111");
+    assert reg1 = x"1234_5678" severity error;
+    wb_readl(clk, wb_out, wb_in, x"0000_0000", v);
+    assert v = x"1234_5678" severity error;
+
+    --  Testing register write with mask
+    report "Testing register write with mask" severity note;
+    wb_writel(clk, wb_out, wb_in, x"0000_0000", x"9abc_def0", "1010");
+    assert reg1 = x"9a34_de78" severity error;
+    wb_readl(clk, wb_out, wb_in, x"0000_0000", v);
+    assert v = x"9a34_de78" severity error;
+
+    -- Memory
+    -- Testing regular memory write
+    report "Testing regular memory write" severity note;
+    wb_writel(clk, wb_out, wb_in, x"0010_0000", x"1234_5678", "1111");
+    assert reg1 = x"1234_5678" severity error;
+    wb_readl(clk, wb_out, wb_in, x"0010_0000", v);
+    assert v = x"1234_5678" severity error;
+
+    -- Testing memory write with mask
+    report "Testing memory write with mask" severity note;
+    wb_writel(clk, wb_out, wb_in, x"0010_0000", x"9abc_def0", "1010");
+    assert reg1 = x"9a34_de78" severity error;
+    wb_readl(clk, wb_out, wb_in, x"0010_0000", v);
+    assert v = x"9a34_de78" severity error;
+
+    wait until rising_edge(clk);
+    wait until rising_edge(clk);
+    report "End of test" severity note;
+    end_of_test <= true;
+  end process main;
+
+  watchdog : process is
+  begin
+    wait until end_of_test for 5 us;
+    assert end_of_test report "timeout" severity failure;
+    wait;
+  end process watchdog;
+
+end tb;


### PR DESCRIPTION
This might be a bit a controversial PR. So please feel free to share your opinion about it.

Currently, multiple of the bus interface support some form of a write mask. This means that upon a write request, the request sender can specify, which parts of the written value should be updated and, which should be ignored. Hence, it can mask part of its write request. The following interfaces support this (corresponding signal name in parentheses):
- APB (`pstrb`)
- Avalon (`byteenable`)
- AXI4 Lite (`wstrb`)
- Wishbone (`sel`)

As I understand the current implementation in cheby, the write mask is only supported for
- memory writes (i.e. no write mask is applied when writing to registers)
- with a granularity of Bytes (i.e. one can only mask group of 8 bits at a time)

This PR changes these two points by:
- Changing the write mask granularity of the internal bus (`ibus`)  to bits instead of Bytes
- Translating the write mask of every interface to the write mask of the internal bus and back (translating the Byte mask to a bit mask and back)
- Applying the write mask to registers too

The main idea behind this PR is to make the write mask more consistent by applying it to register writes too and to allow for bit manipulations on register writes. We need such a feature for our registers, where we want to manipulate individual bits, e.g. just change the enable bit without modifying any other setting in the register. Our idea was to implement an additional bus interface with a write mask granularity of 1 bit. We don't intend to push that bus interface to this repo, but we thought that the feature itself is nevertheless useful or the overall project, hence this PR.

Of course, as it stands now, none of the existing bus interfaces need such a low granularity. Hence, there is quite some translation from the interface to the internal bus and back for nothing. We assumed this trade-off to be acceptable as the current EDA tools should be able to recognize what is happening and optimize it away.

We tried to add a few settings to disable the new behavior but ultimately failed:
- Adding a write mask granularity setting makes the entire code much more complicated than simply always translating
- Adding a setting to disable write masks for register writes (as it was the case before) proved to complicated as there is no easy way to access the `x-hdl` options (defined per interface) from the `root` element (inside `genreg.py`)

You might have some better idea on how to implement such settings.