### PR TITLE
LaTeX updates and consistent newline support in documentation

### DIFF
--- a/proto/cheby/data/main_template.tex
+++ b/proto/cheby/data/main_template.tex
@@ -20,7 +20,6 @@
 
 % Memory Map
 \newenvironment{memmap}{
-  \vspace{5mm}
   \centering
   \begin{longtblr}{
     width    = \textwidth,
@@ -47,7 +46,6 @@
 
 % Register Drawing
 \newenvironment{regdraw}{
-  \vspace{5mm}
   \begin{center}
   \begin{tblr}{
     width    = \textwidth,
@@ -63,7 +61,6 @@
 
 % Register Description
 \newenvironment{regdesc}{
-  \vspace{5mm}
   \centering
   \begin{tblr}{
     width    = \textwidth,
@@ -74,7 +71,7 @@
   }
   Bits & R/W & Name & Description \\
 }{
-  \end{tblr}
+  \end{longtblr}
 }
 
 \begin{document}

--- a/proto/cheby/data/main_template.tex
+++ b/proto/cheby/data/main_template.tex
@@ -18,11 +18,15 @@
 \usepackage[colorlinks=true,linkcolor=blue]{hyperref}
 \usepackage{xcolor}
 
+% Remove table caption for longtblr tables
+\DefTblrTemplate{firsthead, middlehead, lasthead}{default}{}
+
 % Memory Map
 \newenvironment{memmap}{
   \centering
   \begin{longtblr}{
     width    = \textwidth,
+    rowhead  = {1},
     hline{1} = {1pt},
     hline{2} = {0.5pt},
     hline{Z} = {1pt},
@@ -62,8 +66,9 @@
 % Register Description
 \newenvironment{regdesc}{
   \centering
-  \begin{tblr}{
+  \begin{longtblr}{
     width    = \textwidth,
+    rowhead  = {1},
     hline{1} = {1pt},
     hline{2} = {0.5pt},
     hline{Z} = {1pt},

--- a/proto/cheby/data/main_template.tex
+++ b/proto/cheby/data/main_template.tex
@@ -67,9 +67,9 @@
     hline{1} = {1pt},
     hline{2} = {0.5pt},
     hline{Z} = {1pt},
-    colspec  = {X[1] X[1] X[2] X[7]},
+    colspec  = {X[1] X[2] X[7]},
   }
-  Bits & R/W & Name & Description \\
+  Bits & Name & Description \\
 }{
   \end{longtblr}
 }

--- a/proto/cheby/print_html.py
+++ b/proto/cheby/print_html.py
@@ -105,17 +105,27 @@ def print_regdescr_reg(_periph, pfx, raw, num):
         res += '</tr>\n'
     res += '</table>\n'
 
-    res += '<ul>\n'
+    res += '<dl>\n'
     for f in r.children:
-        res += '<li><b>\n'
-        res += f.name or r.name
-        res += '\n</b>[<i>{}</i>]: {}\n'.format(
-            r.access, f.description or r.description or '')
+        name = f.name or r.name
+        access = r.access
+
+        desc = f.description or r.description or ''
         if f.comment is not None:
-            res += '<br>'
-            res += f.comment.replace('\n', '<br>')
-            res += '\n'
-    res += '</ul>\n'
+            comment = f.comment
+            if desc:
+                desc += '\n\n' + comment
+            else:
+                desc = comment
+        desc = desc.replace('\n', '<br>')
+
+        res += '  <dt><b>{name}</b> [<i>{access}</i>]</dt>\n'.format(
+            name=name, access=access
+        )
+        res += '  <dd>{desc}</dd>\n'.format(desc=desc)
+
+    res += '</dl>\n'
+
     return res
 
 

--- a/proto/cheby/print_latex.py
+++ b/proto/cheby/print_latex.py
@@ -2,16 +2,29 @@ import cheby.tree as tree
 import cheby.gen_doc as gen_doc
 from cheby.wrutils import w, wln
 from pathlib import Path
+import re
 
 # Generate Latex Documentation
 #
 # Note: Python requires that '\' be escaped as '\\' and
-# curly brackes need to be repeated when using format(). 
+# curly brackets need to be repeated when using format().
 
 
-def escape_printable(field):
-    field = field.replace('_', '\\textunderscore\\allowbreak{}')
-    return field.replace('.', '.\\allowbreak{}')
+def escape_printable(text):
+    # Remove whitespaces at start and end of string
+    text = text.strip()
+
+    # Escape special characters
+    SPECIAL_CHARS = ['\\', '&', '%', '$', '#', '_', '{', '}', '~', '^']
+    for char in SPECIAL_CHARS:
+        text = text.replace(char, '\\' + char)
+
+    # Allow line breaks after '_' and '.' in long strings
+    ALLOW_BREAK_CHARS = ['.', '_']
+    for char in ALLOW_BREAK_CHARS:
+        text = text.replace(char, char + '\\allowbreak{}')
+
+    return text
 
 
 def print_reg(fd, r, raw, print_reg_drawing):
@@ -24,6 +37,17 @@ def print_reg(fd, r, raw, print_reg_drawing):
     wln(fd, "C Block Offset & 0x{:x}\\\\".format(r.c_address))
     wln(fd, "\\end{regsummary}\n")
 
+    # Register description
+    # Print only if available and register contains fields
+    if r.description is not None and r.has_fields():
+        desc = escape_printable(r.description)
+
+        pattern = r"(\S+)\n(\S+)"
+        replacement = r"\1 \\\\\n\2"
+        desc = re.sub(pattern, replacement, desc)
+
+        wln(fd, "{desc}\n".format(desc=desc))
+
     # Drawing of contents
     if print_reg_drawing:
         descr = gen_doc.build_regdescr_table(r)
@@ -33,46 +57,50 @@ def print_reg(fd, r, raw, print_reg_drawing):
                 style = ''
                 if col.style == 'field':
                     style = 'bg=lightgray'
-                    
+
                 if col.colspan > 1:
                     w(fd, "\\SetCell[c={}]{{c, {}}} ".format(col.colspan, style))
                 elif style != '':
                     w(fd, "\\SetCell{{{}}} ".format(style))
-    
+
                 w(fd, "{} ".format(escape_printable(col.content)))
                 if i < len(desc_raw) - 1:
                     w(fd, "& ")
             wln(fd, '\\\\')
         wln(fd, "\\end{regdraw}\n")
 
-    # Description of individual registers
+    # Description of bit ranges in register
     wln(fd, "\\begin{regdesc}")
-    
-    for f in r.children:        
+
+    for f in r.children:
         if r.has_fields():
             desc_src = f
         else:
             desc_src = r
-        
+
         # Bit range
         if f.hi is not None:
             w(fd, '{}:{} & '.format(f.hi, f.lo))
         else:
             w(fd, '{} & '.format(f.lo))
-            
+
         # Access
         w(fd, '{} & '.format(r.access or ''))
-        
+
         # Name
         w(fd, '{} & '.format(escape_printable(desc_src.name)))
-        
-        # Description + comment
-        desc_comment = desc_src.description or ''
-        if desc_src.comment is not None:
-            desc_comment = desc_comment + '' + desc_src.comment
 
-        w(fd, '{}'.format(escape_printable(desc_comment)))
+        # Description + comment
+        desc = desc_src.description or ''
+        if desc_src.comment is not None:
+            desc += '\n\n' + desc_src.comment
+
+        desc = escape_printable(desc)
+        desc = desc.replace('\n', ' \\newline ')
+
+        w(fd, '{{{}}}'.format(desc))
         wln(fd, '\\\\')
+
     wln(fd, "\\end{regdesc}\n\n")
 
 
@@ -82,7 +110,7 @@ def print_map_summary(fd, summary):
         w(fd, "{} & ".format(r.address))
         w(fd, "{} & ".format(r.typ))
         if isinstance(r.node, tree.Reg):
-            w(fd, "\hyperref[sec:{}]{{{}}} & ".format(r.name, escape_printable(r.name)))
+            w(fd, "\\hyperref[sec:{}]{{{}}} & ".format(r.name, escape_printable(r.name)))
         else:
             w(fd, "{} & ".format(escape_printable(r.name)))
         w(fd, "{}".format(escape_printable(r.node.c_name)))
@@ -126,7 +154,7 @@ def print_root(fd, root, print_reg_drawing):
 
 def print_latex(fd, n, print_reg_drawing=True):
     # Print latex documentation of root n to file descriptor fd
-    
+
     if isinstance(n, tree.Root):
         print_root(fd, n, print_reg_drawing)
     else:
@@ -135,10 +163,10 @@ def print_latex(fd, n, print_reg_drawing=True):
 
 def copy_template(fd_target):
     # Copy the template for the main file to the directory of the register file
-    
+
     # Path of template source is relative to the executed script
     path_source = Path(__file__).parent / 'data' / 'main_template.tex'
-    
+
     # Copy file
     with open(path_source, 'r') as fd_source:
         fd_target.write(fd_source.read())

--- a/proto/cheby/print_latex.py
+++ b/proto/cheby/print_latex.py
@@ -27,7 +27,12 @@ def escape_printable(text):
     return text
 
 
-def print_reg(fd, r, raw, print_reg_drawing):
+def print_reg(fd, r, raw, print_reg_drawing, word_size):
+    ACCESSES = {
+        "rw": "read/write",
+        "wo": "write-only",
+        "ro": "read-only",
+    }
 
     # Register Summary
     wln(fd, "\\begin{regsummary}")
@@ -35,6 +40,7 @@ def print_reg(fd, r, raw, print_reg_drawing):
     wln(fd, "HW Address & 0x{:x}\\\\".format(raw.abs_addr))
     wln(fd, "C Prefix & {}\\\\".format(escape_printable(raw.name)))
     wln(fd, "C Block Offset & 0x{:x}\\\\".format(r.c_address))
+    wln(fd, "Access & {}\\\\".format(ACCESSES[r.access]))
     wln(fd, "\\end{regsummary}\n")
 
     # Register description
@@ -83,9 +89,6 @@ def print_reg(fd, r, raw, print_reg_drawing):
             w(fd, '{}:{} & '.format(f.hi, f.lo))
         else:
             w(fd, '{} & '.format(f.lo))
-
-        # Access
-        w(fd, '{} & '.format(r.access or ''))
 
         # Name
         w(fd, '{} & '.format(escape_printable(desc_src.name)))

--- a/testfiles/features/semver1.html
+++ b/testfiles/features/semver1.html
@@ -125,11 +125,10 @@
  <td class="td_field" colspan="8">r1[7:0]</td>
 </tr>
 </table>
-<ul>
-<li><b>
-r1
-</b>[<i>rw</i>]: 
-</ul>
+<dl>
+  <dt><b>r1</b> [<i>rw</i>]</dt>
+  <dd></dd>
+</dl>
 
 
 </BODY>

--- a/testfiles/features/semver1.tex
+++ b/testfiles/features/semver1.tex
@@ -15,6 +15,7 @@ HW Prefix & r1\\
 HW Address & 0x0\\
 C Prefix & r1\\
 C Block Offset & 0x0\\
+Access & read/write\\
 \end{regsummary}
 
 \begin{regdraw}
@@ -29,7 +30,7 @@ C Block Offset & 0x0\\
 \end{regdraw}
 
 \begin{regdesc}
-31:0 & rw & r1 & \\
+31:0 & r1 & {}\\
 \end{regdesc}
 
 

--- a/testfiles/issue67/repeatInRepeat.html
+++ b/testfiles/issue67/repeatInRepeat.html
@@ -281,11 +281,10 @@
  <td class="td_field" colspan="8">reg1[7:0]</td>
 </tr>
 </table>
-<ul>
-<li><b>
-reg1
-</b>[<i>rw</i>]: 
-</ul>
+<dl>
+  <dt><b>reg1</b> [<i>rw</i>]</dt>
+  <dd></dd>
+</dl>
 <a name="repA.0.block1.repB.1.reg1"></a>
 <h3>2.2. repA.0.block1.repB.1.reg1</h3>
 <table cellpadding=0 cellspacing=0 border=0>
@@ -309,11 +308,10 @@ reg1
  <td class="td_field" colspan="8">reg1[7:0]</td>
 </tr>
 </table>
-<ul>
-<li><b>
-reg1
-</b>[<i>rw</i>]: 
-</ul>
+<dl>
+  <dt><b>reg1</b> [<i>rw</i>]</dt>
+  <dd></dd>
+</dl>
 <a name="repA.1.block1.repB.0.reg1"></a>
 <h3>2.3. repA.1.block1.repB.0.reg1</h3>
 <table cellpadding=0 cellspacing=0 border=0>
@@ -337,11 +335,10 @@ reg1
  <td class="td_field" colspan="8">reg1[7:0]</td>
 </tr>
 </table>
-<ul>
-<li><b>
-reg1
-</b>[<i>rw</i>]: 
-</ul>
+<dl>
+  <dt><b>reg1</b> [<i>rw</i>]</dt>
+  <dd></dd>
+</dl>
 <a name="repA.1.block1.repB.1.reg1"></a>
 <h3>2.4. repA.1.block1.repB.1.reg1</h3>
 <table cellpadding=0 cellspacing=0 border=0>
@@ -365,11 +362,10 @@ reg1
  <td class="td_field" colspan="8">reg1[7:0]</td>
 </tr>
 </table>
-<ul>
-<li><b>
-reg1
-</b>[<i>rw</i>]: 
-</ul>
+<dl>
+  <dt><b>reg1</b> [<i>rw</i>]</dt>
+  <dd></dd>
+</dl>
 <a name="repA.2.block1.repB.0.reg1"></a>
 <h3>2.5. repA.2.block1.repB.0.reg1</h3>
 <table cellpadding=0 cellspacing=0 border=0>
@@ -393,11 +389,10 @@ reg1
  <td class="td_field" colspan="8">reg1[7:0]</td>
 </tr>
 </table>
-<ul>
-<li><b>
-reg1
-</b>[<i>rw</i>]: 
-</ul>
+<dl>
+  <dt><b>reg1</b> [<i>rw</i>]</dt>
+  <dd></dd>
+</dl>
 <a name="repA.2.block1.repB.1.reg1"></a>
 <h3>2.6. repA.2.block1.repB.1.reg1</h3>
 <table cellpadding=0 cellspacing=0 border=0>
@@ -421,11 +416,10 @@ reg1
  <td class="td_field" colspan="8">reg1[7:0]</td>
 </tr>
 </table>
-<ul>
-<li><b>
-reg1
-</b>[<i>rw</i>]: 
-</ul>
+<dl>
+  <dt><b>reg1</b> [<i>rw</i>]</dt>
+  <dd></dd>
+</dl>
 <a name="repA.3.block1.repB.0.reg1"></a>
 <h3>2.7. repA.3.block1.repB.0.reg1</h3>
 <table cellpadding=0 cellspacing=0 border=0>
@@ -449,11 +443,10 @@ reg1
  <td class="td_field" colspan="8">reg1[7:0]</td>
 </tr>
 </table>
-<ul>
-<li><b>
-reg1
-</b>[<i>rw</i>]: 
-</ul>
+<dl>
+  <dt><b>reg1</b> [<i>rw</i>]</dt>
+  <dd></dd>
+</dl>
 <a name="repA.3.block1.repB.1.reg1"></a>
 <h3>2.8. repA.3.block1.repB.1.reg1</h3>
 <table cellpadding=0 cellspacing=0 border=0>
@@ -477,11 +470,10 @@ reg1
  <td class="td_field" colspan="8">reg1[7:0]</td>
 </tr>
 </table>
-<ul>
-<li><b>
-reg1
-</b>[<i>rw</i>]: 
-</ul>
+<dl>
+  <dt><b>reg1</b> [<i>rw</i>]</dt>
+  <dd></dd>
+</dl>
 
 
 </BODY>

--- a/testfiles/issue67/repeatInRepeat.tex
+++ b/testfiles/issue67/repeatInRepeat.tex
@@ -3,44 +3,45 @@
 
 \begin{memmap}
 0x00-0x1f & BLOCK & repA & repA\\
-0x00-0x07 & BLOCK & repA.\allowbreak{}0 & repA\textunderscore\allowbreak{}0\\
-0x00-0x07 & BLOCK & repA.\allowbreak{}0.\allowbreak{}block1 & repA\textunderscore\allowbreak{}0\textunderscore\allowbreak{}block1\\
-0x00-0x07 & BLOCK & repA.\allowbreak{}0.\allowbreak{}block1.\allowbreak{}repB & repA\textunderscore\allowbreak{}0\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\\
-0x00-0x03 & BLOCK & repA.\allowbreak{}0.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}0 & repA\textunderscore\allowbreak{}0\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}0\\
-0x00 & REG & \hyperref[sec:repA.0.block1.repB.0.reg1]{repA.\allowbreak{}0.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}0.\allowbreak{}reg1} & repA\textunderscore\allowbreak{}0\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}0\textunderscore\allowbreak{}reg1\\
-0x04-0x07 & BLOCK & repA.\allowbreak{}0.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}1 & repA\textunderscore\allowbreak{}0\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}1\\
-0x04 & REG & \hyperref[sec:repA.0.block1.repB.1.reg1]{repA.\allowbreak{}0.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}1.\allowbreak{}reg1} & repA\textunderscore\allowbreak{}0\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}1\textunderscore\allowbreak{}reg1\\
-0x08-0x0f & BLOCK & repA.\allowbreak{}1 & repA\textunderscore\allowbreak{}1\\
-0x08-0x0f & BLOCK & repA.\allowbreak{}1.\allowbreak{}block1 & repA\textunderscore\allowbreak{}1\textunderscore\allowbreak{}block1\\
-0x08-0x0f & BLOCK & repA.\allowbreak{}1.\allowbreak{}block1.\allowbreak{}repB & repA\textunderscore\allowbreak{}1\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\\
-0x08-0x0b & BLOCK & repA.\allowbreak{}1.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}0 & repA\textunderscore\allowbreak{}1\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}0\\
-0x08 & REG & \hyperref[sec:repA.1.block1.repB.0.reg1]{repA.\allowbreak{}1.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}0.\allowbreak{}reg1} & repA\textunderscore\allowbreak{}1\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}0\textunderscore\allowbreak{}reg1\\
-0x0c-0x0f & BLOCK & repA.\allowbreak{}1.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}1 & repA\textunderscore\allowbreak{}1\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}1\\
-0x0c & REG & \hyperref[sec:repA.1.block1.repB.1.reg1]{repA.\allowbreak{}1.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}1.\allowbreak{}reg1} & repA\textunderscore\allowbreak{}1\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}1\textunderscore\allowbreak{}reg1\\
-0x10-0x17 & BLOCK & repA.\allowbreak{}2 & repA\textunderscore\allowbreak{}2\\
-0x10-0x17 & BLOCK & repA.\allowbreak{}2.\allowbreak{}block1 & repA\textunderscore\allowbreak{}2\textunderscore\allowbreak{}block1\\
-0x10-0x17 & BLOCK & repA.\allowbreak{}2.\allowbreak{}block1.\allowbreak{}repB & repA\textunderscore\allowbreak{}2\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\\
-0x10-0x13 & BLOCK & repA.\allowbreak{}2.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}0 & repA\textunderscore\allowbreak{}2\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}0\\
-0x10 & REG & \hyperref[sec:repA.2.block1.repB.0.reg1]{repA.\allowbreak{}2.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}0.\allowbreak{}reg1} & repA\textunderscore\allowbreak{}2\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}0\textunderscore\allowbreak{}reg1\\
-0x14-0x17 & BLOCK & repA.\allowbreak{}2.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}1 & repA\textunderscore\allowbreak{}2\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}1\\
-0x14 & REG & \hyperref[sec:repA.2.block1.repB.1.reg1]{repA.\allowbreak{}2.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}1.\allowbreak{}reg1} & repA\textunderscore\allowbreak{}2\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}1\textunderscore\allowbreak{}reg1\\
-0x18-0x1f & BLOCK & repA.\allowbreak{}3 & repA\textunderscore\allowbreak{}3\\
-0x18-0x1f & BLOCK & repA.\allowbreak{}3.\allowbreak{}block1 & repA\textunderscore\allowbreak{}3\textunderscore\allowbreak{}block1\\
-0x18-0x1f & BLOCK & repA.\allowbreak{}3.\allowbreak{}block1.\allowbreak{}repB & repA\textunderscore\allowbreak{}3\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\\
-0x18-0x1b & BLOCK & repA.\allowbreak{}3.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}0 & repA\textunderscore\allowbreak{}3\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}0\\
-0x18 & REG & \hyperref[sec:repA.3.block1.repB.0.reg1]{repA.\allowbreak{}3.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}0.\allowbreak{}reg1} & repA\textunderscore\allowbreak{}3\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}0\textunderscore\allowbreak{}reg1\\
-0x1c-0x1f & BLOCK & repA.\allowbreak{}3.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}1 & repA\textunderscore\allowbreak{}3\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}1\\
-0x1c & REG & \hyperref[sec:repA.3.block1.repB.1.reg1]{repA.\allowbreak{}3.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}1.\allowbreak{}reg1} & repA\textunderscore\allowbreak{}3\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}1\textunderscore\allowbreak{}reg1\\
+0x00-0x07 & BLOCK & repA.\allowbreak{}0 & repA\_\allowbreak{}0\\
+0x00-0x07 & BLOCK & repA.\allowbreak{}0.\allowbreak{}block1 & repA\_\allowbreak{}0\_\allowbreak{}block1\\
+0x00-0x07 & BLOCK & repA.\allowbreak{}0.\allowbreak{}block1.\allowbreak{}repB & repA\_\allowbreak{}0\_\allowbreak{}block1\_\allowbreak{}repB\\
+0x00-0x03 & BLOCK & repA.\allowbreak{}0.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}0 & repA\_\allowbreak{}0\_\allowbreak{}block1\_\allowbreak{}repB\_\allowbreak{}0\\
+0x00 & REG & \hyperref[sec:repA.0.block1.repB.0.reg1]{repA.\allowbreak{}0.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}0.\allowbreak{}reg1} & repA\_\allowbreak{}0\_\allowbreak{}block1\_\allowbreak{}repB\_\allowbreak{}0\_\allowbreak{}reg1\\
+0x04-0x07 & BLOCK & repA.\allowbreak{}0.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}1 & repA\_\allowbreak{}0\_\allowbreak{}block1\_\allowbreak{}repB\_\allowbreak{}1\\
+0x04 & REG & \hyperref[sec:repA.0.block1.repB.1.reg1]{repA.\allowbreak{}0.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}1.\allowbreak{}reg1} & repA\_\allowbreak{}0\_\allowbreak{}block1\_\allowbreak{}repB\_\allowbreak{}1\_\allowbreak{}reg1\\
+0x08-0x0f & BLOCK & repA.\allowbreak{}1 & repA\_\allowbreak{}1\\
+0x08-0x0f & BLOCK & repA.\allowbreak{}1.\allowbreak{}block1 & repA\_\allowbreak{}1\_\allowbreak{}block1\\
+0x08-0x0f & BLOCK & repA.\allowbreak{}1.\allowbreak{}block1.\allowbreak{}repB & repA\_\allowbreak{}1\_\allowbreak{}block1\_\allowbreak{}repB\\
+0x08-0x0b & BLOCK & repA.\allowbreak{}1.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}0 & repA\_\allowbreak{}1\_\allowbreak{}block1\_\allowbreak{}repB\_\allowbreak{}0\\
+0x08 & REG & \hyperref[sec:repA.1.block1.repB.0.reg1]{repA.\allowbreak{}1.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}0.\allowbreak{}reg1} & repA\_\allowbreak{}1\_\allowbreak{}block1\_\allowbreak{}repB\_\allowbreak{}0\_\allowbreak{}reg1\\
+0x0c-0x0f & BLOCK & repA.\allowbreak{}1.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}1 & repA\_\allowbreak{}1\_\allowbreak{}block1\_\allowbreak{}repB\_\allowbreak{}1\\
+0x0c & REG & \hyperref[sec:repA.1.block1.repB.1.reg1]{repA.\allowbreak{}1.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}1.\allowbreak{}reg1} & repA\_\allowbreak{}1\_\allowbreak{}block1\_\allowbreak{}repB\_\allowbreak{}1\_\allowbreak{}reg1\\
+0x10-0x17 & BLOCK & repA.\allowbreak{}2 & repA\_\allowbreak{}2\\
+0x10-0x17 & BLOCK & repA.\allowbreak{}2.\allowbreak{}block1 & repA\_\allowbreak{}2\_\allowbreak{}block1\\
+0x10-0x17 & BLOCK & repA.\allowbreak{}2.\allowbreak{}block1.\allowbreak{}repB & repA\_\allowbreak{}2\_\allowbreak{}block1\_\allowbreak{}repB\\
+0x10-0x13 & BLOCK & repA.\allowbreak{}2.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}0 & repA\_\allowbreak{}2\_\allowbreak{}block1\_\allowbreak{}repB\_\allowbreak{}0\\
+0x10 & REG & \hyperref[sec:repA.2.block1.repB.0.reg1]{repA.\allowbreak{}2.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}0.\allowbreak{}reg1} & repA\_\allowbreak{}2\_\allowbreak{}block1\_\allowbreak{}repB\_\allowbreak{}0\_\allowbreak{}reg1\\
+0x14-0x17 & BLOCK & repA.\allowbreak{}2.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}1 & repA\_\allowbreak{}2\_\allowbreak{}block1\_\allowbreak{}repB\_\allowbreak{}1\\
+0x14 & REG & \hyperref[sec:repA.2.block1.repB.1.reg1]{repA.\allowbreak{}2.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}1.\allowbreak{}reg1} & repA\_\allowbreak{}2\_\allowbreak{}block1\_\allowbreak{}repB\_\allowbreak{}1\_\allowbreak{}reg1\\
+0x18-0x1f & BLOCK & repA.\allowbreak{}3 & repA\_\allowbreak{}3\\
+0x18-0x1f & BLOCK & repA.\allowbreak{}3.\allowbreak{}block1 & repA\_\allowbreak{}3\_\allowbreak{}block1\\
+0x18-0x1f & BLOCK & repA.\allowbreak{}3.\allowbreak{}block1.\allowbreak{}repB & repA\_\allowbreak{}3\_\allowbreak{}block1\_\allowbreak{}repB\\
+0x18-0x1b & BLOCK & repA.\allowbreak{}3.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}0 & repA\_\allowbreak{}3\_\allowbreak{}block1\_\allowbreak{}repB\_\allowbreak{}0\\
+0x18 & REG & \hyperref[sec:repA.3.block1.repB.0.reg1]{repA.\allowbreak{}3.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}0.\allowbreak{}reg1} & repA\_\allowbreak{}3\_\allowbreak{}block1\_\allowbreak{}repB\_\allowbreak{}0\_\allowbreak{}reg1\\
+0x1c-0x1f & BLOCK & repA.\allowbreak{}3.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}1 & repA\_\allowbreak{}3\_\allowbreak{}block1\_\allowbreak{}repB\_\allowbreak{}1\\
+0x1c & REG & \hyperref[sec:repA.3.block1.repB.1.reg1]{repA.\allowbreak{}3.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}1.\allowbreak{}reg1} & repA\_\allowbreak{}3\_\allowbreak{}block1\_\allowbreak{}repB\_\allowbreak{}1\_\allowbreak{}reg1\\
 \end{memmap}
 
 \section{Register Description}
 \subsubsection{repA.\allowbreak{}0.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}0.\allowbreak{}reg1}
 \label{sec:repA.0.block1.repB.0.reg1}
 \begin{regsummary}
-HW Prefix & repA\textunderscore\allowbreak{}0\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}0\textunderscore\allowbreak{}reg1\\
+HW Prefix & repA\_\allowbreak{}0\_\allowbreak{}block1\_\allowbreak{}repB\_\allowbreak{}0\_\allowbreak{}reg1\\
 HW Address & 0x0\\
 C Prefix & repA.\allowbreak{}0.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}0.\allowbreak{}reg1\\
 C Block Offset & 0x0\\
+Access & read/write\\
 \end{regsummary}
 
 \begin{regdraw}
@@ -49,17 +50,18 @@ C Block Offset & 0x0\\
 \end{regdraw}
 
 \begin{regdesc}
-7:0 & rw & reg1 & \\
+7:0 & reg1 & {}\\
 \end{regdesc}
 
 
 \subsubsection{repA.\allowbreak{}0.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}1.\allowbreak{}reg1}
 \label{sec:repA.0.block1.repB.1.reg1}
 \begin{regsummary}
-HW Prefix & repA\textunderscore\allowbreak{}0\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}1\textunderscore\allowbreak{}reg1\\
+HW Prefix & repA\_\allowbreak{}0\_\allowbreak{}block1\_\allowbreak{}repB\_\allowbreak{}1\_\allowbreak{}reg1\\
 HW Address & 0x4\\
 C Prefix & repA.\allowbreak{}0.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}1.\allowbreak{}reg1\\
 C Block Offset & 0x0\\
+Access & read/write\\
 \end{regsummary}
 
 \begin{regdraw}
@@ -68,17 +70,18 @@ C Block Offset & 0x0\\
 \end{regdraw}
 
 \begin{regdesc}
-7:0 & rw & reg1 & \\
+7:0 & reg1 & {}\\
 \end{regdesc}
 
 
 \subsubsection{repA.\allowbreak{}1.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}0.\allowbreak{}reg1}
 \label{sec:repA.1.block1.repB.0.reg1}
 \begin{regsummary}
-HW Prefix & repA\textunderscore\allowbreak{}1\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}0\textunderscore\allowbreak{}reg1\\
+HW Prefix & repA\_\allowbreak{}1\_\allowbreak{}block1\_\allowbreak{}repB\_\allowbreak{}0\_\allowbreak{}reg1\\
 HW Address & 0x8\\
 C Prefix & repA.\allowbreak{}1.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}0.\allowbreak{}reg1\\
 C Block Offset & 0x0\\
+Access & read/write\\
 \end{regsummary}
 
 \begin{regdraw}
@@ -87,17 +90,18 @@ C Block Offset & 0x0\\
 \end{regdraw}
 
 \begin{regdesc}
-7:0 & rw & reg1 & \\
+7:0 & reg1 & {}\\
 \end{regdesc}
 
 
 \subsubsection{repA.\allowbreak{}1.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}1.\allowbreak{}reg1}
 \label{sec:repA.1.block1.repB.1.reg1}
 \begin{regsummary}
-HW Prefix & repA\textunderscore\allowbreak{}1\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}1\textunderscore\allowbreak{}reg1\\
+HW Prefix & repA\_\allowbreak{}1\_\allowbreak{}block1\_\allowbreak{}repB\_\allowbreak{}1\_\allowbreak{}reg1\\
 HW Address & 0xc\\
 C Prefix & repA.\allowbreak{}1.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}1.\allowbreak{}reg1\\
 C Block Offset & 0x0\\
+Access & read/write\\
 \end{regsummary}
 
 \begin{regdraw}
@@ -106,17 +110,18 @@ C Block Offset & 0x0\\
 \end{regdraw}
 
 \begin{regdesc}
-7:0 & rw & reg1 & \\
+7:0 & reg1 & {}\\
 \end{regdesc}
 
 
 \subsubsection{repA.\allowbreak{}2.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}0.\allowbreak{}reg1}
 \label{sec:repA.2.block1.repB.0.reg1}
 \begin{regsummary}
-HW Prefix & repA\textunderscore\allowbreak{}2\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}0\textunderscore\allowbreak{}reg1\\
+HW Prefix & repA\_\allowbreak{}2\_\allowbreak{}block1\_\allowbreak{}repB\_\allowbreak{}0\_\allowbreak{}reg1\\
 HW Address & 0x10\\
 C Prefix & repA.\allowbreak{}2.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}0.\allowbreak{}reg1\\
 C Block Offset & 0x0\\
+Access & read/write\\
 \end{regsummary}
 
 \begin{regdraw}
@@ -125,17 +130,18 @@ C Block Offset & 0x0\\
 \end{regdraw}
 
 \begin{regdesc}
-7:0 & rw & reg1 & \\
+7:0 & reg1 & {}\\
 \end{regdesc}
 
 
 \subsubsection{repA.\allowbreak{}2.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}1.\allowbreak{}reg1}
 \label{sec:repA.2.block1.repB.1.reg1}
 \begin{regsummary}
-HW Prefix & repA\textunderscore\allowbreak{}2\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}1\textunderscore\allowbreak{}reg1\\
+HW Prefix & repA\_\allowbreak{}2\_\allowbreak{}block1\_\allowbreak{}repB\_\allowbreak{}1\_\allowbreak{}reg1\\
 HW Address & 0x14\\
 C Prefix & repA.\allowbreak{}2.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}1.\allowbreak{}reg1\\
 C Block Offset & 0x0\\
+Access & read/write\\
 \end{regsummary}
 
 \begin{regdraw}
@@ -144,17 +150,18 @@ C Block Offset & 0x0\\
 \end{regdraw}
 
 \begin{regdesc}
-7:0 & rw & reg1 & \\
+7:0 & reg1 & {}\\
 \end{regdesc}
 
 
 \subsubsection{repA.\allowbreak{}3.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}0.\allowbreak{}reg1}
 \label{sec:repA.3.block1.repB.0.reg1}
 \begin{regsummary}
-HW Prefix & repA\textunderscore\allowbreak{}3\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}0\textunderscore\allowbreak{}reg1\\
+HW Prefix & repA\_\allowbreak{}3\_\allowbreak{}block1\_\allowbreak{}repB\_\allowbreak{}0\_\allowbreak{}reg1\\
 HW Address & 0x18\\
 C Prefix & repA.\allowbreak{}3.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}0.\allowbreak{}reg1\\
 C Block Offset & 0x0\\
+Access & read/write\\
 \end{regsummary}
 
 \begin{regdraw}
@@ -163,17 +170,18 @@ C Block Offset & 0x0\\
 \end{regdraw}
 
 \begin{regdesc}
-7:0 & rw & reg1 & \\
+7:0 & reg1 & {}\\
 \end{regdesc}
 
 
 \subsubsection{repA.\allowbreak{}3.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}1.\allowbreak{}reg1}
 \label{sec:repA.3.block1.repB.1.reg1}
 \begin{regsummary}
-HW Prefix & repA\textunderscore\allowbreak{}3\textunderscore\allowbreak{}block1\textunderscore\allowbreak{}repB\textunderscore\allowbreak{}1\textunderscore\allowbreak{}reg1\\
+HW Prefix & repA\_\allowbreak{}3\_\allowbreak{}block1\_\allowbreak{}repB\_\allowbreak{}1\_\allowbreak{}reg1\\
 HW Address & 0x1c\\
 C Prefix & repA.\allowbreak{}3.\allowbreak{}block1.\allowbreak{}repB.\allowbreak{}1.\allowbreak{}reg1\\
 C Block Offset & 0x0\\
+Access & read/write\\
 \end{regsummary}
 
 \begin{regdraw}
@@ -182,7 +190,7 @@ C Block Offset & 0x0\\
 \end{regdraw}
 
 \begin{regdesc}
-7:0 & rw & reg1 & \\
+7:0 & reg1 & {}\\
 \end{regdesc}
 
 

--- a/testfiles/issue84/sps200CavityControl_as.html
+++ b/testfiles/issue84/sps200CavityControl_as.html
@@ -374,20 +374,16 @@
  <td class="td_field" colspan="8">patch[7:0]</td>
 </tr>
 </table>
-<ul>
-<li><b>
-platform
-</b>[<i>ro</i>]: Identifying which platform the version belongs to (i.e. pci, lhc_vme, vme64, ...)
-<li><b>
-major
-</b>[<i>ro</i>]: Major version indicating incompatible changes
-<li><b>
-minor
-</b>[<i>ro</i>]: Minor version indicating feature enhancements
-<li><b>
-patch
-</b>[<i>ro</i>]: Patch indicating bug fixes
-</ul>
+<dl>
+  <dt><b>platform</b> [<i>ro</i>]</dt>
+  <dd>Identifying which platform the version belongs to (i.e. pci, lhc_vme, vme64, ...)</dd>
+  <dt><b>major</b> [<i>ro</i>]</dt>
+  <dd>Major version indicating incompatible changes</dd>
+  <dt><b>minor</b> [<i>ro</i>]</dt>
+  <dd>Minor version indicating feature enhancements</dd>
+  <dt><b>patch</b> [<i>ro</i>]</dt>
+  <dd>Patch indicating bug fixes</dd>
+</dl>
 <a name="hwInfo.serialNumber"></a>
 <h3>2.1.2. hwInfo.serialNumber</h3>
 <table cellpadding=0 cellspacing=0 border=0>
@@ -505,11 +501,10 @@ HW serial number
  <td class="td_field" colspan="8">serialNumber[7:0]</td>
 </tr>
 </table>
-<ul>
-<li><b>
-serialNumber
-</b>[<i>ro</i>]: HW serial number
-</ul>
+<dl>
+  <dt><b>serialNumber</b> [<i>ro</i>]</dt>
+  <dd>HW serial number</dd>
+</dl>
 <a name="hwInfo.firmwareVersion"></a>
 <h3>2.1.3. hwInfo.firmwareVersion</h3>
 <table cellpadding=0 cellspacing=0 border=0>
@@ -582,17 +577,14 @@ Firmware Version
  <td class="td_field" colspan="8">patch[7:0]</td>
 </tr>
 </table>
-<ul>
-<li><b>
-major
-</b>[<i>ro</i>]: Major version indicating incompatible changes
-<li><b>
-minor
-</b>[<i>ro</i>]: Minor version indicating feature enhancements
-<li><b>
-patch
-</b>[<i>ro</i>]: Patch indicating bug fixes
-</ul>
+<dl>
+  <dt><b>major</b> [<i>ro</i>]</dt>
+  <dd>Major version indicating incompatible changes</dd>
+  <dt><b>minor</b> [<i>ro</i>]</dt>
+  <dd>Minor version indicating feature enhancements</dd>
+  <dt><b>patch</b> [<i>ro</i>]</dt>
+  <dd>Patch indicating bug fixes</dd>
+</dl>
 <a name="hwInfo.memMapVersion"></a>
 <h3>2.1.4. hwInfo.memMapVersion</h3>
 <table cellpadding=0 cellspacing=0 border=0>
@@ -665,17 +657,14 @@ Memory Map Version
  <td class="td_field" colspan="8">patch[7:0]</td>
 </tr>
 </table>
-<ul>
-<li><b>
-major
-</b>[<i>ro</i>]: Memory Map Version
-<li><b>
-minor
-</b>[<i>ro</i>]: Memory Map Version
-<li><b>
-patch
-</b>[<i>ro</i>]: Memory Map Version
-</ul>
+<dl>
+  <dt><b>major</b> [<i>ro</i>]</dt>
+  <dd>Memory Map Version</dd>
+  <dt><b>minor</b> [<i>ro</i>]</dt>
+  <dd>Memory Map Version</dd>
+  <dt><b>patch</b> [<i>ro</i>]</dt>
+  <dd>Memory Map Version</dd>
+</dl>
 <a name="hwInfo.echo"></a>
 <h3>2.1.5. hwInfo.echo</h3>
 <table cellpadding=0 cellspacing=0 border=0>
@@ -741,12 +730,10 @@ Echo register. This version of the standard foresees only 8bits linked to real m
  <td class="td_field" colspan="8">echo[7:0]</td>
 </tr>
 </table>
-<ul>
-<li><b>
-echo
-</b>[<i>rw</i>]: Echo register. This version of the standard foresees only 8bits linked to real memory
-<br>Register used solely by software. No interaction with the firmware foreseen.<br>The idea is to use this register as "flag" in the hardware to remember your actions from the software side.<br><br>Reading 0xFF often happens when the board is not even reachable (i.e. bus problems on VME)<br><br>On the other hand if the board is reachable the usual state of flipflops are 0x00. Thus this would indicate that no initialization has been attempted yet.<br><br>At start of your software (FESA class) you should set the value 0x40 indicating that initialization is in progress. <br>This is important for you to later one check if you can read this value back before finally setting it to 0x80 (the value previously used with Cheburashka).<br><br>If your initialization failed but you want to continue anyway you should set the register to 0xC0 to indicate this error <br><br>This register is in particular useful if you have several entities interacting with the hardware. In this case several bits could be assigned to this entities (bits 5..0) to signalize that they have done there part successful and a main entity checks all the expected bits.
-</ul>
+<dl>
+  <dt><b>echo</b> [<i>rw</i>]</dt>
+  <dd>Echo register. This version of the standard foresees only 8bits linked to real memory<br><br>Register used solely by software. No interaction with the firmware foreseen.<br>The idea is to use this register as "flag" in the hardware to remember your actions from the software side.<br><br>Reading 0xFF often happens when the board is not even reachable (i.e. bus problems on VME)<br><br>On the other hand if the board is reachable the usual state of flipflops are 0x00. Thus this would indicate that no initialization has been attempted yet.<br><br>At start of your software (FESA class) you should set the value 0x40 indicating that initialization is in progress. <br>This is important for you to later one check if you can read this value back before finally setting it to 0x80 (the value previously used with Cheburashka).<br><br>If your initialization failed but you want to continue anyway you should set the register to 0xC0 to indicate this error <br><br>This register is in particular useful if you have several entities interacting with the hardware. In this case several bits could be assigned to this entities (bits 5..0) to signalize that they have done there part successful and a main entity checks all the expected bits.</dd>
+</dl>
 <a name="app.modulation.ipInfo.stdVersion"></a>
 <h3>2.1.6. app.modulation.ipInfo.stdVersion</h3>
 <table cellpadding=0 cellspacing=0 border=0>
@@ -816,17 +803,14 @@ echo
  <td class="td_field" colspan="8">patch[7:0]</td>
 </tr>
 </table>
-<ul>
-<li><b>
-major
-</b>[<i>ro</i>]: Major version indicating incompatible changes
-<li><b>
-minor
-</b>[<i>ro</i>]: Minor version indicating feature enhancements
-<li><b>
-patch
-</b>[<i>ro</i>]: Patch indicating bug fixes
-</ul>
+<dl>
+  <dt><b>major</b> [<i>ro</i>]</dt>
+  <dd>Major version indicating incompatible changes</dd>
+  <dt><b>minor</b> [<i>ro</i>]</dt>
+  <dd>Minor version indicating feature enhancements</dd>
+  <dt><b>patch</b> [<i>ro</i>]</dt>
+  <dd>Patch indicating bug fixes</dd>
+</dl>
 <a name="app.modulation.ipInfo.ident"></a>
 <h3>2.1.7. app.modulation.ipInfo.ident</h3>
 <table cellpadding=0 cellspacing=0 border=0>
@@ -892,11 +876,10 @@ IP Ident code
  <td class="td_field" colspan="8">ident[7:0]</td>
 </tr>
 </table>
-<ul>
-<li><b>
-ident
-</b>[<i>ro</i>]: IP Ident code
-</ul>
+<dl>
+  <dt><b>ident</b> [<i>ro</i>]</dt>
+  <dd>IP Ident code</dd>
+</dl>
 <a name="app.modulation.ipInfo.firmwareVersion"></a>
 <h3>2.1.8. app.modulation.ipInfo.firmwareVersion</h3>
 <table cellpadding=0 cellspacing=0 border=0>
@@ -969,17 +952,14 @@ Firmware Version
  <td class="td_field" colspan="8">patch[7:0]</td>
 </tr>
 </table>
-<ul>
-<li><b>
-major
-</b>[<i>ro</i>]: Major version indicating incompatible changes
-<li><b>
-minor
-</b>[<i>ro</i>]: Minor version indicating feature enhancements
-<li><b>
-patch
-</b>[<i>ro</i>]: Patch indicating bug fixes
-</ul>
+<dl>
+  <dt><b>major</b> [<i>ro</i>]</dt>
+  <dd>Major version indicating incompatible changes</dd>
+  <dt><b>minor</b> [<i>ro</i>]</dt>
+  <dd>Minor version indicating feature enhancements</dd>
+  <dt><b>patch</b> [<i>ro</i>]</dt>
+  <dd>Patch indicating bug fixes</dd>
+</dl>
 <a name="app.modulation.ipInfo.memMapVersion"></a>
 <h3>2.1.9. app.modulation.ipInfo.memMapVersion</h3>
 <table cellpadding=0 cellspacing=0 border=0>
@@ -1052,17 +1032,14 @@ Memory Map Version
  <td class="td_field" colspan="8">patch[7:0]</td>
 </tr>
 </table>
-<ul>
-<li><b>
-major
-</b>[<i>ro</i>]: Major version indicating incompatible changes
-<li><b>
-minor
-</b>[<i>ro</i>]: Minor version indicating feature enhancements
-<li><b>
-patch
-</b>[<i>ro</i>]: Patch indicating bug fixes
-</ul>
+<dl>
+  <dt><b>major</b> [<i>ro</i>]</dt>
+  <dd>Major version indicating incompatible changes</dd>
+  <dt><b>minor</b> [<i>ro</i>]</dt>
+  <dd>Minor version indicating feature enhancements</dd>
+  <dt><b>patch</b> [<i>ro</i>]</dt>
+  <dd>Patch indicating bug fixes</dd>
+</dl>
 <a name="app.modulation.ipInfo.echo"></a>
 <h3>2.1.10. app.modulation.ipInfo.echo</h3>
 <table cellpadding=0 cellspacing=0 border=0>
@@ -1149,11 +1126,10 @@ Echo register. This version of the standard foresees only 8bits linked to real m
  <td class="td_field" colspan="8">echo[7:0]</td>
 </tr>
 </table>
-<ul>
-<li><b>
-echo
-</b>[<i>rw</i>]: This version of the standard foresees only 8bits linked to real memory
-</ul>
+<dl>
+  <dt><b>echo</b> [<i>rw</i>]</dt>
+  <dd>This version of the standard foresees only 8bits linked to real memory</dd>
+</dl>
 <a name="app.modulation.control"></a>
 <h3>2.1.11. app.modulation.control</h3>
 <table cellpadding=0 cellspacing=0 border=0>
@@ -1242,45 +1218,32 @@ echo
  <td class="td_field" colspan="1">useTestSignal</td>
 </tr>
 </table>
-<ul>
-<li><b>
-useTestSignal
-</b>[<i>rw</i>]: Use DDS generated test signal instead of ADC input as demodulation input
-<br>Test signal is synthezied with additional internal DDS, test signals frequency given by ftw_RF.
-<li><b>
-useImpulse
-</b>[<i>rw</i>]: Use impulse instead of demodulation output
-<li><b>
-useStaticSignal
-</b>[<i>rw</i>]: Use static signal from register instead of demodulation output
-<li><b>
-bypassDemod
-</b>[<i>rw</i>]: Bypass demodulator
-<li><b>
-bypassMod
-</b>[<i>rw</i>]: Bypass modulator
-<li><b>
-wrInputsValid
-</b>[<i>rw</i>]: transmit WR frame
-<li><b>
-wrInputsValidLatch
-</b>[<i>rw</i>]: transmit WR no autoclear
-<li><b>
-wrResetNCO
-</b>[<i>rw</i>]: activate WR frame control bit
-<li><b>
-wrResetSlip
-</b>[<i>rw</i>]: activate WR frame control bit
-<li><b>
-wrRresetFSK
-</b>[<i>rw</i>]: activate WR frame control bit
-<li><b>
-rate
-</b>[<i>rw</i>]: 
-<li><b>
-clearBPLatches
-</b>[<i>rw</i>]: 
-</ul>
+<dl>
+  <dt><b>useTestSignal</b> [<i>rw</i>]</dt>
+  <dd>Use DDS generated test signal instead of ADC input as demodulation input<br><br>Test signal is synthezied with additional internal DDS, test signals frequency given by ftw_RF.</dd>
+  <dt><b>useImpulse</b> [<i>rw</i>]</dt>
+  <dd>Use impulse instead of demodulation output</dd>
+  <dt><b>useStaticSignal</b> [<i>rw</i>]</dt>
+  <dd>Use static signal from register instead of demodulation output</dd>
+  <dt><b>bypassDemod</b> [<i>rw</i>]</dt>
+  <dd>Bypass demodulator</dd>
+  <dt><b>bypassMod</b> [<i>rw</i>]</dt>
+  <dd>Bypass modulator</dd>
+  <dt><b>wrInputsValid</b> [<i>rw</i>]</dt>
+  <dd>transmit WR frame</dd>
+  <dt><b>wrInputsValidLatch</b> [<i>rw</i>]</dt>
+  <dd>transmit WR no autoclear</dd>
+  <dt><b>wrResetNCO</b> [<i>rw</i>]</dt>
+  <dd>activate WR frame control bit</dd>
+  <dt><b>wrResetSlip</b> [<i>rw</i>]</dt>
+  <dd>activate WR frame control bit</dd>
+  <dt><b>wrRresetFSK</b> [<i>rw</i>]</dt>
+  <dd>activate WR frame control bit</dd>
+  <dt><b>rate</b> [<i>rw</i>]</dt>
+  <dd></dd>
+  <dt><b>clearBPLatches</b> [<i>rw</i>]</dt>
+  <dd></dd>
+</dl>
 <a name="app.modulation.testSignal.amplitude"></a>
 <h3>2.1.12. app.modulation.testSignal.amplitude</h3>
 <table cellpadding=0 cellspacing=0 border=0>
@@ -1320,11 +1283,10 @@ Amplitude for the test signal
  <td class="td_field" colspan="8">amplitude[7:0]</td>
 </tr>
 </table>
-<ul>
-<li><b>
-amplitude
-</b>[<i>rw</i>]: Amplitude for the test signal
-</ul>
+<dl>
+  <dt><b>amplitude</b> [<i>rw</i>]</dt>
+  <dd>Amplitude for the test signal</dd>
+</dl>
 <a name="app.modulation.testSignal.ftw"></a>
 <h3>2.1.13. app.modulation.testSignal.ftw</h3>
 <table cellpadding=0 cellspacing=0 border=0>
@@ -1442,11 +1404,10 @@ FTW of the test signal (frequency relative to fs)
  <td class="td_field" colspan="8">ftw[7:0]</td>
 </tr>
 </table>
-<ul>
-<li><b>
-ftw
-</b>[<i>rw</i>]: FTW of the test signal (frequency relative to fs)
-</ul>
+<dl>
+  <dt><b>ftw</b> [<i>rw</i>]</dt>
+  <dd>FTW of the test signal (frequency relative to fs)</dd>
+</dl>
 <a name="app.modulation.staticSignal.i"></a>
 <h3>2.1.14. app.modulation.staticSignal.i</h3>
 <table cellpadding=0 cellspacing=0 border=0>
@@ -1486,11 +1447,10 @@ Constant to be used as OTF input for channel I
  <td class="td_field" colspan="8">i[7:0]</td>
 </tr>
 </table>
-<ul>
-<li><b>
-i
-</b>[<i>rw</i>]: Constant to be used as OTF input for channel I
-</ul>
+<dl>
+  <dt><b>i</b> [<i>rw</i>]</dt>
+  <dd>Constant to be used as OTF input for channel I</dd>
+</dl>
 <a name="app.modulation.staticSignal.q"></a>
 <h3>2.1.15. app.modulation.staticSignal.q</h3>
 <table cellpadding=0 cellspacing=0 border=0>
@@ -1530,11 +1490,10 @@ Constant to be used as OTF input for channel Q
  <td class="td_field" colspan="8">q[7:0]</td>
 </tr>
 </table>
-<ul>
-<li><b>
-q
-</b>[<i>rw</i>]: Constant to be used as OTF input for channel Q
-</ul>
+<dl>
+  <dt><b>q</b> [<i>rw</i>]</dt>
+  <dd>Constant to be used as OTF input for channel Q</dd>
+</dl>
 <a name="app.modulation.ftwH1main"></a>
 <h3>2.1.16. app.modulation.ftwH1main</h3>
 <table cellpadding=0 cellspacing=0 border=0>
@@ -1649,11 +1608,10 @@ q
  <td class="td_field" colspan="8">ftwH1main[7:0]</td>
 </tr>
 </table>
-<ul>
-<li><b>
-ftwH1main
-</b>[<i>rw</i>]: 
-</ul>
+<dl>
+  <dt><b>ftwH1main</b> [<i>rw</i>]</dt>
+  <dd></dd>
+</dl>
 <a name="app.modulation.ftwH1on"></a>
 <h3>2.1.17. app.modulation.ftwH1on</h3>
 <table cellpadding=0 cellspacing=0 border=0>
@@ -1768,11 +1726,10 @@ ftwH1main
  <td class="td_field" colspan="8">ftwH1on[7:0]</td>
 </tr>
 </table>
-<ul>
-<li><b>
-ftwH1on
-</b>[<i>rw</i>]: 
-</ul>
+<dl>
+  <dt><b>ftwH1on</b> [<i>rw</i>]</dt>
+  <dd></dd>
+</dl>
 <a name="app.modulation.dftwH1slip0"></a>
 <h3>2.1.18. app.modulation.dftwH1slip0</h3>
 <table cellpadding=0 cellspacing=0 border=0>
@@ -1835,11 +1792,10 @@ ftwH1on
  <td class="td_field" colspan="8">dftwH1slip0[7:0]</td>
 </tr>
 </table>
-<ul>
-<li><b>
-dftwH1slip0
-</b>[<i>rw</i>]: 
-</ul>
+<dl>
+  <dt><b>dftwH1slip0</b> [<i>rw</i>]</dt>
+  <dd></dd>
+</dl>
 <a name="app.modulation.dftwH1slip1"></a>
 <h3>2.1.19. app.modulation.dftwH1slip1</h3>
 <table cellpadding=0 cellspacing=0 border=0>
@@ -1902,11 +1858,10 @@ dftwH1slip0
  <td class="td_field" colspan="8">dftwH1slip1[7:0]</td>
 </tr>
 </table>
-<ul>
-<li><b>
-dftwH1slip1
-</b>[<i>rw</i>]: 
-</ul>
+<dl>
+  <dt><b>dftwH1slip1</b> [<i>rw</i>]</dt>
+  <dd></dd>
+</dl>
 <a name="app.modulation.latches"></a>
 <h3>2.1.20. app.modulation.latches</h3>
 <table cellpadding=0 cellspacing=0 border=0>
@@ -1990,11 +1945,10 @@ dftwH1slip1
  <td class="td_field" colspan="8">backplane[7:0]</td>
 </tr>
 </table>
-<ul>
-<li><b>
-backplane
-</b>[<i>rw</i>]: 
-</ul>
+<dl>
+  <dt><b>backplane</b> [<i>rw</i>]</dt>
+  <dd></dd>
+</dl>
 
 <h3>2.2 Register description for address space bar4</h3>
 <a name="fgc_ddr.data64.data64"></a>
@@ -2111,14 +2065,12 @@ backplane
  <td class="td_field" colspan="8">lower[7:0]</td>
 </tr>
 </table>
-<ul>
-<li><b>
-upper
-</b>[<i>rw</i>]: 
-<li><b>
-lower
-</b>[<i>rw</i>]: 
-</ul>
+<dl>
+  <dt><b>upper</b> [<i>rw</i>]</dt>
+  <dd></dd>
+  <dt><b>lower</b> [<i>rw</i>]</dt>
+  <dd></dd>
+</dl>
 <a name="acq_ddr.data32.data32"></a>
 <h3>2.2.2. acq_ddr.data32.data32</h3>
 <table cellpadding=0 cellspacing=0 border=0>
@@ -2181,14 +2133,12 @@ lower
  <td class="td_field" colspan="8">lower[7:0]</td>
 </tr>
 </table>
-<ul>
-<li><b>
-upper
-</b>[<i>rw</i>]: 
-<li><b>
-lower
-</b>[<i>rw</i>]: 
-</ul>
+<dl>
+  <dt><b>upper</b> [<i>rw</i>]</dt>
+  <dd></dd>
+  <dt><b>lower</b> [<i>rw</i>]</dt>
+  <dd></dd>
+</dl>
 <a name="acq_ram.data32.data32"></a>
 <h3>2.2.3. acq_ram.data32.data32</h3>
 <table cellpadding=0 cellspacing=0 border=0>
@@ -2251,14 +2201,12 @@ lower
  <td class="td_field" colspan="8">lower[7:0]</td>
 </tr>
 </table>
-<ul>
-<li><b>
-upper
-</b>[<i>rw</i>]: 
-<li><b>
-lower
-</b>[<i>rw</i>]: 
-</ul>
+<dl>
+  <dt><b>upper</b> [<i>rw</i>]</dt>
+  <dd></dd>
+  <dt><b>lower</b> [<i>rw</i>]</dt>
+  <dd></dd>
+</dl>
 
 
 </BODY>

--- a/testfiles/issue84/sps200CavityControl_as.tex
+++ b/testfiles/issue84/sps200CavityControl_as.tex
@@ -4,44 +4,44 @@ Memory Map for SPS TWC200 Cavity Control
 \subsection{For Space bar0}
 \begin{memmap}
 0x000000-0x00001f & SUBMAP & hwInfo & hwInfo\\
-0x000000 & REG & \hyperref[sec:hwInfo.stdVersion]{hwInfo.\allowbreak{}stdVersion} & hwInfo\textunderscore\allowbreak{}stdVersion\\
-0x000008 & REG & \hyperref[sec:hwInfo.serialNumber]{hwInfo.\allowbreak{}serialNumber} & hwInfo\textunderscore\allowbreak{}serialNumber\\
-0x000010 & REG & \hyperref[sec:hwInfo.firmwareVersion]{hwInfo.\allowbreak{}firmwareVersion} & hwInfo\textunderscore\allowbreak{}firmwareVersion\\
-0x000014 & REG & \hyperref[sec:hwInfo.memMapVersion]{hwInfo.\allowbreak{}memMapVersion} & hwInfo\textunderscore\allowbreak{}memMapVersion\\
-0x000018 & REG & \hyperref[sec:hwInfo.echo]{hwInfo.\allowbreak{}echo} & hwInfo\textunderscore\allowbreak{}echo\\
+0x000000 & REG & \hyperref[sec:hwInfo.stdVersion]{hwInfo.\allowbreak{}stdVersion} & hwInfo\_\allowbreak{}stdVersion\\
+0x000008 & REG & \hyperref[sec:hwInfo.serialNumber]{hwInfo.\allowbreak{}serialNumber} & hwInfo\_\allowbreak{}serialNumber\\
+0x000010 & REG & \hyperref[sec:hwInfo.firmwareVersion]{hwInfo.\allowbreak{}firmwareVersion} & hwInfo\_\allowbreak{}firmwareVersion\\
+0x000014 & REG & \hyperref[sec:hwInfo.memMapVersion]{hwInfo.\allowbreak{}memMapVersion} & hwInfo\_\allowbreak{}memMapVersion\\
+0x000018 & REG & \hyperref[sec:hwInfo.echo]{hwInfo.\allowbreak{}echo} & hwInfo\_\allowbreak{}echo\\
 0x100000-0x17ffff & SUBMAP & app & app\\
-0x100000-0x1003ff & SUBMAP & app.\allowbreak{}modulation & app\textunderscore\allowbreak{}modulation\\
-0x100000-0x10001f & SUBMAP & app.\allowbreak{}modulation.\allowbreak{}ipInfo & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}ipInfo\\
-0x100000 & REG & \hyperref[sec:app.modulation.ipInfo.stdVersion]{app.\allowbreak{}modulation.\allowbreak{}ipInfo.\allowbreak{}stdVersion} & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}ipInfo\textunderscore\allowbreak{}stdVersion\\
-0x100004 & REG & \hyperref[sec:app.modulation.ipInfo.ident]{app.\allowbreak{}modulation.\allowbreak{}ipInfo.\allowbreak{}ident} & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}ipInfo\textunderscore\allowbreak{}ident\\
-0x100008 & REG & \hyperref[sec:app.modulation.ipInfo.firmwareVersion]{app.\allowbreak{}modulation.\allowbreak{}ipInfo.\allowbreak{}firmwareVersion} & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}ipInfo\textunderscore\allowbreak{}firmwareVersion\\
-0x10000c & REG & \hyperref[sec:app.modulation.ipInfo.memMapVersion]{app.\allowbreak{}modulation.\allowbreak{}ipInfo.\allowbreak{}memMapVersion} & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}ipInfo\textunderscore\allowbreak{}memMapVersion\\
-0x100010 & REG & \hyperref[sec:app.modulation.ipInfo.echo]{app.\allowbreak{}modulation.\allowbreak{}ipInfo.\allowbreak{}echo} & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}ipInfo\textunderscore\allowbreak{}echo\\
-0x100020 & REG & \hyperref[sec:app.modulation.control]{app.\allowbreak{}modulation.\allowbreak{}control} & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}control\\
-0x100030-0x10003f & BLOCK & app.\allowbreak{}modulation.\allowbreak{}testSignal & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}testSignal\\
-0x100030 & REG & \hyperref[sec:app.modulation.testSignal.amplitude]{app.\allowbreak{}modulation.\allowbreak{}testSignal.\allowbreak{}amplitude} & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}testSignal\textunderscore\allowbreak{}amplitude\\
-0x100038 & REG & \hyperref[sec:app.modulation.testSignal.ftw]{app.\allowbreak{}modulation.\allowbreak{}testSignal.\allowbreak{}ftw} & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}testSignal\textunderscore\allowbreak{}ftw\\
-0x100040-0x10004f & BLOCK & app.\allowbreak{}modulation.\allowbreak{}staticSignal & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}staticSignal\\
-0x100040 & REG & \hyperref[sec:app.modulation.staticSignal.i]{app.\allowbreak{}modulation.\allowbreak{}staticSignal.\allowbreak{}i} & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}staticSignal\textunderscore\allowbreak{}i\\
-0x100044 & REG & \hyperref[sec:app.modulation.staticSignal.q]{app.\allowbreak{}modulation.\allowbreak{}staticSignal.\allowbreak{}q} & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}staticSignal\textunderscore\allowbreak{}q\\
-0x100050 & REG & \hyperref[sec:app.modulation.ftwH1main]{app.\allowbreak{}modulation.\allowbreak{}ftwH1main} & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}ftwH1main\\
-0x100058 & REG & \hyperref[sec:app.modulation.ftwH1on]{app.\allowbreak{}modulation.\allowbreak{}ftwH1on} & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}ftwH1on\\
-0x100060 & REG & \hyperref[sec:app.modulation.dftwH1slip0]{app.\allowbreak{}modulation.\allowbreak{}dftwH1slip0} & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}dftwH1slip0\\
-0x100064 & REG & \hyperref[sec:app.modulation.dftwH1slip1]{app.\allowbreak{}modulation.\allowbreak{}dftwH1slip1} & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}dftwH1slip1\\
-0x100068 & REG & \hyperref[sec:app.modulation.latches]{app.\allowbreak{}modulation.\allowbreak{}latches} & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}latches\\
+0x100000-0x1003ff & SUBMAP & app.\allowbreak{}modulation & app\_\allowbreak{}modulation\\
+0x100000-0x10001f & SUBMAP & app.\allowbreak{}modulation.\allowbreak{}ipInfo & app\_\allowbreak{}modulation\_\allowbreak{}ipInfo\\
+0x100000 & REG & \hyperref[sec:app.modulation.ipInfo.stdVersion]{app.\allowbreak{}modulation.\allowbreak{}ipInfo.\allowbreak{}stdVersion} & app\_\allowbreak{}modulation\_\allowbreak{}ipInfo\_\allowbreak{}stdVersion\\
+0x100004 & REG & \hyperref[sec:app.modulation.ipInfo.ident]{app.\allowbreak{}modulation.\allowbreak{}ipInfo.\allowbreak{}ident} & app\_\allowbreak{}modulation\_\allowbreak{}ipInfo\_\allowbreak{}ident\\
+0x100008 & REG & \hyperref[sec:app.modulation.ipInfo.firmwareVersion]{app.\allowbreak{}modulation.\allowbreak{}ipInfo.\allowbreak{}firmwareVersion} & app\_\allowbreak{}modulation\_\allowbreak{}ipInfo\_\allowbreak{}firmwareVersion\\
+0x10000c & REG & \hyperref[sec:app.modulation.ipInfo.memMapVersion]{app.\allowbreak{}modulation.\allowbreak{}ipInfo.\allowbreak{}memMapVersion} & app\_\allowbreak{}modulation\_\allowbreak{}ipInfo\_\allowbreak{}memMapVersion\\
+0x100010 & REG & \hyperref[sec:app.modulation.ipInfo.echo]{app.\allowbreak{}modulation.\allowbreak{}ipInfo.\allowbreak{}echo} & app\_\allowbreak{}modulation\_\allowbreak{}ipInfo\_\allowbreak{}echo\\
+0x100020 & REG & \hyperref[sec:app.modulation.control]{app.\allowbreak{}modulation.\allowbreak{}control} & app\_\allowbreak{}modulation\_\allowbreak{}control\\
+0x100030-0x10003f & BLOCK & app.\allowbreak{}modulation.\allowbreak{}testSignal & app\_\allowbreak{}modulation\_\allowbreak{}testSignal\\
+0x100030 & REG & \hyperref[sec:app.modulation.testSignal.amplitude]{app.\allowbreak{}modulation.\allowbreak{}testSignal.\allowbreak{}amplitude} & app\_\allowbreak{}modulation\_\allowbreak{}testSignal\_\allowbreak{}amplitude\\
+0x100038 & REG & \hyperref[sec:app.modulation.testSignal.ftw]{app.\allowbreak{}modulation.\allowbreak{}testSignal.\allowbreak{}ftw} & app\_\allowbreak{}modulation\_\allowbreak{}testSignal\_\allowbreak{}ftw\\
+0x100040-0x10004f & BLOCK & app.\allowbreak{}modulation.\allowbreak{}staticSignal & app\_\allowbreak{}modulation\_\allowbreak{}staticSignal\\
+0x100040 & REG & \hyperref[sec:app.modulation.staticSignal.i]{app.\allowbreak{}modulation.\allowbreak{}staticSignal.\allowbreak{}i} & app\_\allowbreak{}modulation\_\allowbreak{}staticSignal\_\allowbreak{}i\\
+0x100044 & REG & \hyperref[sec:app.modulation.staticSignal.q]{app.\allowbreak{}modulation.\allowbreak{}staticSignal.\allowbreak{}q} & app\_\allowbreak{}modulation\_\allowbreak{}staticSignal\_\allowbreak{}q\\
+0x100050 & REG & \hyperref[sec:app.modulation.ftwH1main]{app.\allowbreak{}modulation.\allowbreak{}ftwH1main} & app\_\allowbreak{}modulation\_\allowbreak{}ftwH1main\\
+0x100058 & REG & \hyperref[sec:app.modulation.ftwH1on]{app.\allowbreak{}modulation.\allowbreak{}ftwH1on} & app\_\allowbreak{}modulation\_\allowbreak{}ftwH1on\\
+0x100060 & REG & \hyperref[sec:app.modulation.dftwH1slip0]{app.\allowbreak{}modulation.\allowbreak{}dftwH1slip0} & app\_\allowbreak{}modulation\_\allowbreak{}dftwH1slip0\\
+0x100064 & REG & \hyperref[sec:app.modulation.dftwH1slip1]{app.\allowbreak{}modulation.\allowbreak{}dftwH1slip1} & app\_\allowbreak{}modulation\_\allowbreak{}dftwH1slip1\\
+0x100068 & REG & \hyperref[sec:app.modulation.latches]{app.\allowbreak{}modulation.\allowbreak{}latches} & app\_\allowbreak{}modulation\_\allowbreak{}latches\\
 \end{memmap}
 
 \subsection{For Space bar4}
 \begin{memmap}
-0x00000000-0x000fffff & SUBMAP & fgc\textunderscore\allowbreak{}ddr & fgc\textunderscore\allowbreak{}ddr\\
-0x00000000-0x000fffff & MEMORY & fgc\textunderscore\allowbreak{}ddr.\allowbreak{}data64 & fgc\textunderscore\allowbreak{}ddr\textunderscore\allowbreak{}data64\\
- +0x00000000 & REG & \hyperref[sec:fgc_ddr.data64.data64]{fgc\textunderscore\allowbreak{}ddr.\allowbreak{}data64.\allowbreak{}data64} & fgc\textunderscore\allowbreak{}ddr\textunderscore\allowbreak{}data64\textunderscore\allowbreak{}data64\\
-0x20000000-0x3fffffff & SUBMAP & acq\textunderscore\allowbreak{}ddr & acq\textunderscore\allowbreak{}ddr\\
-0x20000000-0x3fffffff & MEMORY & acq\textunderscore\allowbreak{}ddr.\allowbreak{}data32 & acq\textunderscore\allowbreak{}ddr\textunderscore\allowbreak{}data32\\
- +0x20000000 & REG & \hyperref[sec:acq_ddr.data32.data32]{acq\textunderscore\allowbreak{}ddr.\allowbreak{}data32.\allowbreak{}data32} & acq\textunderscore\allowbreak{}ddr\textunderscore\allowbreak{}data32\textunderscore\allowbreak{}data32\\
-0x80000000-0x8001ffff & SUBMAP & acq\textunderscore\allowbreak{}ram & acq\textunderscore\allowbreak{}ram\\
-0x80000000-0x8001ffff & MEMORY & acq\textunderscore\allowbreak{}ram.\allowbreak{}data32 & acq\textunderscore\allowbreak{}ram\textunderscore\allowbreak{}data32\\
- +0x80000000 & REG & \hyperref[sec:acq_ram.data32.data32]{acq\textunderscore\allowbreak{}ram.\allowbreak{}data32.\allowbreak{}data32} & acq\textunderscore\allowbreak{}ram\textunderscore\allowbreak{}data32\textunderscore\allowbreak{}data32\\
+0x00000000-0x000fffff & SUBMAP & fgc\_\allowbreak{}ddr & fgc\_\allowbreak{}ddr\\
+0x00000000-0x000fffff & MEMORY & fgc\_\allowbreak{}ddr.\allowbreak{}data64 & fgc\_\allowbreak{}ddr\_\allowbreak{}data64\\
+ +0x00000000 & REG & \hyperref[sec:fgc_ddr.data64.data64]{fgc\_\allowbreak{}ddr.\allowbreak{}data64.\allowbreak{}data64} & fgc\_\allowbreak{}ddr\_\allowbreak{}data64\_\allowbreak{}data64\\
+0x20000000-0x3fffffff & SUBMAP & acq\_\allowbreak{}ddr & acq\_\allowbreak{}ddr\\
+0x20000000-0x3fffffff & MEMORY & acq\_\allowbreak{}ddr.\allowbreak{}data32 & acq\_\allowbreak{}ddr\_\allowbreak{}data32\\
+ +0x20000000 & REG & \hyperref[sec:acq_ddr.data32.data32]{acq\_\allowbreak{}ddr.\allowbreak{}data32.\allowbreak{}data32} & acq\_\allowbreak{}ddr\_\allowbreak{}data32\_\allowbreak{}data32\\
+0x80000000-0x8001ffff & SUBMAP & acq\_\allowbreak{}ram & acq\_\allowbreak{}ram\\
+0x80000000-0x8001ffff & MEMORY & acq\_\allowbreak{}ram.\allowbreak{}data32 & acq\_\allowbreak{}ram\_\allowbreak{}data32\\
+ +0x80000000 & REG & \hyperref[sec:acq_ram.data32.data32]{acq\_\allowbreak{}ram.\allowbreak{}data32.\allowbreak{}data32} & acq\_\allowbreak{}ram\_\allowbreak{}data32\_\allowbreak{}data32\\
 \end{memmap}
 
 \subsection{Register Description for Space bar0}
@@ -49,10 +49,11 @@ Memory Map for SPS TWC200 Cavity Control
 \subsubsection{hwInfo.\allowbreak{}stdVersion}
 \label{sec:hwInfo.stdVersion}
 \begin{regsummary}
-HW Prefix & hwInfo\textunderscore\allowbreak{}stdVersion\\
+HW Prefix & hwInfo\_\allowbreak{}stdVersion\\
 HW Address & 0x0\\
 C Prefix & hwInfo.\allowbreak{}stdVersion\\
 C Block Offset & 0x0\\
+Access & read-only\\
 \end{regsummary}
 
 \begin{regdraw}
@@ -67,20 +68,21 @@ C Block Offset & 0x0\\
 \end{regdraw}
 
 \begin{regdesc}
-31:24 & ro & platform & Identifying which platform the version belongs to (i.\allowbreak{}e.\allowbreak{} pci, lhc\textunderscore\allowbreak{}vme, vme64, .\allowbreak{}.\allowbreak{}.\allowbreak{})\\
-23:16 & ro & major & Major version indicating incompatible changes\\
-15:8 & ro & minor & Minor version indicating feature enhancements\\
-7:0 & ro & patch & Patch indicating bug fixes\\
+31:24 & platform & {Identifying which platform the version belongs to (i.\allowbreak{}e.\allowbreak{} pci, lhc\_\allowbreak{}vme, vme64, .\allowbreak{}.\allowbreak{}.\allowbreak{})}\\
+23:16 & major & {Major version indicating incompatible changes}\\
+15:8 & minor & {Minor version indicating feature enhancements}\\
+7:0 & patch & {Patch indicating bug fixes}\\
 \end{regdesc}
 
 
 \subsubsection{hwInfo.\allowbreak{}serialNumber}
 \label{sec:hwInfo.serialNumber}
 \begin{regsummary}
-HW Prefix & hwInfo\textunderscore\allowbreak{}serialNumber\\
+HW Prefix & hwInfo\_\allowbreak{}serialNumber\\
 HW Address & 0x8\\
 C Prefix & hwInfo.\allowbreak{}serialNumber\\
 C Block Offset & 0x8\\
+Access & read-only\\
 \end{regsummary}
 
 \begin{regdraw}
@@ -103,18 +105,21 @@ C Block Offset & 0x8\\
 \end{regdraw}
 
 \begin{regdesc}
-63:0 & ro & serialNumber & HW serial number\\
+63:0 & serialNumber & {HW serial number}\\
 \end{regdesc}
 
 
 \subsubsection{hwInfo.\allowbreak{}firmwareVersion}
 \label{sec:hwInfo.firmwareVersion}
 \begin{regsummary}
-HW Prefix & hwInfo\textunderscore\allowbreak{}firmwareVersion\\
+HW Prefix & hwInfo\_\allowbreak{}firmwareVersion\\
 HW Address & 0x10\\
 C Prefix & hwInfo.\allowbreak{}firmwareVersion\\
 C Block Offset & 0x10\\
+Access & read-only\\
 \end{regsummary}
+
+Firmware Version
 
 \begin{regdraw}
 31 & 30 & 29 & 28 & 27 & 26 & 25 & 24 \\
@@ -128,20 +133,23 @@ C Block Offset & 0x10\\
 \end{regdraw}
 
 \begin{regdesc}
-23:16 & ro & major & Major version indicating incompatible changes\\
-15:8 & ro & minor & Minor version indicating feature enhancements\\
-7:0 & ro & patch & Patch indicating bug fixes\\
+23:16 & major & {Major version indicating incompatible changes}\\
+15:8 & minor & {Minor version indicating feature enhancements}\\
+7:0 & patch & {Patch indicating bug fixes}\\
 \end{regdesc}
 
 
 \subsubsection{hwInfo.\allowbreak{}memMapVersion}
 \label{sec:hwInfo.memMapVersion}
 \begin{regsummary}
-HW Prefix & hwInfo\textunderscore\allowbreak{}memMapVersion\\
+HW Prefix & hwInfo\_\allowbreak{}memMapVersion\\
 HW Address & 0x14\\
 C Prefix & hwInfo.\allowbreak{}memMapVersion\\
 C Block Offset & 0x14\\
+Access & read-only\\
 \end{regsummary}
+
+Memory Map Version
 
 \begin{regdraw}
 31 & 30 & 29 & 28 & 27 & 26 & 25 & 24 \\
@@ -155,19 +163,20 @@ C Block Offset & 0x14\\
 \end{regdraw}
 
 \begin{regdesc}
-23:16 & ro & major & \\
-15:8 & ro & minor & \\
-7:0 & ro & patch & \\
+23:16 & major & {}\\
+15:8 & minor & {}\\
+7:0 & patch & {}\\
 \end{regdesc}
 
 
 \subsubsection{hwInfo.\allowbreak{}echo}
 \label{sec:hwInfo.echo}
 \begin{regsummary}
-HW Prefix & hwInfo\textunderscore\allowbreak{}echo\\
+HW Prefix & hwInfo\_\allowbreak{}echo\\
 HW Address & 0x18\\
 C Prefix & hwInfo.\allowbreak{}echo\\
 C Block Offset & 0x18\\
+Access & read/write\\
 \end{regsummary}
 
 \begin{regdraw}
@@ -182,29 +191,18 @@ C Block Offset & 0x18\\
 \end{regdraw}
 
 \begin{regdesc}
-31:0 & rw & echo & Echo register.\allowbreak{} This version of the standard foresees only 8bits linked to real memoryRegister used solely by software.\allowbreak{} No interaction with the firmware foreseen.\allowbreak{}
-The idea is to use this register as "flag" in the hardware to remember your actions from the software side.\allowbreak{}
-
-Reading 0xFF often happens when the board is not even reachable (i.\allowbreak{}e.\allowbreak{} bus problems on VME)
-
-On the other hand if the board is reachable the usual state of flipflops are 0x00.\allowbreak{} Thus this would indicate that no initialization has been attempted yet.\allowbreak{}
-
-At start of your software (FESA class) you should set the value 0x40 indicating that initialization is in progress.\allowbreak{} 
-This is important for you to later one check if you can read this value back before finally setting it to 0x80 (the value previously used with Cheburashka).\allowbreak{}
-
-If your initialization failed but you want to continue anyway you should set the register to 0xC0 to indicate this error 
-
-This register is in particular useful if you have several entities interacting with the hardware.\allowbreak{} In this case several bits could be assigned to this entities (bits 5.\allowbreak{}.\allowbreak{}0) to signalize that they have done there part successful and a main entity checks all the expected bits.\allowbreak{}\\
+31:0 & echo & {Echo register.\allowbreak{} This version of the standard foresees only 8bits linked to real memory \newline  \newline Register used solely by software.\allowbreak{} No interaction with the firmware foreseen.\allowbreak{} \newline The idea is to use this register as "flag" in the hardware to remember your actions from the software side.\allowbreak{} \newline  \newline Reading 0xFF often happens when the board is not even reachable (i.\allowbreak{}e.\allowbreak{} bus problems on VME) \newline  \newline On the other hand if the board is reachable the usual state of flipflops are 0x00.\allowbreak{} Thus this would indicate that no initialization has been attempted yet.\allowbreak{} \newline  \newline At start of your software (FESA class) you should set the value 0x40 indicating that initialization is in progress.\allowbreak{}  \newline This is important for you to later one check if you can read this value back before finally setting it to 0x80 (the value previously used with Cheburashka).\allowbreak{} \newline  \newline If your initialization failed but you want to continue anyway you should set the register to 0xC0 to indicate this error  \newline  \newline This register is in particular useful if you have several entities interacting with the hardware.\allowbreak{} In this case several bits could be assigned to this entities (bits 5.\allowbreak{}.\allowbreak{}0) to signalize that they have done there part successful and a main entity checks all the expected bits.\allowbreak{}}\\
 \end{regdesc}
 
 
 \subsubsection{app.\allowbreak{}modulation.\allowbreak{}ipInfo.\allowbreak{}stdVersion}
 \label{sec:app.modulation.ipInfo.stdVersion}
 \begin{regsummary}
-HW Prefix & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}ipInfo\textunderscore\allowbreak{}stdVersion\\
+HW Prefix & app\_\allowbreak{}modulation\_\allowbreak{}ipInfo\_\allowbreak{}stdVersion\\
 HW Address & 0x100000\\
 C Prefix & app.\allowbreak{}modulation.\allowbreak{}ipInfo.\allowbreak{}stdVersion\\
 C Block Offset & 0x0\\
+Access & read-only\\
 \end{regsummary}
 
 \begin{regdraw}
@@ -219,19 +217,20 @@ C Block Offset & 0x0\\
 \end{regdraw}
 
 \begin{regdesc}
-23:16 & ro & major & Major version indicating incompatible changes\\
-15:8 & ro & minor & Minor version indicating feature enhancements\\
-7:0 & ro & patch & Patch indicating bug fixes\\
+23:16 & major & {Major version indicating incompatible changes}\\
+15:8 & minor & {Minor version indicating feature enhancements}\\
+7:0 & patch & {Patch indicating bug fixes}\\
 \end{regdesc}
 
 
 \subsubsection{app.\allowbreak{}modulation.\allowbreak{}ipInfo.\allowbreak{}ident}
 \label{sec:app.modulation.ipInfo.ident}
 \begin{regsummary}
-HW Prefix & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}ipInfo\textunderscore\allowbreak{}ident\\
+HW Prefix & app\_\allowbreak{}modulation\_\allowbreak{}ipInfo\_\allowbreak{}ident\\
 HW Address & 0x100004\\
 C Prefix & app.\allowbreak{}modulation.\allowbreak{}ipInfo.\allowbreak{}ident\\
 C Block Offset & 0x4\\
+Access & read-only\\
 \end{regsummary}
 
 \begin{regdraw}
@@ -246,18 +245,21 @@ C Block Offset & 0x4\\
 \end{regdraw}
 
 \begin{regdesc}
-31:0 & ro & ident & IP Ident code\\
+31:0 & ident & {IP Ident code}\\
 \end{regdesc}
 
 
 \subsubsection{app.\allowbreak{}modulation.\allowbreak{}ipInfo.\allowbreak{}firmwareVersion}
 \label{sec:app.modulation.ipInfo.firmwareVersion}
 \begin{regsummary}
-HW Prefix & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}ipInfo\textunderscore\allowbreak{}firmwareVersion\\
+HW Prefix & app\_\allowbreak{}modulation\_\allowbreak{}ipInfo\_\allowbreak{}firmwareVersion\\
 HW Address & 0x100008\\
 C Prefix & app.\allowbreak{}modulation.\allowbreak{}ipInfo.\allowbreak{}firmwareVersion\\
 C Block Offset & 0x8\\
+Access & read-only\\
 \end{regsummary}
+
+Firmware Version
 
 \begin{regdraw}
 31 & 30 & 29 & 28 & 27 & 26 & 25 & 24 \\
@@ -271,20 +273,23 @@ C Block Offset & 0x8\\
 \end{regdraw}
 
 \begin{regdesc}
-23:16 & ro & major & Major version indicating incompatible changes\\
-15:8 & ro & minor & Minor version indicating feature enhancements\\
-7:0 & ro & patch & Patch indicating bug fixes\\
+23:16 & major & {Major version indicating incompatible changes}\\
+15:8 & minor & {Minor version indicating feature enhancements}\\
+7:0 & patch & {Patch indicating bug fixes}\\
 \end{regdesc}
 
 
 \subsubsection{app.\allowbreak{}modulation.\allowbreak{}ipInfo.\allowbreak{}memMapVersion}
 \label{sec:app.modulation.ipInfo.memMapVersion}
 \begin{regsummary}
-HW Prefix & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}ipInfo\textunderscore\allowbreak{}memMapVersion\\
+HW Prefix & app\_\allowbreak{}modulation\_\allowbreak{}ipInfo\_\allowbreak{}memMapVersion\\
 HW Address & 0x10000c\\
 C Prefix & app.\allowbreak{}modulation.\allowbreak{}ipInfo.\allowbreak{}memMapVersion\\
 C Block Offset & 0xc\\
+Access & read-only\\
 \end{regsummary}
+
+Memory Map Version
 
 \begin{regdraw}
 31 & 30 & 29 & 28 & 27 & 26 & 25 & 24 \\
@@ -298,20 +303,23 @@ C Block Offset & 0xc\\
 \end{regdraw}
 
 \begin{regdesc}
-23:16 & ro & major & Major version indicating incompatible changes\\
-15:8 & ro & minor & Minor version indicating feature enhancements\\
-7:0 & ro & patch & Patch indicating bug fixes\\
+23:16 & major & {Major version indicating incompatible changes}\\
+15:8 & minor & {Minor version indicating feature enhancements}\\
+7:0 & patch & {Patch indicating bug fixes}\\
 \end{regdesc}
 
 
 \subsubsection{app.\allowbreak{}modulation.\allowbreak{}ipInfo.\allowbreak{}echo}
 \label{sec:app.modulation.ipInfo.echo}
 \begin{regsummary}
-HW Prefix & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}ipInfo\textunderscore\allowbreak{}echo\\
+HW Prefix & app\_\allowbreak{}modulation\_\allowbreak{}ipInfo\_\allowbreak{}echo\\
 HW Address & 0x100010\\
 C Prefix & app.\allowbreak{}modulation.\allowbreak{}ipInfo.\allowbreak{}echo\\
 C Block Offset & 0x10\\
+Access & read/write\\
 \end{regsummary}
+
+Echo register.\allowbreak{} This version of the standard foresees only 8bits linked to real memory
 
 \begin{regdraw}
 31 & 30 & 29 & 28 & 27 & 26 & 25 & 24 \\
@@ -325,17 +333,18 @@ C Block Offset & 0x10\\
 \end{regdraw}
 
 \begin{regdesc}
-7:0 & rw & echo & This version of the standard foresees only 8bits linked to real memory\\
+7:0 & echo & {This version of the standard foresees only 8bits linked to real memory}\\
 \end{regdesc}
 
 
 \subsubsection{app.\allowbreak{}modulation.\allowbreak{}control}
 \label{sec:app.modulation.control}
 \begin{regsummary}
-HW Prefix & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}control\\
+HW Prefix & app\_\allowbreak{}modulation\_\allowbreak{}control\\
 HW Address & 0x100020\\
 C Prefix & app.\allowbreak{}modulation.\allowbreak{}control\\
 C Block Offset & 0x20\\
+Access & read/write\\
 \end{regsummary}
 
 \begin{regdraw}
@@ -350,28 +359,29 @@ C Block Offset & 0x20\\
 \end{regdraw}
 
 \begin{regdesc}
-0 & rw & useTestSignal & Use DDS generated test signal instead of ADC input as demodulation inputTest signal is synthezied with additional internal DDS, test signals frequency given by ftw\textunderscore\allowbreak{}RF.\allowbreak{}\\
-1 & rw & useImpulse & Use impulse instead of demodulation output\\
-2 & rw & useStaticSignal & Use static signal from register instead of demodulation output\\
-5 & rw & bypassDemod & Bypass demodulator\\
-6 & rw & bypassMod & Bypass modulator\\
-7 & rw & wrInputsValid & transmit WR frame\\
-11 & rw & wrInputsValidLatch & transmit WR no autoclear\\
-8 & rw & wrResetNCO & activate WR frame control bit\\
-9 & rw & wrResetSlip & activate WR frame control bit\\
-10 & rw & wrRresetFSK & activate WR frame control bit\\
-14:12 & rw & rate & \\
-15 & rw & clearBPLatches & \\
+0 & useTestSignal & {Use DDS generated test signal instead of ADC input as demodulation input \newline  \newline Test signal is synthezied with additional internal DDS, test signals frequency given by ftw\_\allowbreak{}RF.\allowbreak{}}\\
+1 & useImpulse & {Use impulse instead of demodulation output}\\
+2 & useStaticSignal & {Use static signal from register instead of demodulation output}\\
+5 & bypassDemod & {Bypass demodulator}\\
+6 & bypassMod & {Bypass modulator}\\
+7 & wrInputsValid & {transmit WR frame}\\
+11 & wrInputsValidLatch & {transmit WR no autoclear}\\
+8 & wrResetNCO & {activate WR frame control bit}\\
+9 & wrResetSlip & {activate WR frame control bit}\\
+10 & wrRresetFSK & {activate WR frame control bit}\\
+14:12 & rate & {}\\
+15 & clearBPLatches & {}\\
 \end{regdesc}
 
 
 \subsubsection{app.\allowbreak{}modulation.\allowbreak{}testSignal.\allowbreak{}amplitude}
 \label{sec:app.modulation.testSignal.amplitude}
 \begin{regsummary}
-HW Prefix & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}testSignal\textunderscore\allowbreak{}amplitude\\
+HW Prefix & app\_\allowbreak{}modulation\_\allowbreak{}testSignal\_\allowbreak{}amplitude\\
 HW Address & 0x100030\\
 C Prefix & app.\allowbreak{}modulation.\allowbreak{}testSignal.\allowbreak{}amplitude\\
 C Block Offset & 0x0\\
+Access & read/write\\
 \end{regsummary}
 
 \begin{regdraw}
@@ -382,17 +392,18 @@ C Block Offset & 0x0\\
 \end{regdraw}
 
 \begin{regdesc}
-15:0 & rw & amplitude & Amplitude for the test signal\\
+15:0 & amplitude & {Amplitude for the test signal}\\
 \end{regdesc}
 
 
 \subsubsection{app.\allowbreak{}modulation.\allowbreak{}testSignal.\allowbreak{}ftw}
 \label{sec:app.modulation.testSignal.ftw}
 \begin{regsummary}
-HW Prefix & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}testSignal\textunderscore\allowbreak{}ftw\\
+HW Prefix & app\_\allowbreak{}modulation\_\allowbreak{}testSignal\_\allowbreak{}ftw\\
 HW Address & 0x100038\\
 C Prefix & app.\allowbreak{}modulation.\allowbreak{}testSignal.\allowbreak{}ftw\\
 C Block Offset & 0x8\\
+Access & read/write\\
 \end{regsummary}
 
 \begin{regdraw}
@@ -415,17 +426,18 @@ C Block Offset & 0x8\\
 \end{regdraw}
 
 \begin{regdesc}
-63:0 & rw & ftw & FTW of the test signal (frequency relative to fs)\\
+63:0 & ftw & {FTW of the test signal (frequency relative to fs)}\\
 \end{regdesc}
 
 
 \subsubsection{app.\allowbreak{}modulation.\allowbreak{}staticSignal.\allowbreak{}i}
 \label{sec:app.modulation.staticSignal.i}
 \begin{regsummary}
-HW Prefix & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}staticSignal\textunderscore\allowbreak{}i\\
+HW Prefix & app\_\allowbreak{}modulation\_\allowbreak{}staticSignal\_\allowbreak{}i\\
 HW Address & 0x100040\\
 C Prefix & app.\allowbreak{}modulation.\allowbreak{}staticSignal.\allowbreak{}i\\
 C Block Offset & 0x0\\
+Access & read/write\\
 \end{regsummary}
 
 \begin{regdraw}
@@ -436,17 +448,18 @@ C Block Offset & 0x0\\
 \end{regdraw}
 
 \begin{regdesc}
-15:0 & rw & i & Constant to be used as OTF input for channel I\\
+15:0 & i & {Constant to be used as OTF input for channel I}\\
 \end{regdesc}
 
 
 \subsubsection{app.\allowbreak{}modulation.\allowbreak{}staticSignal.\allowbreak{}q}
 \label{sec:app.modulation.staticSignal.q}
 \begin{regsummary}
-HW Prefix & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}staticSignal\textunderscore\allowbreak{}q\\
+HW Prefix & app\_\allowbreak{}modulation\_\allowbreak{}staticSignal\_\allowbreak{}q\\
 HW Address & 0x100044\\
 C Prefix & app.\allowbreak{}modulation.\allowbreak{}staticSignal.\allowbreak{}q\\
 C Block Offset & 0x4\\
+Access & read/write\\
 \end{regsummary}
 
 \begin{regdraw}
@@ -457,17 +470,18 @@ C Block Offset & 0x4\\
 \end{regdraw}
 
 \begin{regdesc}
-15:0 & rw & q & Constant to be used as OTF input for channel Q\\
+15:0 & q & {Constant to be used as OTF input for channel Q}\\
 \end{regdesc}
 
 
 \subsubsection{app.\allowbreak{}modulation.\allowbreak{}ftwH1main}
 \label{sec:app.modulation.ftwH1main}
 \begin{regsummary}
-HW Prefix & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}ftwH1main\\
+HW Prefix & app\_\allowbreak{}modulation\_\allowbreak{}ftwH1main\\
 HW Address & 0x100050\\
 C Prefix & app.\allowbreak{}modulation.\allowbreak{}ftwH1main\\
 C Block Offset & 0x50\\
+Access & read/write\\
 \end{regsummary}
 
 \begin{regdraw}
@@ -490,17 +504,18 @@ C Block Offset & 0x50\\
 \end{regdraw}
 
 \begin{regdesc}
-63:0 & rw & ftwH1main & \\
+63:0 & ftwH1main & {}\\
 \end{regdesc}
 
 
 \subsubsection{app.\allowbreak{}modulation.\allowbreak{}ftwH1on}
 \label{sec:app.modulation.ftwH1on}
 \begin{regsummary}
-HW Prefix & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}ftwH1on\\
+HW Prefix & app\_\allowbreak{}modulation\_\allowbreak{}ftwH1on\\
 HW Address & 0x100058\\
 C Prefix & app.\allowbreak{}modulation.\allowbreak{}ftwH1on\\
 C Block Offset & 0x58\\
+Access & read/write\\
 \end{regsummary}
 
 \begin{regdraw}
@@ -523,17 +538,18 @@ C Block Offset & 0x58\\
 \end{regdraw}
 
 \begin{regdesc}
-63:0 & rw & ftwH1on & \\
+63:0 & ftwH1on & {}\\
 \end{regdesc}
 
 
 \subsubsection{app.\allowbreak{}modulation.\allowbreak{}dftwH1slip0}
 \label{sec:app.modulation.dftwH1slip0}
 \begin{regsummary}
-HW Prefix & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}dftwH1slip0\\
+HW Prefix & app\_\allowbreak{}modulation\_\allowbreak{}dftwH1slip0\\
 HW Address & 0x100060\\
 C Prefix & app.\allowbreak{}modulation.\allowbreak{}dftwH1slip0\\
 C Block Offset & 0x60\\
+Access & read/write\\
 \end{regsummary}
 
 \begin{regdraw}
@@ -548,17 +564,18 @@ C Block Offset & 0x60\\
 \end{regdraw}
 
 \begin{regdesc}
-31:0 & rw & dftwH1slip0 & \\
+31:0 & dftwH1slip0 & {}\\
 \end{regdesc}
 
 
 \subsubsection{app.\allowbreak{}modulation.\allowbreak{}dftwH1slip1}
 \label{sec:app.modulation.dftwH1slip1}
 \begin{regsummary}
-HW Prefix & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}dftwH1slip1\\
+HW Prefix & app\_\allowbreak{}modulation\_\allowbreak{}dftwH1slip1\\
 HW Address & 0x100064\\
 C Prefix & app.\allowbreak{}modulation.\allowbreak{}dftwH1slip1\\
 C Block Offset & 0x64\\
+Access & read/write\\
 \end{regsummary}
 
 \begin{regdraw}
@@ -573,17 +590,18 @@ C Block Offset & 0x64\\
 \end{regdraw}
 
 \begin{regdesc}
-31:0 & rw & dftwH1slip1 & \\
+31:0 & dftwH1slip1 & {}\\
 \end{regdesc}
 
 
 \subsubsection{app.\allowbreak{}modulation.\allowbreak{}latches}
 \label{sec:app.modulation.latches}
 \begin{regsummary}
-HW Prefix & app\textunderscore\allowbreak{}modulation\textunderscore\allowbreak{}latches\\
+HW Prefix & app\_\allowbreak{}modulation\_\allowbreak{}latches\\
 HW Address & 0x100068\\
 C Prefix & app.\allowbreak{}modulation.\allowbreak{}latches\\
 C Block Offset & 0x68\\
+Access & read/write\\
 \end{regsummary}
 
 \begin{regdraw}
@@ -598,19 +616,20 @@ C Block Offset & 0x68\\
 \end{regdraw}
 
 \begin{regdesc}
-7:0 & rw & backplane & \\
+7:0 & backplane & {}\\
 \end{regdesc}
 
 
 \subsection{Register Description for Space bar4}
 
-\subsubsection{fgc\textunderscore\allowbreak{}ddr.\allowbreak{}data64.\allowbreak{}data64}
+\subsubsection{fgc\_\allowbreak{}ddr.\allowbreak{}data64.\allowbreak{}data64}
 \label{sec:fgc_ddr.data64.data64}
 \begin{regsummary}
-HW Prefix & fgc\textunderscore\allowbreak{}ddr\textunderscore\allowbreak{}data64\textunderscore\allowbreak{}data64\\
+HW Prefix & fgc\_\allowbreak{}ddr\_\allowbreak{}data64\_\allowbreak{}data64\\
 HW Address & 0x0\\
-C Prefix & fgc\textunderscore\allowbreak{}ddr.\allowbreak{}data64.\allowbreak{}data64\\
+C Prefix & fgc\_\allowbreak{}ddr.\allowbreak{}data64.\allowbreak{}data64\\
 C Block Offset & 0x0\\
+Access & read/write\\
 \end{regsummary}
 
 \begin{regdraw}
@@ -633,18 +652,19 @@ C Block Offset & 0x0\\
 \end{regdraw}
 
 \begin{regdesc}
-63:32 & rw & upper & \\
-31:0 & rw & lower & \\
+63:32 & upper & {}\\
+31:0 & lower & {}\\
 \end{regdesc}
 
 
-\subsubsection{acq\textunderscore\allowbreak{}ddr.\allowbreak{}data32.\allowbreak{}data32}
+\subsubsection{acq\_\allowbreak{}ddr.\allowbreak{}data32.\allowbreak{}data32}
 \label{sec:acq_ddr.data32.data32}
 \begin{regsummary}
-HW Prefix & acq\textunderscore\allowbreak{}ddr\textunderscore\allowbreak{}data32\textunderscore\allowbreak{}data32\\
+HW Prefix & acq\_\allowbreak{}ddr\_\allowbreak{}data32\_\allowbreak{}data32\\
 HW Address & 0x20000000\\
-C Prefix & acq\textunderscore\allowbreak{}ddr.\allowbreak{}data32.\allowbreak{}data32\\
+C Prefix & acq\_\allowbreak{}ddr.\allowbreak{}data32.\allowbreak{}data32\\
 C Block Offset & 0x0\\
+Access & read/write\\
 \end{regsummary}
 
 \begin{regdraw}
@@ -659,18 +679,19 @@ C Block Offset & 0x0\\
 \end{regdraw}
 
 \begin{regdesc}
-31:16 & rw & upper & \\
-15:0 & rw & lower & \\
+31:16 & upper & {}\\
+15:0 & lower & {}\\
 \end{regdesc}
 
 
-\subsubsection{acq\textunderscore\allowbreak{}ram.\allowbreak{}data32.\allowbreak{}data32}
+\subsubsection{acq\_\allowbreak{}ram.\allowbreak{}data32.\allowbreak{}data32}
 \label{sec:acq_ram.data32.data32}
 \begin{regsummary}
-HW Prefix & acq\textunderscore\allowbreak{}ram\textunderscore\allowbreak{}data32\textunderscore\allowbreak{}data32\\
+HW Prefix & acq\_\allowbreak{}ram\_\allowbreak{}data32\_\allowbreak{}data32\\
 HW Address & 0x80000000\\
-C Prefix & acq\textunderscore\allowbreak{}ram.\allowbreak{}data32.\allowbreak{}data32\\
+C Prefix & acq\_\allowbreak{}ram.\allowbreak{}data32.\allowbreak{}data32\\
 C Block Offset & 0x0\\
+Access & read/write\\
 \end{regsummary}
 
 \begin{regdraw}
@@ -685,8 +706,8 @@ C Block Offset & 0x0\\
 \end{regdraw}
 
 \begin{regdesc}
-31:16 & rw & upper & \\
-15:0 & rw & lower & \\
+31:16 & upper & {}\\
+15:0 & lower & {}\\
 \end{regdesc}
 
 

--- a/testfiles/issue9/test.html
+++ b/testfiles/issue9/test.html
@@ -162,11 +162,10 @@ Test register 1
  <td class="td_field" colspan="8">register1[7:0]</td>
 </tr>
 </table>
-<ul>
-<li><b>
-register1
-</b>[<i>wo</i>]: Test register 1
-</ul>
+<dl>
+  <dt><b>register1</b> [<i>wo</i>]</dt>
+  <dd>Test register 1</dd>
+</dl>
 <a name="block1.register2"></a>
 <h3>2.2. block1.register2</h3>
 <table cellpadding=0 cellspacing=0 border=0>
@@ -258,14 +257,12 @@ Test register 2
  <td class="td_field" colspan="1">field1</td>
 </tr>
 </table>
-<ul>
-<li><b>
-field1
-</b>[<i>ro</i>]: Test field 1
-<li><b>
-field2
-</b>[<i>ro</i>]: Test field 2
-</ul>
+<dl>
+  <dt><b>field1</b> [<i>ro</i>]</dt>
+  <dd>Test field 1</dd>
+  <dt><b>field2</b> [<i>ro</i>]</dt>
+  <dd>Test field 2</dd>
+</dl>
 <a name="block1.register3"></a>
 <h3>2.3. block1.register3</h3>
 <table cellpadding=0 cellspacing=0 border=0>
@@ -331,11 +328,10 @@ Test register 3
  <td class="td_field" colspan="8">register3[7:0]</td>
 </tr>
 </table>
-<ul>
-<li><b>
-register3
-</b>[<i>rw</i>]: Test register 3
-</ul>
+<dl>
+  <dt><b>register3</b> [<i>rw</i>]</dt>
+  <dd>Test register 3</dd>
+</dl>
 <a name="block1.block2.register4"></a>
 <h3>2.4. block1.block2.register4</h3>
 <table cellpadding=0 cellspacing=0 border=0>
@@ -427,14 +423,12 @@ Test register 4
  <td class="td_field" colspan="1">field3</td>
 </tr>
 </table>
-<ul>
-<li><b>
-field3
-</b>[<i>ro</i>]: Test field 3
-<li><b>
-field4
-</b>[<i>ro</i>]: Test field 4
-</ul>
+<dl>
+  <dt><b>field3</b> [<i>ro</i>]</dt>
+  <dd>Test field 3</dd>
+  <dt><b>field4</b> [<i>ro</i>]</dt>
+  <dd>Test field 4</dd>
+</dl>
 
 
 </BODY>

--- a/testfiles/issue9/test.tex
+++ b/testfiles/issue9/test.tex
@@ -4,10 +4,10 @@ Test AXI4-Lite interface
 \begin{memmap}
 0x00 & REG & \hyperref[sec:register1]{register1} & register1\\
 0x10-0x1f & BLOCK & block1 & block1\\
-0x10 & REG & \hyperref[sec:block1.register2]{block1.\allowbreak{}register2} & block1\textunderscore\allowbreak{}register2\\
-0x14 & REG & \hyperref[sec:block1.register3]{block1.\allowbreak{}register3} & block1\textunderscore\allowbreak{}register3\\
-0x18-0x1b & BLOCK & block1.\allowbreak{}block2 & block1\textunderscore\allowbreak{}block2\\
-0x18 & REG & \hyperref[sec:block1.block2.register4]{block1.\allowbreak{}block2.\allowbreak{}register4} & block1\textunderscore\allowbreak{}block2\textunderscore\allowbreak{}register4\\
+0x10 & REG & \hyperref[sec:block1.register2]{block1.\allowbreak{}register2} & block1\_\allowbreak{}register2\\
+0x14 & REG & \hyperref[sec:block1.register3]{block1.\allowbreak{}register3} & block1\_\allowbreak{}register3\\
+0x18-0x1b & BLOCK & block1.\allowbreak{}block2 & block1\_\allowbreak{}block2\\
+0x18 & REG & \hyperref[sec:block1.block2.register4]{block1.\allowbreak{}block2.\allowbreak{}register4} & block1\_\allowbreak{}block2\_\allowbreak{}register4\\
 \end{memmap}
 
 \section{Register Description}
@@ -18,6 +18,7 @@ HW Prefix & register1\\
 HW Address & 0x0\\
 C Prefix & register1\\
 C Block Offset & 0x0\\
+Access & write-only\\
 \end{regsummary}
 
 \begin{regdraw}
@@ -32,18 +33,21 @@ C Block Offset & 0x0\\
 \end{regdraw}
 
 \begin{regdesc}
-31:0 & wo & register1 & Test register 1\\
+31:0 & register1 & {Test register 1}\\
 \end{regdesc}
 
 
 \subsubsection{block1.\allowbreak{}register2}
 \label{sec:block1.register2}
 \begin{regsummary}
-HW Prefix & block1\textunderscore\allowbreak{}register2\\
+HW Prefix & block1\_\allowbreak{}register2\\
 HW Address & 0x10\\
 C Prefix & block1.\allowbreak{}register2\\
 C Block Offset & 0x0\\
+Access & read-only\\
 \end{regsummary}
+
+Test register 2
 
 \begin{regdraw}
 31 & 30 & 29 & 28 & 27 & 26 & 25 & 24 \\
@@ -57,18 +61,19 @@ C Block Offset & 0x0\\
 \end{regdraw}
 
 \begin{regdesc}
-0 & ro & field1 & Test field 1\\
-3:1 & ro & field2 & Test field 2\\
+0 & field1 & {Test field 1}\\
+3:1 & field2 & {Test field 2}\\
 \end{regdesc}
 
 
 \subsubsection{block1.\allowbreak{}register3}
 \label{sec:block1.register3}
 \begin{regsummary}
-HW Prefix & block1\textunderscore\allowbreak{}register3\\
+HW Prefix & block1\_\allowbreak{}register3\\
 HW Address & 0x14\\
 C Prefix & block1.\allowbreak{}register3\\
 C Block Offset & 0x4\\
+Access & read/write\\
 \end{regsummary}
 
 \begin{regdraw}
@@ -83,18 +88,21 @@ C Block Offset & 0x4\\
 \end{regdraw}
 
 \begin{regdesc}
-31:0 & rw & register3 & Test register 3\\
+31:0 & register3 & {Test register 3}\\
 \end{regdesc}
 
 
 \subsubsection{block1.\allowbreak{}block2.\allowbreak{}register4}
 \label{sec:block1.block2.register4}
 \begin{regsummary}
-HW Prefix & block1\textunderscore\allowbreak{}block2\textunderscore\allowbreak{}register4\\
+HW Prefix & block1\_\allowbreak{}block2\_\allowbreak{}register4\\
 HW Address & 0x18\\
 C Prefix & block1.\allowbreak{}block2.\allowbreak{}register4\\
 C Block Offset & 0x0\\
+Access & read-only\\
 \end{regsummary}
+
+Test register 4
 
 \begin{regdraw}
 31 & 30 & 29 & 28 & 27 & 26 & 25 & 24 \\
@@ -108,8 +116,8 @@ C Block Offset & 0x0\\
 \end{regdraw}
 
 \begin{regdesc}
-0 & ro & field3 & Test field 3\\
-3:1 & ro & field4 & Test field 4\\
+0 & field3 & {Test field 3}\\
+3:1 & field4 & {Test field 4}\\
 \end{regdesc}
 
 


### PR DESCRIPTION
This PR improves the LaTeX documentation layout and was done in consultation with @stefanlippuner. 

- Add register `description` after register summary if register contains fields/children.
  + Single newline are respected (by adding `\\`).
  + Multiple newline are left and treated by LaTeX as a new paragraph.
- Allow line breaks inside bit field `description`.
  + Each newline is simply replaced with a `\newline` command (similar behavior than `\\`).
- Remove the `access` column from the bit field table to gain more width for the `description` column.
  + Not necessary to state per bit field as `access` type is set per register.
  + Add `access` type to the register summary instead.
- Allow bit field table to break at page end and spread over multiple pages.
- Adapt long table layout.
  + Remove caption.
  + Add row header to be shown on each page of a continuous table.
- Improve escaping of special characters.

There is one change concerning the HTML documentation: Similar to LaTeX, newlines are now supported in the bit field. In order to do so, the `<ul>` lists have been changed to descriptive lists, i.e., `<dl>`, which slightly alters how they look like.