### PR TITLE
Add CI configuration for Github (on push / pull request)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+on: [push, pull_request]
+
+name: CI
+
+jobs:
+  generation:
+    name: Generation
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Setup Python venv
+        run: |
+          python3 -m venv .venv
+          source .venv/bin/activate
+          python -V
+          pip install -r requirements.txt
+
+      - name: Test Generation
+        run: |
+          cd proto
+          python3 tests.py
+
+  interaction:
+    name: Interaction
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Install GHDL
+        run: sudo apt-get install ghdl
+
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Setup Python venv
+        run: |
+          python3 -m venv .venv
+          source .venv/bin/activate
+          python -V
+          pip install -r requirements.txt
+
+      - name: Test Generation
+        run: |
+          cd testfiles/tb
+          ./run.sh

--- a/testfiles/tb/run.sh
+++ b/testfiles/tb/run.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 GHDL=${GHDL:-ghdl}
 GHDL_FLAGS=--std=08


### PR DESCRIPTION
This enables the Gitlab CI jobs on Github too. This should hopefully prevent us from merging broken commits.

I had to switch `/testfiles/tb/run.sh` to bash, because /bin/sh doesn't point to bash on Ubuntu (the only Linux availbe for Github actions).

Example pipeline: https://github.com/stefanlippuner/cheby/actions/runs/6271367017