### PR TITLE
Fix crash in maybe_pad due to missing el, make parameters explicit

### DIFF
--- a/proto/tests.py
+++ b/proto/tests.py
@@ -129,7 +129,7 @@ def layout_err(t):
 def test_layout():
     global nbr_tests
     hfiles = []
-    for f in ['demo', 'features/block1', 'features/array1', 'features/array2',
+    for f in ['padding-block/reg', 'demo', 'features/block1', 'features/array1', 'features/array2',
               'bug-gen-c/fids-errmiss',
               'bug-gen-c-02/mbox_regs',
               'bug-gen-c-02/fip_urv_regs',

--- a/testfiles/padding-block/reg.cheby
+++ b/testfiles/padding-block/reg.cheby
@@ -1,0 +1,45 @@
+memory-map:
+  bus: apb-32
+  name: padding_block_reg
+  x-hdl:
+    iogroup: regs
+    pipeline: rd-out
+    bus-error: True
+  description: 'Register map with a padding block.'
+  children:
+    - reg:
+        name: version
+        description: 'Hardware version.'
+        type: unsigned
+        width: 32
+        x-hdl:
+          type: const
+        access: ro
+        preset: 0x3
+    - reg:
+        name: control
+        description: 'Control register.'
+        width: 32
+        access: rw
+    - repeat:
+        name: subunit
+        count: 8
+        align: False
+        address: 0x100
+        x-hdl:
+          iogroup: subunit_regs
+        children:
+          - reg:
+              name: status
+              width: 32
+              access: ro
+          - reg:
+              name: control
+              description: 'Control stuff'
+              width: 32
+              access: wo
+          - block:
+              # Dummy block to align addresses to 0x80 grid
+              name: padding
+              align: false
+              size: 0x78


### PR DESCRIPTION
Changes:
  - Fix crash in maybe_pad due to missing el.
  - Add small testcase for this crash.
  - Change padding comment from words to bytes, as the 'words' could have a different width in the same file.

On master, generating a C file for the test file results in the following crash in `maybe_pad`:

```bash
cheby-dev -i reg.cheby --gen-c reg.h
# [...]
  File "proto/cheby/tree.py", line 32, in visit
    return f(*args, **kwargs)
  File "proto/cheby/gen_c.py", line 125, in cprint_block
    cprint_children(cp, n, n.c_size)
  File "proto/cheby/gen_c.py", line 100, in cprint_children
    maybe_pad(size - addr)
  File "proto/cheby/gen_c.py", line 69, in maybe_pad
    cp.cp_txt('/* padding to: {} words */'.format(el.c_address // sz))
NameError: free variable 'el' referenced before assignment in enclosing scope
```

The bug is triggered when `n.c_sorted_children` is empty. In that case, `el` is not defined before it's used for the last pad.

The padding comments referred to the number of words of the specific size, which could be quite confusing. E.g., the following could happen:

```c
    /* padding to: 28 words */
    uint8_t __padding_1[2];

    /* ... */

    /* padding to: 16 words */
    uint32_t __padding_0[5];
```

now this should be more clear:
```c
    /* padding to: 28 Bytes */
    uint8_t __padding_1[2];

    /* ... */

    /* padding to: 64 Bytes */
    uint32_t __padding_0[5];
```