### PR TITLE
Add x-hdl attribute to control write mask generation

### DIFF
--- a/doc/cheby-ug.txt
+++ b/doc/cheby-ug.txt
@@ -289,6 +289,18 @@ or `RRESP`) is non-zero returning `SLVERR` (`0b10`).
 ** `wb-*`: In case of an error, the request is not acknowledged (`ACK` stays
 deasserted) but instead an error is returned (`ERR` is asserted).
 
+`wmask`:: Enable the masking of the write data in a write request through the
+dedicated bus features. The value is a boolean. By default this option is
+disabled. Only the following bus interfaces are supported:
+
+** `apb-32`: Using the `PSTRB` signal a Byte-wise mask is applied.
+
+** `avalon-lite-32`: Using the `BE` signal a Byte-wise mask is applied.
+
+** `axi4-lite-32`: Using the `WSTRB` signal a Byte-wise mask is applied.
+
+** `wb-*`: Using the `SEL` signal a Byte-wise mask is applied.
+
 === Registers
 
 A register uses one (usual case) or two (for 64-bit registers) words address.

--- a/proto/cheby/hdl/genreg.py
+++ b/proto/cheby/hdl/genreg.py
@@ -129,7 +129,7 @@ class GenFieldReg(GenFieldBase):
         reg, dat, mask = self.extract_reg_dat(
             off, self.field.h_reg, ibus.wr_dat, ibus.wr_sel
         )
-        if self.root.c_wmask_reg and mask is not None:
+        if hasattr(self.root, "hdl_wmask") and self.root.hdl_wmask and mask is not None:
             then_stmts.append(
                 HDLAssign(
                     reg,
@@ -154,7 +154,7 @@ class GenFieldNoPort(GenFieldBase):
         reg, dat, mask = self.extract_reg_dat(
             off, self.field.h_reg, ibus.wr_dat, ibus.wr_sel
         )
-        if self.root.c_wmask_reg and mask is not None:
+        if hasattr(self.root, "hdl_wmask") and self.root.hdl_wmask and mask is not None:
             then_stmts.append(
                 HDLAssign(
                     reg,
@@ -183,7 +183,11 @@ class GenFieldWire(GenFieldBase):
             reg, dat, mask = self.extract_reg_dat(
                 off, self.field.h_oport, ibus.wr_dat, ibus.wr_sel
             )
-            if self.root.c_wmask_reg and mask is not None:
+            if (
+                hasattr(self.root, "hdl_wmask")
+                and self.root.hdl_wmask
+                and mask is not None
+            ):
                 stmts.append(
                     HDLAssign(
                         reg,
@@ -219,7 +223,7 @@ class GenFieldAutoclear(GenFieldBase):
         reg, dat, mask = self.extract_reg_dat(
             off, self.field.h_reg, ibus.wr_dat, ibus.wr_sel
         )
-        if self.root.c_wmask_reg and mask is not None:
+        if hasattr(self.root, "hdl_wmask") and self.root.hdl_wmask and mask is not None:
             then_stmts.append(
                 HDLAssign(
                     reg,

--- a/proto/cheby/layout.py
+++ b/proto/cheby/layout.py
@@ -649,14 +649,12 @@ def layout_bus(root, name):
        * c_align_reg
        * c_bussplit
        * c_buserr
-       * c_wmask_reg
        And deduce:
        * c_addr_word_bits
        * c_word_bits"""
     root.c_align_reg = True
     root.c_buserr = False
     root.c_bussplit = False
-    root.c_wmask_reg = False
     if name is None:    # default
         root.c_word_size = 4
         root.c_word_endian = 'big'
@@ -735,7 +733,6 @@ def copy_bus(dst, src):
     dst.c_align_reg = src.c_align_reg
     dst.c_bussplit = src.c_bussplit
     dst.c_buserr = src.c_buserr
-    dst.c_wmask_reg = src.c_wmask_reg
     dst.c_addr_word_bits = src.c_addr_word_bits
     dst.c_word_bits = src.c_word_bits
 

--- a/testfiles/tb/run.sh
+++ b/testfiles/tb/run.sh
@@ -175,24 +175,10 @@ build_wmask_any()
     name="$1"
     name_short="$2"
 
-    local file="../../proto/cheby/layout.py"
-    local setting="root\.c_wmask_reg"
-
-    # Change default setting temporarily to enable write mask for all supporting interfaces
-    local prev_setting=$(grep "${setting}" "${file}" | awk '{print $NF}')
-    if [[ -n "${prev_setting}" && "${prev_setting}" == "False" ]]; then
-        sed -i "s|${setting} = ${prev_setting}|${setting} = True|" "${file}"
-    fi
-
     echo "## Testing register write mask for interface '${name}'"
     sed -e '/bus:/s/BUS/'"${name}"'/' -e '/name:/s/NAME/'"${name_short}"'/' < wmask.cheby > wmask_${name_short}.cheby
 
     build_any "wmask_${name_short}"
-
-    # Restore previous write mask setting
-    if [[ -n "${prev_setting}" && "${prev_setting}" == "False" ]]; then
-        sed -i "s|${setting} = True|${setting} = ${prev_setting}|" "${file}"
-    fi
 }
 
 # Build packages

--- a/testfiles/tb/wmask.cheby
+++ b/testfiles/tb/wmask.cheby
@@ -1,6 +1,8 @@
 memory-map:
   bus: BUS
   name: wmask_NAME
+  x-hdl:
+    wmask: True
   children:
   - reg:
       name: reg1


### PR DESCRIPTION
Originally introduced in d8c313276e086175e5a37b0ea0a8d0825b946bb1 (as part of #16), the hard-coded constant is replaced with a `x-hdl` attribute to be set on the memory map.