### PR TITLE
Pipeline reset value for multi-bit signals

### DIFF
--- a/testfiles/bug-cernbe/repro.vhdl
+++ b/testfiles/bug-cernbe/repro.vhdl
@@ -52,7 +52,10 @@ begin
     if rising_edge(Clk) then
       if rst_n = '0' then
         rd_ack_int <= '0';
+        VMERdData <= "0000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "00";
+        wr_dat_d0 <= "0000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         VMERdData <= rd_dat_d0;

--- a/testfiles/bug-cernbe/sub_repro.vhdl
+++ b/testfiles/bug-cernbe/sub_repro.vhdl
@@ -44,7 +44,10 @@ begin
     if rising_edge(Clk) then
       if rst_n = '0' then
         rd_ack_int <= '0';
+        VMERdData <= "0000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0";
+        wr_dat_d0 <= "0000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         VMERdData <= rd_dat_d0;

--- a/testfiles/bug-empty/noinp.vhdl
+++ b/testfiles/bug-empty/noinp.vhdl
@@ -94,7 +94,10 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/bug-empty/noout.vhdl
+++ b/testfiles/bug-empty/noout.vhdl
@@ -87,7 +87,9 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/bug-gen_wt/m1.vhdl
+++ b/testfiles/bug-gen_wt/m1.vhdl
@@ -50,7 +50,10 @@ begin
     if rising_edge(Clk) then
       if rst_n = '0' then
         rd_ack_int <= '0';
+        VMERdData <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         VMERdData <= rd_dat_d0;

--- a/testfiles/bug-memory/mem64ro.vhdl
+++ b/testfiles/bug-memory/mem64ro.vhdl
@@ -103,7 +103,11 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "00000000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
+        wr_sel_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/bug-repmem/bran.vhdl
+++ b/testfiles/bug-repmem/bran.vhdl
@@ -252,7 +252,10 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_o.dat <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0000000000000000000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_o.dat <= rd_dat_d0;

--- a/testfiles/crossbar/crossbar.v
+++ b/testfiles/crossbar/crossbar.v
@@ -91,7 +91,11 @@ module crossbar_wb
     if (!wb.rst_n)
       begin
         rd_ack_int <= 1'b0;
+        wb.dati <= 32'b00000000000000000000000000000000;
         wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 16'b0000000000000000;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+        wr_sel_d0 <= 32'b00000000000000000000000000000000;
       end
     else
       begin

--- a/testfiles/features/axi4_byte.vhdl
+++ b/testfiles/features/axi4_byte.vhdl
@@ -132,7 +132,10 @@ begin
     if rising_edge(aclk) then
       if areset_n = '0' then
         rd_ack <= '0';
+        rd_data <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack <= rd_ack_d0;
         rd_data <= rd_dat_d0;

--- a/testfiles/features/axi4_submap_wb.vhdl
+++ b/testfiles/features/axi4_submap_wb.vhdl
@@ -106,7 +106,11 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0";
+        wr_dat_d0 <= "00000000000000000000000000000000";
+        wr_sel_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/features/axi4_word.vhdl
+++ b/testfiles/features/axi4_word.vhdl
@@ -132,7 +132,10 @@ begin
     if rising_edge(aclk) then
       if areset_n = '0' then
         rd_ack <= '0';
+        rd_data <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack <= rd_ack_d0;
         rd_data <= rd_dat_d0;

--- a/testfiles/features/blkprefix1.vhdl
+++ b/testfiles/features/blkprefix1.vhdl
@@ -86,7 +86,10 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/features/blkprefix2.vhdl
+++ b/testfiles/features/blkprefix2.vhdl
@@ -86,7 +86,10 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/features/blkprefix3.vhdl
+++ b/testfiles/features/blkprefix3.vhdl
@@ -94,7 +94,10 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "00";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/features/blkprefix4.vhdl
+++ b/testfiles/features/blkprefix4.vhdl
@@ -114,7 +114,10 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/features/enums1.vhdl
+++ b/testfiles/features/enums1.vhdl
@@ -76,7 +76,9 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/features/enums2.vhdl
+++ b/testfiles/features/enums2.vhdl
@@ -76,7 +76,9 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/features/iogroup1.vhdl
+++ b/testfiles/features/iogroup1.vhdl
@@ -108,7 +108,10 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "00";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/features/iogroup2.vhdl
+++ b/testfiles/features/iogroup2.vhdl
@@ -95,7 +95,10 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/features/mapinfo2.vhdl
+++ b/testfiles/features/mapinfo2.vhdl
@@ -43,7 +43,10 @@ begin
     if rising_edge(Clk) then
       if rst_n = '0' then
         rd_ack_int <= '0';
+        VMERdData <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "000000000000000000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         VMERdData <= rd_dat_d0;

--- a/testfiles/features/mem64ro.vhdl
+++ b/testfiles/features/mem64ro.vhdl
@@ -103,7 +103,11 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "00000000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
+        wr_sel_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/features/mem64rodual.vhdl
+++ b/testfiles/features/mem64rodual.vhdl
@@ -95,7 +95,9 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_sel_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/features/no_port.vhdl
+++ b/testfiles/features/no_port.vhdl
@@ -60,7 +60,10 @@ begin
     if rising_edge(pclk) then
       if presetn = '0' then
         rd_ack <= '0';
+        rd_data <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack <= rd_ack_d0;
         rd_data <= rd_dat_d0;

--- a/testfiles/features/orclrout_rw.vhdl
+++ b/testfiles/features/orclrout_rw.vhdl
@@ -77,7 +77,9 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/features/reg-strobe.vhdl
+++ b/testfiles/features/reg-strobe.vhdl
@@ -78,7 +78,9 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/features/reg128.vhdl
+++ b/testfiles/features/reg128.vhdl
@@ -78,7 +78,10 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "00";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/features/regprefix1.vhdl
+++ b/testfiles/features/regprefix1.vhdl
@@ -94,7 +94,10 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "00";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/features/regprefix2.vhdl
+++ b/testfiles/features/regprefix2.vhdl
@@ -94,7 +94,10 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "00";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/features/regprefix3.vhdl
+++ b/testfiles/features/regprefix3.vhdl
@@ -90,7 +90,10 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/features/repeat-iogroup1.vhdl
+++ b/testfiles/features/repeat-iogroup1.vhdl
@@ -98,7 +98,10 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/features/repeat-iogroup2.vhdl
+++ b/testfiles/features/repeat-iogroup2.vhdl
@@ -102,7 +102,10 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/features/repeat-iogroup3.vhdl
+++ b/testfiles/features/repeat-iogroup3.vhdl
@@ -102,7 +102,10 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/features/repeat-iogroup4.vhdl
+++ b/testfiles/features/repeat-iogroup4.vhdl
@@ -106,7 +106,10 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/features/semver1.vhdl
+++ b/testfiles/features/semver1.vhdl
@@ -76,7 +76,9 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/features/semver2.vhdl
+++ b/testfiles/features/semver2.vhdl
@@ -78,7 +78,10 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/features/wires1.vhdl
+++ b/testfiles/features/wires1.vhdl
@@ -94,7 +94,10 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "00";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/features/xilinx_attrs.vhdl
+++ b/testfiles/features/xilinx_attrs.vhdl
@@ -229,7 +229,11 @@ begin
     if rising_edge(aclk) then
       if areset_n = '0' then
         rd_ack <= '0';
+        rd_data <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0";
+        wr_dat_d0 <= "00000000000000000000000000000000";
+        wr_sel_d0 <= "00000000000000000000000000000000";
       else
         rd_ack <= rd_ack_d0;
         rd_data <= rd_dat_d0;

--- a/testfiles/features/xilinx_attrs_cern.vhdl
+++ b/testfiles/features/xilinx_attrs_cern.vhdl
@@ -75,7 +75,10 @@ begin
     if rising_edge(Clk) then
       if rst_n = '0' then
         rd_ack_int <= '0';
+        VMERdData <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         VMERdData <= rd_dat_d0;

--- a/testfiles/fmc-adc01/fmc_adc_alt_trigin.vhdl
+++ b/testfiles/fmc-adc01/fmc_adc_alt_trigin.vhdl
@@ -79,7 +79,10 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_o.dat <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_o.dat <= rd_dat_d0;

--- a/testfiles/fmc-adc01/fmc_adc_alt_trigout.vhdl
+++ b/testfiles/fmc-adc01/fmc_adc_alt_trigout.vhdl
@@ -114,7 +114,10 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_o.dat <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_o.dat <= rd_dat_d0;

--- a/testfiles/issue10/test.vhdl
+++ b/testfiles/issue10/test.vhdl
@@ -144,7 +144,10 @@ begin
     if rising_edge(aclk) then
       if areset_n = '0' then
         rd_ack <= '0';
+        rd_data <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack <= rd_ack_d0;
         rd_data <= rd_dat_d0;

--- a/testfiles/issue11/test_port1.vhdl
+++ b/testfiles/issue11/test_port1.vhdl
@@ -78,7 +78,9 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/issue11/test_port1_field.vhdl
+++ b/testfiles/issue11/test_port1_field.vhdl
@@ -78,7 +78,9 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/issue11/test_port1_reg.vhdl
+++ b/testfiles/issue11/test_port1_reg.vhdl
@@ -77,7 +77,9 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/issue11/test_port2_reg.vhdl
+++ b/testfiles/issue11/test_port2_reg.vhdl
@@ -72,6 +72,7 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
       else
         rd_ack_int <= rd_ack_d0;

--- a/testfiles/issue11/test_port2_wire.vhdl
+++ b/testfiles/issue11/test_port2_wire.vhdl
@@ -77,7 +77,9 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/issue13/mainMap2.vhdl
+++ b/testfiles/issue13/mainMap2.vhdl
@@ -63,7 +63,10 @@ begin
     if rising_edge(Clk) then
       if rst_n = '0' then
         rd_ack_int <= '0';
+        VMERdData <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0000000000000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         VMERdData <= rd_dat_d0;

--- a/testfiles/issue14/test-axi.vhdl
+++ b/testfiles/issue14/test-axi.vhdl
@@ -126,7 +126,10 @@ begin
     if rising_edge(aclk) then
       if areset_n = '0' then
         rd_ack <= '0';
+        rd_data <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack <= rd_ack_d0;
         rd_data <= rd_dat_d0;

--- a/testfiles/issue14/test-be.vhdl
+++ b/testfiles/issue14/test-be.vhdl
@@ -126,7 +126,10 @@ begin
     if rising_edge(aclk) then
       if areset_n = '0' then
         rd_ack <= '0';
+        rd_data <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack <= rd_ack_d0;
         rd_data <= rd_dat_d0;

--- a/testfiles/issue14/test-le.vhdl
+++ b/testfiles/issue14/test-le.vhdl
@@ -126,7 +126,10 @@ begin
     if rising_edge(aclk) then
       if areset_n = '0' then
         rd_ack <= '0';
+        rd_data <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack <= rd_ack_d0;
         rd_data <= rd_dat_d0;

--- a/testfiles/issue39/addressingMemory.vhdl
+++ b/testfiles/issue39/addressingMemory.vhdl
@@ -52,7 +52,10 @@ begin
     if rising_edge(Clk) then
       if rst_n = '0' then
         rd_ack_int <= '0';
+        VMERdData <= "0000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "00000000000000000000";
+        wr_dat_d0 <= "0000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         VMERdData <= rd_dat_d0;

--- a/testfiles/issue40/bugConstraints.vhdl
+++ b/testfiles/issue40/bugConstraints.vhdl
@@ -47,7 +47,10 @@ begin
     if rising_edge(Clk) then
       if rst_n = '0' then
         rd_ack_int <= '0';
+        VMERdData <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         VMERdData <= rd_dat_d0;

--- a/testfiles/issue41/bugBlockFields.vhdl
+++ b/testfiles/issue41/bugBlockFields.vhdl
@@ -47,7 +47,9 @@ begin
     if rising_edge(Clk) then
       if rst_n = '0' then
         rd_ack_int <= '0';
+        VMERdData <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         VMERdData <= rd_dat_d0;

--- a/testfiles/issue44/m1.vhdl
+++ b/testfiles/issue44/m1.vhdl
@@ -105,7 +105,10 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "000000000000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/issue45/test16.vhdl
+++ b/testfiles/issue45/test16.vhdl
@@ -39,7 +39,9 @@ begin
     if rising_edge(Clk) then
       if rst_n = '0' then
         rd_ack_int <= '0';
+        VMERdData <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         VMERdData <= rd_dat_d0;

--- a/testfiles/issue45/test8.vhdl
+++ b/testfiles/issue45/test8.vhdl
@@ -39,7 +39,9 @@ begin
     if rising_edge(Clk) then
       if rst_n = '0' then
         rd_ack_int <= '0';
+        VMERdData <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         VMERdData <= rd_dat_d0;

--- a/testfiles/issue52/hwInfo.vhdl
+++ b/testfiles/issue52/hwInfo.vhdl
@@ -55,7 +55,10 @@ begin
     if rising_edge(Clk) then
       if rst_n = '0' then
         rd_ack_int <= '0';
+        VMERdData <= "0000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0000";
+        wr_dat_d0 <= "0000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         VMERdData <= rd_dat_d0;

--- a/testfiles/issue59/inherit.vhdl
+++ b/testfiles/issue59/inherit.vhdl
@@ -84,7 +84,9 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/issue64/simple_reg1.vhdl
+++ b/testfiles/issue64/simple_reg1.vhdl
@@ -76,7 +76,9 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/issue66/m1.vhdl
+++ b/testfiles/issue66/m1.vhdl
@@ -49,7 +49,10 @@ begin
     if rising_edge(Clk) then
       if rst_n = '0' then
         rd_ack_int <= '0';
+        VMERdData <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "000000000000000000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         VMERdData <= rd_dat_d0;

--- a/testfiles/issue75/m1.vhdl
+++ b/testfiles/issue75/m1.vhdl
@@ -41,7 +41,10 @@ begin
     if rising_edge(Clk) then
       if rst_n = '0' then
         rd_ack_int <= '0';
+        VMERdData <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         VMERdData <= rd_dat_d0;

--- a/testfiles/issue77/m1.vhdl
+++ b/testfiles/issue77/m1.vhdl
@@ -119,7 +119,9 @@ begin
     if rising_edge(aclk) then
       if areset_n = '0' then
         rd_ack <= '0';
+        rd_data <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack <= rd_ack_d0;
         rd_data <= rd_dat_d0;

--- a/testfiles/issue77/m2.vhdl
+++ b/testfiles/issue77/m2.vhdl
@@ -76,7 +76,9 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/issue77/m3.vhdl
+++ b/testfiles/issue77/m3.vhdl
@@ -39,7 +39,9 @@ begin
     if rising_edge(Clk) then
       if rst_n = '0' then
         rd_ack_int <= '0';
+        VMERdData <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         VMERdData <= rd_dat_d0;

--- a/testfiles/issue77/s1.vhdl
+++ b/testfiles/issue77/s1.vhdl
@@ -140,7 +140,10 @@ begin
     if rising_edge(aclk) then
       if areset_n = '0' then
         rd_ack <= '0';
+        rd_data <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_dat_d0 <= "00000000000000000000000000000000";
+        wr_sel_d0 <= "00000000000000000000000000000000";
       else
         rd_ack <= rd_ack_d0;
         rd_data <= rd_dat_d0;

--- a/testfiles/issue77/s2.vhdl
+++ b/testfiles/issue77/s2.vhdl
@@ -129,7 +129,9 @@ begin
     if rising_edge(aclk) then
       if areset_n = '0' then
         rd_ack <= '0';
+        rd_data <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack <= rd_ack_d0;
         rd_data <= rd_dat_d0;

--- a/testfiles/issue77/s3.vhdl
+++ b/testfiles/issue77/s3.vhdl
@@ -143,7 +143,10 @@ begin
     if rising_edge(aclk) then
       if areset_n = '0' then
         rd_ack <= '0';
+        rd_data <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_dat_d0 <= "00000000000000000000000000000000";
+        wr_sel_d0 <= "00000000000000000000000000000000";
       else
         rd_ack <= rd_ack_d0;
         rd_data <= rd_dat_d0;

--- a/testfiles/issue77/s4.vhdl
+++ b/testfiles/issue77/s4.vhdl
@@ -105,7 +105,11 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0";
+        wr_dat_d0 <= "00000000000000000000000000000000";
+        wr_sel_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/issue77/s5.vhdl
+++ b/testfiles/issue77/s5.vhdl
@@ -98,7 +98,11 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0";
+        wr_dat_d0 <= "00000000000000000000000000000000";
+        wr_sel_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/issue77/s6.vhdl
+++ b/testfiles/issue77/s6.vhdl
@@ -69,7 +69,9 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_o.dat <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_o.dat <= rd_dat_d0;

--- a/testfiles/issue79/CSR.vhdl
+++ b/testfiles/issue79/CSR.vhdl
@@ -134,7 +134,11 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "00000000000000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
+        wr_sel_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/issue8/simpleMap_bug.vhdl
+++ b/testfiles/issue8/simpleMap_bug.vhdl
@@ -40,7 +40,9 @@ begin
     if rising_edge(Clk) then
       if rst_n = '0' then
         rd_ack_int <= '0';
+        VMERdData <= "0000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         VMERdData <= rd_dat_d0;

--- a/testfiles/issue8/simpleMap_noBug.vhdl
+++ b/testfiles/issue8/simpleMap_noBug.vhdl
@@ -40,7 +40,9 @@ begin
     if rising_edge(Clk) then
       if rst_n = '0' then
         rd_ack_int <= '0';
+        VMERdData <= "0000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         VMERdData <= rd_dat_d0;

--- a/testfiles/issue84/sps200CavityControl_as.vhdl
+++ b/testfiles/issue84/sps200CavityControl_as.vhdl
@@ -178,7 +178,11 @@ begin
     if rising_edge(aclk) then
       if areset_n = '0' then
         rd_ack <= '0';
+        rd_data <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0000000000000000000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
+        wr_sel_d0 <= "00000000000000000000000000000000";
       else
         rd_ack <= rd_ack_d0;
         rd_data <= rd_dat_d0;

--- a/testfiles/issue87/qsm_regs.vhdl
+++ b/testfiles/issue87/qsm_regs.vhdl
@@ -140,7 +140,10 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_o.dat <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "000000000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_o.dat <= rd_dat_d0;

--- a/testfiles/issue89/map.vhdl
+++ b/testfiles/issue89/map.vhdl
@@ -49,7 +49,10 @@ begin
     if rising_edge(Clk) then
       if rst_n = '0' then
         rd_ack_int <= '0';
+        VMERdData <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "000000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         VMERdData <= rd_dat_d0;

--- a/testfiles/issue9/test.vhdl
+++ b/testfiles/issue9/test.vhdl
@@ -144,7 +144,10 @@ begin
     if rising_edge(aclk) then
       if areset_n = '0' then
         rd_ack <= '0';
+        rd_data <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack <= rd_ack_d0;
         rd_data <= rd_dat_d0;

--- a/testfiles/issue90/bugDPSSRAMbwSel.vhdl
+++ b/testfiles/issue90/bugDPSSRAMbwSel.vhdl
@@ -141,7 +141,11 @@ begin
     if rising_edge(aclk) then
       if areset_n = '0' then
         rd_ack <= '0';
+        rd_data <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "000000000000000000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
+        wr_sel_d0 <= "00000000000000000000000000000000";
       else
         rd_ack <= rd_ack_d0;
         rd_data <= rd_dat_d0;

--- a/testfiles/issue92/blockInMap.vhdl
+++ b/testfiles/issue92/blockInMap.vhdl
@@ -33,6 +33,7 @@ begin
     if rising_edge(Clk) then
       if rst_n = '0' then
         rd_ack_int <= '0';
+        VMERdData <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
       else
         rd_ack_int <= rd_ack_d0;

--- a/testfiles/memory01/mainMap.vhdl
+++ b/testfiles/memory01/mainMap.vhdl
@@ -43,6 +43,7 @@ begin
     if rising_edge(Clk) then
       if rst_n = '0' then
         rd_ack_int <= '0';
+        VMERdData <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
       else
         rd_ack_int <= rd_ack_d0;

--- a/testfiles/memory01/sramro.vhdl
+++ b/testfiles/memory01/sramro.vhdl
@@ -70,6 +70,7 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_o.dat <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
       else
         rd_ack_int <= rd_ack_d0;

--- a/testfiles/memory01/sramrw.vhdl
+++ b/testfiles/memory01/sramrw.vhdl
@@ -76,7 +76,10 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_o.dat <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "000000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_o.dat <= rd_dat_d0;

--- a/testfiles/memory01/sramwo.vhdl
+++ b/testfiles/memory01/sramwo.vhdl
@@ -71,7 +71,10 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_o.dat <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "000000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_o.dat <= rd_dat_d0;

--- a/testfiles/tb/golden_files/addrwidth_axi4_mst_byte-byte.vhdl
+++ b/testfiles/tb/golden_files/addrwidth_axi4_mst_byte-byte.vhdl
@@ -158,7 +158,11 @@ begin
     if rising_edge(aclk) then
       if areset_n = '0' then
         rd_ack <= '0';
+        rd_data <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "00";
+        wr_dat_d0 <= "00000000000000000000000000000000";
+        wr_sel_d0 <= "00000000000000000000000000000000";
       else
         rd_ack <= rd_ack_d0;
         rd_data <= rd_dat_d0;

--- a/testfiles/tb/golden_files/addrwidth_axi4_mst_byte-word.vhdl
+++ b/testfiles/tb/golden_files/addrwidth_axi4_mst_byte-word.vhdl
@@ -158,7 +158,11 @@ begin
     if rising_edge(aclk) then
       if areset_n = '0' then
         rd_ack <= '0';
+        rd_data <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "00";
+        wr_dat_d0 <= "00000000000000000000000000000000";
+        wr_sel_d0 <= "00000000000000000000000000000000";
       else
         rd_ack <= rd_ack_d0;
         rd_data <= rd_dat_d0;

--- a/testfiles/tb/golden_files/addrwidth_axi4_mst_word-byte.vhdl
+++ b/testfiles/tb/golden_files/addrwidth_axi4_mst_word-byte.vhdl
@@ -158,7 +158,11 @@ begin
     if rising_edge(aclk) then
       if areset_n = '0' then
         rd_ack <= '0';
+        rd_data <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "00";
+        wr_dat_d0 <= "00000000000000000000000000000000";
+        wr_sel_d0 <= "00000000000000000000000000000000";
       else
         rd_ack <= rd_ack_d0;
         rd_data <= rd_dat_d0;

--- a/testfiles/tb/golden_files/addrwidth_axi4_sub_byte-byte.vhdl
+++ b/testfiles/tb/golden_files/addrwidth_axi4_sub_byte-byte.vhdl
@@ -132,7 +132,10 @@ begin
     if rising_edge(aclk) then
       if areset_n = '0' then
         rd_ack <= '0';
+        rd_data <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack <= rd_ack_d0;
         rd_data <= rd_dat_d0;

--- a/testfiles/tb/golden_files/addrwidth_axi4_sub_byte-word.vhdl
+++ b/testfiles/tb/golden_files/addrwidth_axi4_sub_byte-word.vhdl
@@ -132,7 +132,10 @@ begin
     if rising_edge(aclk) then
       if areset_n = '0' then
         rd_ack <= '0';
+        rd_data <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack <= rd_ack_d0;
         rd_data <= rd_dat_d0;

--- a/testfiles/tb/golden_files/addrwidth_axi4_sub_word-byte.vhdl
+++ b/testfiles/tb/golden_files/addrwidth_axi4_sub_word-byte.vhdl
@@ -132,7 +132,10 @@ begin
     if rising_edge(aclk) then
       if areset_n = '0' then
         rd_ack <= '0';
+        rd_data <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack <= rd_ack_d0;
         rd_data <= rd_dat_d0;

--- a/testfiles/tb/golden_files/all1_apb_all.vhdl
+++ b/testfiles/tb/golden_files/all1_apb_all.vhdl
@@ -208,8 +208,13 @@ begin
     if rising_edge(pclk) then
       if presetn = '0' then
         rd_req_d0 <= '0';
+        rd_adr_d0 <= "0000000000000";
         rd_ack <= '0';
+        rd_data <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0000000000000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
+        wr_sel_d0 <= "00000000000000000000000000000000";
         wr_ack <= '0';
       else
         rd_req_d0 <= rd_req;

--- a/testfiles/tb/golden_files/all1_apb_in,out.vhdl
+++ b/testfiles/tb/golden_files/all1_apb_in,out.vhdl
@@ -208,8 +208,13 @@ begin
     if rising_edge(pclk) then
       if presetn = '0' then
         rd_req_d0 <= '0';
+        rd_adr_d0 <= "0000000000000";
         rd_ack <= '0';
+        rd_data <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0000000000000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
+        wr_sel_d0 <= "00000000000000000000000000000000";
         wr_ack <= '0';
       else
         rd_req_d0 <= rd_req;

--- a/testfiles/tb/golden_files/all1_apb_in.vhdl
+++ b/testfiles/tb/golden_files/all1_apb_in.vhdl
@@ -205,7 +205,11 @@ begin
     if rising_edge(pclk) then
       if presetn = '0' then
         rd_req_d0 <= '0';
+        rd_adr_d0 <= "0000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0000000000000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
+        wr_sel_d0 <= "00000000000000000000000000000000";
       else
         rd_req_d0 <= rd_req;
         rd_adr_d0 <= rd_addr;

--- a/testfiles/tb/golden_files/all1_apb_out.vhdl
+++ b/testfiles/tb/golden_files/all1_apb_out.vhdl
@@ -202,6 +202,7 @@ begin
     if rising_edge(pclk) then
       if presetn = '0' then
         rd_ack <= '0';
+        rd_data <= "00000000000000000000000000000000";
         wr_ack <= '0';
       else
         rd_ack <= rd_ack_d0;

--- a/testfiles/tb/golden_files/all1_apb_rd-in,wr-out.vhdl
+++ b/testfiles/tb/golden_files/all1_apb_rd-in,wr-out.vhdl
@@ -202,6 +202,7 @@ begin
     if rising_edge(pclk) then
       if presetn = '0' then
         rd_req_d0 <= '0';
+        rd_adr_d0 <= "0000000000000";
         wr_ack <= '0';
       else
         rd_req_d0 <= rd_req;

--- a/testfiles/tb/golden_files/all1_apb_rd-in.vhdl
+++ b/testfiles/tb/golden_files/all1_apb_rd-in.vhdl
@@ -201,6 +201,7 @@ begin
     if rising_edge(pclk) then
       if presetn = '0' then
         rd_req_d0 <= '0';
+        rd_adr_d0 <= "0000000000000";
       else
         rd_req_d0 <= rd_req;
         rd_adr_d0 <= rd_addr;

--- a/testfiles/tb/golden_files/all1_apb_rd-out.vhdl
+++ b/testfiles/tb/golden_files/all1_apb_rd-out.vhdl
@@ -201,6 +201,7 @@ begin
     if rising_edge(pclk) then
       if presetn = '0' then
         rd_ack <= '0';
+        rd_data <= "00000000000000000000000000000000";
       else
         rd_ack <= rd_ack_d0;
         rd_data <= rd_dat_d0;

--- a/testfiles/tb/golden_files/all1_apb_rd.vhdl
+++ b/testfiles/tb/golden_files/all1_apb_rd.vhdl
@@ -203,7 +203,9 @@ begin
     if rising_edge(pclk) then
       if presetn = '0' then
         rd_req_d0 <= '0';
+        rd_adr_d0 <= "0000000000000";
         rd_ack <= '0';
+        rd_data <= "00000000000000000000000000000000";
       else
         rd_req_d0 <= rd_req;
         rd_adr_d0 <= rd_addr;

--- a/testfiles/tb/golden_files/all1_apb_wr-in,rd-out.vhdl
+++ b/testfiles/tb/golden_files/all1_apb_wr-in,rd-out.vhdl
@@ -205,7 +205,11 @@ begin
     if rising_edge(pclk) then
       if presetn = '0' then
         rd_ack <= '0';
+        rd_data <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0000000000000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
+        wr_sel_d0 <= "00000000000000000000000000000000";
       else
         rd_ack <= rd_ack_d0;
         rd_data <= rd_dat_d0;

--- a/testfiles/tb/golden_files/all1_apb_wr-in.vhdl
+++ b/testfiles/tb/golden_files/all1_apb_wr-in.vhdl
@@ -203,6 +203,9 @@ begin
     if rising_edge(pclk) then
       if presetn = '0' then
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0000000000000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
+        wr_sel_d0 <= "00000000000000000000000000000000";
       else
         wr_req_d0 <= wr_req;
         wr_adr_d0 <= wr_addr;

--- a/testfiles/tb/golden_files/all1_apb_wr.vhdl
+++ b/testfiles/tb/golden_files/all1_apb_wr.vhdl
@@ -204,6 +204,9 @@ begin
     if rising_edge(pclk) then
       if presetn = '0' then
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0000000000000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
+        wr_sel_d0 <= "00000000000000000000000000000000";
         wr_ack <= '0';
       else
         wr_req_d0 <= wr_req;

--- a/testfiles/tb/golden_files/all1_avalon_all.vhdl
+++ b/testfiles/tb/golden_files/all1_avalon_all.vhdl
@@ -209,8 +209,12 @@ begin
     if rising_edge(clk) then
       if rst_n = '0' then
         rd_req_d0 <= '0';
+        rd_adr_d0 <= "0000000000000";
         rd_ack <= '0';
+        readdata <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_dat_d0 <= "00000000000000000000000000000000";
+        wr_sel_d0 <= "00000000000000000000000000000000";
         wr_ack <= '0';
       else
         rd_req_d0 <= rd_req;

--- a/testfiles/tb/golden_files/all1_avalon_in,out.vhdl
+++ b/testfiles/tb/golden_files/all1_avalon_in,out.vhdl
@@ -209,8 +209,12 @@ begin
     if rising_edge(clk) then
       if rst_n = '0' then
         rd_req_d0 <= '0';
+        rd_adr_d0 <= "0000000000000";
         rd_ack <= '0';
+        readdata <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_dat_d0 <= "00000000000000000000000000000000";
+        wr_sel_d0 <= "00000000000000000000000000000000";
         wr_ack <= '0';
       else
         rd_req_d0 <= rd_req;

--- a/testfiles/tb/golden_files/all1_avalon_in.vhdl
+++ b/testfiles/tb/golden_files/all1_avalon_in.vhdl
@@ -206,7 +206,10 @@ begin
     if rising_edge(clk) then
       if rst_n = '0' then
         rd_req_d0 <= '0';
+        rd_adr_d0 <= "0000000000000";
         wr_req_d0 <= '0';
+        wr_dat_d0 <= "00000000000000000000000000000000";
+        wr_sel_d0 <= "00000000000000000000000000000000";
       else
         rd_req_d0 <= rd_req;
         rd_adr_d0 <= adr;

--- a/testfiles/tb/golden_files/all1_avalon_out.vhdl
+++ b/testfiles/tb/golden_files/all1_avalon_out.vhdl
@@ -204,6 +204,7 @@ begin
     if rising_edge(clk) then
       if rst_n = '0' then
         rd_ack <= '0';
+        readdata <= "00000000000000000000000000000000";
         wr_ack <= '0';
       else
         rd_ack <= rd_ack_d0;

--- a/testfiles/tb/golden_files/all1_avalon_rd-in,wr-out.vhdl
+++ b/testfiles/tb/golden_files/all1_avalon_rd-in,wr-out.vhdl
@@ -211,6 +211,7 @@ begin
     if rising_edge(clk) then
       if rst_n = '0' then
         rd_req_d0 <= '0';
+        rd_adr_d0 <= "0000000000000";
         wr_ack <= '0';
       else
         rd_req_d0 <= rd_req;

--- a/testfiles/tb/golden_files/all1_avalon_rd-in.vhdl
+++ b/testfiles/tb/golden_files/all1_avalon_rd-in.vhdl
@@ -210,6 +210,7 @@ begin
     if rising_edge(clk) then
       if rst_n = '0' then
         rd_req_d0 <= '0';
+        rd_adr_d0 <= "0000000000000";
       else
         rd_req_d0 <= rd_req;
         rd_adr_d0 <= adr;

--- a/testfiles/tb/golden_files/all1_avalon_rd-out.vhdl
+++ b/testfiles/tb/golden_files/all1_avalon_rd-out.vhdl
@@ -203,6 +203,7 @@ begin
     if rising_edge(clk) then
       if rst_n = '0' then
         rd_ack <= '0';
+        readdata <= "00000000000000000000000000000000";
       else
         rd_ack <= rd_ack_d0;
         readdata <= rd_dat_d0;

--- a/testfiles/tb/golden_files/all1_avalon_rd.vhdl
+++ b/testfiles/tb/golden_files/all1_avalon_rd.vhdl
@@ -212,7 +212,9 @@ begin
     if rising_edge(clk) then
       if rst_n = '0' then
         rd_req_d0 <= '0';
+        rd_adr_d0 <= "0000000000000";
         rd_ack <= '0';
+        readdata <= "00000000000000000000000000000000";
       else
         rd_req_d0 <= rd_req;
         rd_adr_d0 <= adr;

--- a/testfiles/tb/golden_files/all1_avalon_wr-in,rd-out.vhdl
+++ b/testfiles/tb/golden_files/all1_avalon_wr-in,rd-out.vhdl
@@ -214,7 +214,11 @@ begin
     if rising_edge(clk) then
       if rst_n = '0' then
         rd_ack <= '0';
+        readdata <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0000000000000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
+        wr_sel_d0 <= "00000000000000000000000000000000";
       else
         rd_ack <= rd_ack_d0;
         readdata <= rd_dat_d0;

--- a/testfiles/tb/golden_files/all1_avalon_wr-in.vhdl
+++ b/testfiles/tb/golden_files/all1_avalon_wr-in.vhdl
@@ -212,6 +212,9 @@ begin
     if rising_edge(clk) then
       if rst_n = '0' then
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0000000000000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
+        wr_sel_d0 <= "00000000000000000000000000000000";
       else
         wr_req_d0 <= wr_req;
         wr_adr_d0 <= adr;

--- a/testfiles/tb/golden_files/all1_avalon_wr.vhdl
+++ b/testfiles/tb/golden_files/all1_avalon_wr.vhdl
@@ -213,6 +213,9 @@ begin
     if rising_edge(clk) then
       if rst_n = '0' then
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0000000000000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
+        wr_sel_d0 <= "00000000000000000000000000000000";
         wr_ack <= '0';
       else
         wr_req_d0 <= wr_req;

--- a/testfiles/tb/golden_files/all1_axi4_all.vhdl
+++ b/testfiles/tb/golden_files/all1_axi4_all.vhdl
@@ -275,8 +275,13 @@ begin
     if rising_edge(aclk) then
       if areset_n = '0' then
         rd_req_d0 <= '0';
+        rd_adr_d0 <= "0000000000000";
         rd_ack <= '0';
+        rd_data <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0000000000000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
+        wr_sel_d0 <= "00000000000000000000000000000000";
         wr_ack <= '0';
       else
         rd_req_d0 <= rd_req;

--- a/testfiles/tb/golden_files/all1_axi4_in,out.vhdl
+++ b/testfiles/tb/golden_files/all1_axi4_in,out.vhdl
@@ -275,8 +275,13 @@ begin
     if rising_edge(aclk) then
       if areset_n = '0' then
         rd_req_d0 <= '0';
+        rd_adr_d0 <= "0000000000000";
         rd_ack <= '0';
+        rd_data <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0000000000000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
+        wr_sel_d0 <= "00000000000000000000000000000000";
         wr_ack <= '0';
       else
         rd_req_d0 <= rd_req;

--- a/testfiles/tb/golden_files/all1_axi4_in.vhdl
+++ b/testfiles/tb/golden_files/all1_axi4_in.vhdl
@@ -272,7 +272,11 @@ begin
     if rising_edge(aclk) then
       if areset_n = '0' then
         rd_req_d0 <= '0';
+        rd_adr_d0 <= "0000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0000000000000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
+        wr_sel_d0 <= "00000000000000000000000000000000";
       else
         rd_req_d0 <= rd_req;
         rd_adr_d0 <= rd_addr;

--- a/testfiles/tb/golden_files/all1_axi4_out.vhdl
+++ b/testfiles/tb/golden_files/all1_axi4_out.vhdl
@@ -269,6 +269,7 @@ begin
     if rising_edge(aclk) then
       if areset_n = '0' then
         rd_ack <= '0';
+        rd_data <= "00000000000000000000000000000000";
         wr_ack <= '0';
       else
         rd_ack <= rd_ack_d0;

--- a/testfiles/tb/golden_files/all1_axi4_rd-in,wr-out.vhdl
+++ b/testfiles/tb/golden_files/all1_axi4_rd-in,wr-out.vhdl
@@ -269,6 +269,7 @@ begin
     if rising_edge(aclk) then
       if areset_n = '0' then
         rd_req_d0 <= '0';
+        rd_adr_d0 <= "0000000000000";
         wr_ack <= '0';
       else
         rd_req_d0 <= rd_req;

--- a/testfiles/tb/golden_files/all1_axi4_rd-in.vhdl
+++ b/testfiles/tb/golden_files/all1_axi4_rd-in.vhdl
@@ -268,6 +268,7 @@ begin
     if rising_edge(aclk) then
       if areset_n = '0' then
         rd_req_d0 <= '0';
+        rd_adr_d0 <= "0000000000000";
       else
         rd_req_d0 <= rd_req;
         rd_adr_d0 <= rd_addr;

--- a/testfiles/tb/golden_files/all1_axi4_rd-out.vhdl
+++ b/testfiles/tb/golden_files/all1_axi4_rd-out.vhdl
@@ -268,6 +268,7 @@ begin
     if rising_edge(aclk) then
       if areset_n = '0' then
         rd_ack <= '0';
+        rd_data <= "00000000000000000000000000000000";
       else
         rd_ack <= rd_ack_d0;
         rd_data <= rd_dat_d0;

--- a/testfiles/tb/golden_files/all1_axi4_rd.vhdl
+++ b/testfiles/tb/golden_files/all1_axi4_rd.vhdl
@@ -270,7 +270,9 @@ begin
     if rising_edge(aclk) then
       if areset_n = '0' then
         rd_req_d0 <= '0';
+        rd_adr_d0 <= "0000000000000";
         rd_ack <= '0';
+        rd_data <= "00000000000000000000000000000000";
       else
         rd_req_d0 <= rd_req;
         rd_adr_d0 <= rd_addr;

--- a/testfiles/tb/golden_files/all1_axi4_wr-in,rd-out.vhdl
+++ b/testfiles/tb/golden_files/all1_axi4_wr-in,rd-out.vhdl
@@ -272,7 +272,11 @@ begin
     if rising_edge(aclk) then
       if areset_n = '0' then
         rd_ack <= '0';
+        rd_data <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0000000000000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
+        wr_sel_d0 <= "00000000000000000000000000000000";
       else
         rd_ack <= rd_ack_d0;
         rd_data <= rd_dat_d0;

--- a/testfiles/tb/golden_files/all1_axi4_wr-in.vhdl
+++ b/testfiles/tb/golden_files/all1_axi4_wr-in.vhdl
@@ -270,6 +270,9 @@ begin
     if rising_edge(aclk) then
       if areset_n = '0' then
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0000000000000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
+        wr_sel_d0 <= "00000000000000000000000000000000";
       else
         wr_req_d0 <= wr_req;
         wr_adr_d0 <= wr_addr;

--- a/testfiles/tb/golden_files/all1_axi4_wr.vhdl
+++ b/testfiles/tb/golden_files/all1_axi4_wr.vhdl
@@ -271,6 +271,9 @@ begin
     if rising_edge(aclk) then
       if areset_n = '0' then
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0000000000000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
+        wr_sel_d0 <= "00000000000000000000000000000000";
         wr_ack <= '0';
       else
         wr_req_d0 <= wr_req;

--- a/testfiles/tb/golden_files/all1_cernbe_all.vhdl
+++ b/testfiles/tb/golden_files/all1_cernbe_all.vhdl
@@ -163,8 +163,11 @@ begin
     if rising_edge(Clk) then
       if rst_n = '0' then
         rd_req_d0 <= '0';
+        rd_adr_d0 <= "0000000000000";
         rd_ack_int <= '0';
+        VMERdData <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_dat_d0 <= "00000000000000000000000000000000";
         wr_ack_int <= '0';
       else
         rd_req_d0 <= VMERdMem;

--- a/testfiles/tb/golden_files/all1_cernbe_in,out.vhdl
+++ b/testfiles/tb/golden_files/all1_cernbe_in,out.vhdl
@@ -163,8 +163,11 @@ begin
     if rising_edge(Clk) then
       if rst_n = '0' then
         rd_req_d0 <= '0';
+        rd_adr_d0 <= "0000000000000";
         rd_ack_int <= '0';
+        VMERdData <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_dat_d0 <= "00000000000000000000000000000000";
         wr_ack_int <= '0';
       else
         rd_req_d0 <= VMERdMem;

--- a/testfiles/tb/golden_files/all1_cernbe_in.vhdl
+++ b/testfiles/tb/golden_files/all1_cernbe_in.vhdl
@@ -160,7 +160,9 @@ begin
     if rising_edge(Clk) then
       if rst_n = '0' then
         rd_req_d0 <= '0';
+        rd_adr_d0 <= "0000000000000";
         wr_req_d0 <= '0';
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_req_d0 <= VMERdMem;
         rd_adr_d0 <= VMEAddr;

--- a/testfiles/tb/golden_files/all1_cernbe_out.vhdl
+++ b/testfiles/tb/golden_files/all1_cernbe_out.vhdl
@@ -159,6 +159,7 @@ begin
     if rising_edge(Clk) then
       if rst_n = '0' then
         rd_ack_int <= '0';
+        VMERdData <= "00000000000000000000000000000000";
         wr_ack_int <= '0';
       else
         rd_ack_int <= rd_ack_d0;

--- a/testfiles/tb/golden_files/all1_cernbe_rd-in,wr-out.vhdl
+++ b/testfiles/tb/golden_files/all1_cernbe_rd-in,wr-out.vhdl
@@ -166,6 +166,7 @@ begin
     if rising_edge(Clk) then
       if rst_n = '0' then
         rd_req_d0 <= '0';
+        rd_adr_d0 <= "0000000000000";
         wr_ack_int <= '0';
       else
         rd_req_d0 <= VMERdMem;

--- a/testfiles/tb/golden_files/all1_cernbe_rd-in.vhdl
+++ b/testfiles/tb/golden_files/all1_cernbe_rd-in.vhdl
@@ -165,6 +165,7 @@ begin
     if rising_edge(Clk) then
       if rst_n = '0' then
         rd_req_d0 <= '0';
+        rd_adr_d0 <= "0000000000000";
       else
         rd_req_d0 <= VMERdMem;
         rd_adr_d0 <= VMEAddr;

--- a/testfiles/tb/golden_files/all1_cernbe_rd-out.vhdl
+++ b/testfiles/tb/golden_files/all1_cernbe_rd-out.vhdl
@@ -158,6 +158,7 @@ begin
     if rising_edge(Clk) then
       if rst_n = '0' then
         rd_ack_int <= '0';
+        VMERdData <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         VMERdData <= rd_dat_d0;

--- a/testfiles/tb/golden_files/all1_cernbe_rd.vhdl
+++ b/testfiles/tb/golden_files/all1_cernbe_rd.vhdl
@@ -167,7 +167,9 @@ begin
     if rising_edge(Clk) then
       if rst_n = '0' then
         rd_req_d0 <= '0';
+        rd_adr_d0 <= "0000000000000";
         rd_ack_int <= '0';
+        VMERdData <= "00000000000000000000000000000000";
       else
         rd_req_d0 <= VMERdMem;
         rd_adr_d0 <= VMEAddr;

--- a/testfiles/tb/golden_files/all1_cernbe_wr-in,rd-out.vhdl
+++ b/testfiles/tb/golden_files/all1_cernbe_wr-in,rd-out.vhdl
@@ -168,7 +168,10 @@ begin
     if rising_edge(Clk) then
       if rst_n = '0' then
         rd_ack_int <= '0';
+        VMERdData <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0000000000000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         VMERdData <= rd_dat_d0;

--- a/testfiles/tb/golden_files/all1_cernbe_wr-in.vhdl
+++ b/testfiles/tb/golden_files/all1_cernbe_wr-in.vhdl
@@ -166,6 +166,8 @@ begin
     if rising_edge(Clk) then
       if rst_n = '0' then
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0000000000000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         wr_req_d0 <= VMEWrMem;
         wr_adr_d0 <= VMEAddr;

--- a/testfiles/tb/golden_files/all1_cernbe_wr.vhdl
+++ b/testfiles/tb/golden_files/all1_cernbe_wr.vhdl
@@ -167,6 +167,8 @@ begin
     if rising_edge(Clk) then
       if rst_n = '0' then
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0000000000000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
         wr_ack_int <= '0';
       else
         wr_req_d0 <= VMEWrMem;

--- a/testfiles/tb/golden_files/all1_wb_all.vhdl
+++ b/testfiles/tb/golden_files/all1_wb_all.vhdl
@@ -204,8 +204,12 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_req_d0 <= '0';
+        rd_adr_d0 <= "0000000000000";
         rd_ack_int <= '0';
+        wb_o.dat <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_dat_d0 <= "00000000000000000000000000000000";
+        wr_sel_d0 <= "00000000000000000000000000000000";
         wr_ack_int <= '0';
       else
         rd_req_d0 <= rd_req_int;

--- a/testfiles/tb/golden_files/all1_wb_in,out.vhdl
+++ b/testfiles/tb/golden_files/all1_wb_in,out.vhdl
@@ -204,8 +204,12 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_req_d0 <= '0';
+        rd_adr_d0 <= "0000000000000";
         rd_ack_int <= '0';
+        wb_o.dat <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_dat_d0 <= "00000000000000000000000000000000";
+        wr_sel_d0 <= "00000000000000000000000000000000";
         wr_ack_int <= '0';
       else
         rd_req_d0 <= rd_req_int;

--- a/testfiles/tb/golden_files/all1_wb_in.vhdl
+++ b/testfiles/tb/golden_files/all1_wb_in.vhdl
@@ -201,7 +201,10 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_req_d0 <= '0';
+        rd_adr_d0 <= "0000000000000";
         wr_req_d0 <= '0';
+        wr_dat_d0 <= "00000000000000000000000000000000";
+        wr_sel_d0 <= "00000000000000000000000000000000";
       else
         rd_req_d0 <= rd_req_int;
         rd_adr_d0 <= adr_int;

--- a/testfiles/tb/golden_files/all1_wb_out.vhdl
+++ b/testfiles/tb/golden_files/all1_wb_out.vhdl
@@ -199,6 +199,7 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_o.dat <= "00000000000000000000000000000000";
         wr_ack_int <= '0';
       else
         rd_ack_int <= rd_ack_d0;

--- a/testfiles/tb/golden_files/all1_wb_rd-in,wr-out.vhdl
+++ b/testfiles/tb/golden_files/all1_wb_rd-in,wr-out.vhdl
@@ -206,6 +206,7 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_req_d0 <= '0';
+        rd_adr_d0 <= "0000000000000";
         wr_ack_int <= '0';
       else
         rd_req_d0 <= rd_req_int;

--- a/testfiles/tb/golden_files/all1_wb_rd-in.vhdl
+++ b/testfiles/tb/golden_files/all1_wb_rd-in.vhdl
@@ -205,6 +205,7 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_req_d0 <= '0';
+        rd_adr_d0 <= "0000000000000";
       else
         rd_req_d0 <= rd_req_int;
         rd_adr_d0 <= adr_int;

--- a/testfiles/tb/golden_files/all1_wb_rd-out.vhdl
+++ b/testfiles/tb/golden_files/all1_wb_rd-out.vhdl
@@ -198,6 +198,7 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_o.dat <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_o.dat <= rd_dat_d0;

--- a/testfiles/tb/golden_files/all1_wb_rd.vhdl
+++ b/testfiles/tb/golden_files/all1_wb_rd.vhdl
@@ -207,7 +207,9 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_req_d0 <= '0';
+        rd_adr_d0 <= "0000000000000";
         rd_ack_int <= '0';
+        wb_o.dat <= "00000000000000000000000000000000";
       else
         rd_req_d0 <= rd_req_int;
         rd_adr_d0 <= adr_int;

--- a/testfiles/tb/golden_files/all1_wb_wr-in,rd-out.vhdl
+++ b/testfiles/tb/golden_files/all1_wb_wr-in,rd-out.vhdl
@@ -209,7 +209,11 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_o.dat <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0000000000000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
+        wr_sel_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_o.dat <= rd_dat_d0;

--- a/testfiles/tb/golden_files/all1_wb_wr-in.vhdl
+++ b/testfiles/tb/golden_files/all1_wb_wr-in.vhdl
@@ -207,6 +207,9 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0000000000000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
+        wr_sel_d0 <= "00000000000000000000000000000000";
       else
         wr_req_d0 <= wr_req_int;
         wr_adr_d0 <= adr_int;

--- a/testfiles/tb/golden_files/all1_wb_wr.vhdl
+++ b/testfiles/tb/golden_files/all1_wb_wr.vhdl
@@ -208,6 +208,9 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0000000000000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
+        wr_sel_d0 <= "00000000000000000000000000000000";
         wr_ack_int <= '0';
       else
         wr_req_d0 <= wr_req_int;

--- a/testfiles/tb/golden_files/all2_axi4.vhdl
+++ b/testfiles/tb/golden_files/all2_axi4.vhdl
@@ -158,7 +158,11 @@ begin
     if rising_edge(aclk) then
       if areset_n = '0' then
         rd_ack <= '0';
+        rd_data <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "00000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
+        wr_sel_d0 <= "00000000000000000000000000000000";
       else
         rd_ack <= rd_ack_d0;
         rd_data <= rd_dat_d0;

--- a/testfiles/tb/golden_files/buserr_apb.vhdl
+++ b/testfiles/tb/golden_files/buserr_apb.vhdl
@@ -93,8 +93,11 @@ begin
       if presetn = '0' then
         rd_ack <= '0';
         rd_err <= '0';
+        rd_data <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
         wr_req_del_d0 <= '0';
+        wr_adr_d0 <= "000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack <= rd_ack_d0;
         rd_err <= rd_err_d0;

--- a/testfiles/tb/golden_files/buserr_axi4.vhdl
+++ b/testfiles/tb/golden_files/buserr_axi4.vhdl
@@ -169,7 +169,10 @@ begin
       if areset_n = '0' then
         rd_ack <= '0';
         rd_err <= '0';
+        rd_data <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack <= rd_ack_d0;
         rd_err <= rd_err_d0;

--- a/testfiles/tb/golden_files/buserr_wb.vhdl
+++ b/testfiles/tb/golden_files/buserr_wb.vhdl
@@ -112,7 +112,10 @@ begin
       if rst_n_i = '0' then
         rd_ack_int <= '0';
         rd_err_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         rd_err_int <= rd_err_d0;

--- a/testfiles/tb/golden_files/reg2pip_wb.vhdl
+++ b/testfiles/tb/golden_files/reg2pip_wb.vhdl
@@ -95,6 +95,8 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "00";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         wr_req_d0 <= wr_req_int;
         wr_adr_d0 <= wb_adr_i;

--- a/testfiles/tb/golden_files/reg2ro_wb.vhdl
+++ b/testfiles/tb/golden_files/reg2ro_wb.vhdl
@@ -88,7 +88,9 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "00";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/tb/golden_files/reg2rw_wb.vhdl
+++ b/testfiles/tb/golden_files/reg2rw_wb.vhdl
@@ -153,7 +153,10 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/tb/golden_files/reg2wo_wb.vhdl
+++ b/testfiles/tb/golden_files/reg2wo_wb.vhdl
@@ -104,7 +104,10 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/tb/golden_files/reg3rw_wb.vhdl
+++ b/testfiles/tb/golden_files/reg3rw_wb.vhdl
@@ -125,7 +125,10 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/tb/golden_files/reg3wrw_wb.vhdl
+++ b/testfiles/tb/golden_files/reg3wrw_wb.vhdl
@@ -115,7 +115,10 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/tb/golden_files/reg4wrw_wb.vhdl
+++ b/testfiles/tb/golden_files/reg4wrw_wb.vhdl
@@ -98,7 +98,10 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "00";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/tb/golden_files/reg5rwbe_wb.vhdl
+++ b/testfiles/tb/golden_files/reg5rwbe_wb.vhdl
@@ -82,7 +82,10 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/tb/golden_files/reg5rwle_wb.vhdl
+++ b/testfiles/tb/golden_files/reg5rwle_wb.vhdl
@@ -82,7 +82,10 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/tb/golden_files/reg6ac_wb.vhdl
+++ b/testfiles/tb/golden_files/reg6ac_wb.vhdl
@@ -96,7 +96,10 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "00";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/tb/golden_files/reg7const_wb.vhdl
+++ b/testfiles/tb/golden_files/reg7const_wb.vhdl
@@ -71,7 +71,9 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/tb/golden_files/reg8orclr_wb.vhdl
+++ b/testfiles/tb/golden_files/reg8orclr_wb.vhdl
@@ -98,7 +98,10 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "00";
+        wr_dat_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/tb/golden_files/sub2_axi4.vhdl
+++ b/testfiles/tb/golden_files/sub2_axi4.vhdl
@@ -153,7 +153,11 @@ begin
     if rising_edge(aclk) then
       if areset_n = '0' then
         rd_ack <= '0';
+        rd_data <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
+        wr_sel_d0 <= "00000000000000000000000000000000";
       else
         rd_ack <= rd_ack_d0;
         rd_data <= rd_dat_d0;

--- a/testfiles/tb/golden_files/wmask_apb.vhdl
+++ b/testfiles/tb/golden_files/wmask_apb.vhdl
@@ -80,7 +80,11 @@ begin
     if rising_edge(pclk) then
       if presetn = '0' then
         rd_ack <= '0';
+        rd_data <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
+        wr_sel_d0 <= "00000000000000000000000000000000";
       else
         rd_ack <= rd_ack_d0;
         rd_data <= rd_dat_d0;

--- a/testfiles/tb/golden_files/wmask_axi4.vhdl
+++ b/testfiles/tb/golden_files/wmask_axi4.vhdl
@@ -147,7 +147,11 @@ begin
     if rising_edge(aclk) then
       if areset_n = '0' then
         rd_ack <= '0';
+        rd_data <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
+        wr_sel_d0 <= "00000000000000000000000000000000";
       else
         rd_ack <= rd_ack_d0;
         rd_data <= rd_dat_d0;

--- a/testfiles/tb/golden_files/wmask_wb.vhdl
+++ b/testfiles/tb/golden_files/wmask_wb.vhdl
@@ -101,7 +101,11 @@ begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
         wr_req_d0 <= '0';
+        wr_adr_d0 <= "0000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
+        wr_sel_d0 <= "00000000000000000000000000000000";
       else
         rd_ack_int <= rd_ack_d0;
         wb_dat_o <= rd_dat_d0;

--- a/testfiles/tb/run.sh
+++ b/testfiles/tb/run.sh
@@ -52,7 +52,7 @@ build_any()
         $CHEBY --no-header -i "${file_names[$i]}.cheby" --gen-hdl="${file_names[$i]}.vhdl"
     done
 
-    if [[ "${REGEN}" == "true" || "${REGEN}" == true ]]; then
+    if [[ "${REGEN}" == "true" || "${REGEN}" == true || "${REGEN}" == "1" || "${REGEN}" == 1 ]]; then
         echo "### Update output"
         for (( i = 0; i < ${#file_names[@]}; i++ )); do
             cp "${file_names[$i]}.vhdl" "golden_files/${file_names_ext[$i]}.vhdl"


### PR DESCRIPTION
When enabling a pipeline, cheby instantiates an additional synchronous process, which
1. resets the pipelined signal, and
2. assigns the actual value to the pipelined signal upon a rising clock edge.

Unfortunately, cheby implements step 1 only for signals with a size of 1 bit. Signals with a size greater than one bit are only added in step 2. I.e., in the following example `rd_adr_d0` has no reset assignment while the single-bit signal `rd_req_d0` does:

```vhdl
  -- pipelining for rd-in
  process (pclk) begin
    if rising_edge(pclk) then
      if presetn = '0' then
        rd_req_d0 <= '0';
      else
        rd_req_d0 <= rd_req;
        rd_adr_d0 <= rd_addr;
      end if;
    end if;
  end process;
```

This PR fixes this behavior in c0d21f8bd5835e312eb0a917e058cc42eee21a14 by adding a zero constant value as reset assignment for multip-bit signals.