### PR TITLE
Fix trailing semicolon for VHDL entities without ports

### DIFF
--- a/proto/cheby/print_vhdl.py
+++ b/proto/cheby/print_vhdl.py
@@ -2,6 +2,7 @@
 
 import cheby.hdltree as hdltree
 from cheby.wrutils import w, wln, windent
+import io
 
 
 style = None
@@ -530,43 +531,58 @@ def get_interface_name(inter, is_master, is_out):
 def print_inters_list(fd, lst, name, indent):
     if not lst:
         return
-    windent(fd, indent)
-    wln(fd, "{} (".format(name))
-    first = True
+
+    buffer = io.StringIO()
+
+    windent(buffer, indent)
+    wln(buffer, "{} (".format(name))
+
     for p in lst:
-        if first:
-            first = False
-        else:
-            wln(fd, ";")
         if isinstance(p, hdltree.HDLPort):
-            generate_port(fd, p, indent + 1)
+            generate_port(buffer, p, indent + 1)
+            wln(buffer, ";")
+
         elif isinstance(p, hdltree.HDLParam):
-            generate_param(fd, p, indent + 1)
+            generate_param(buffer, p, indent + 1)
+            wln(buffer, ";")
+
         elif isinstance(p, hdltree.HDLInterfaceInstance):
             # External ports of a slave interface become extra normal ports.
             if not p.is_master:
                 for itfp in p.interface.ports:
-                    if itfp.dir == 'EXT':
+                    if itfp.dir == "EXT":
                         typ = generate_vhdl_type(itfp)
-                        windent(fd, indent + 1)
-                        w(fd, "{:<20} : in    {typ}".format(itfp.name + '_i', typ=typ))
-                        wln(fd, ";")
-            # The interface is composed of two records: for the inputs and for the outputs.
-            generate_decl_comment(fd, p.comment, indent + 1)
+                        windent(buffer, indent + 1)
+                        wln(
+                            buffer,
+                            "{:<20} : in    {typ};".format(itfp.name + "_i", typ=typ),
+                        )
+
+            # The interface is composed of two records: for the inputs and for the
+            # outputs.
             has_input, has_output = has_in_out(p.interface, not p.is_master)
+            if has_input or has_output:
+                # Print comment only if ports are available
+                generate_decl_comment(buffer, p.comment, indent + 1)
+
             if has_input:
-                windent(fd, indent + 1)
+                windent(buffer, indent + 1)
                 nam = get_interface_name(p.interface, p.is_master, False)
-                w(fd, "{:<20} : in    {}".format(p.name + '_i', nam))
-                if has_output:
-                    wln(fd, ";")
+                wln(buffer, "{:<20} : in    {};".format(p.name + "_i", nam))
+
             if has_output:
-                windent(fd, indent + 1)
+                windent(buffer, indent + 1)
                 nam = get_interface_name(p.interface, p.is_master, True)
-                w(fd, "{:<20} : out   {}".format(p.name + '_o', nam))
+                wln(buffer, "{:<20} : out   {};".format(p.name + "_o", nam))
+
         else:
             raise AssertionError
-    wln(fd)
+
+    # Get buffer content and remove last semicolon and newline
+    buffer_content = buffer.getvalue()
+    buffer_content = buffer_content[:-2]
+
+    wln(fd, buffer_content)
     windent(fd, indent)
     wln(fd, ");")
 

--- a/testfiles/features/no_port.cheby
+++ b/testfiles/features/no_port.cheby
@@ -13,3 +13,5 @@ memory-map:
         name: reg1
         access: rw
         width: 32
+        x-hdl:
+          type: no-port

--- a/testfiles/features/no_port.sv
+++ b/testfiles/features/no_port.sv
@@ -11,10 +11,7 @@ module no_port
     input   wire [31:0] pwdata,
     input   wire [3:0] pstrb,
     output  wire [31:0] prdata,
-    output  wire pslverr,
-
-    // REG reg1
-    output  wire [31:0] reg1_o
+    output  wire pslverr
   );
   wire wr_req;
   wire [2:2] wr_addr;
@@ -88,7 +85,6 @@ module no_port
   end
 
   // Register reg1
-  assign reg1_o = reg1_reg;
   always @(posedge(pclk) or negedge(presetn))
   begin
     if (!presetn)

--- a/testfiles/features/no_port.vhdl
+++ b/testfiles/features/no_port.vhdl
@@ -14,10 +14,7 @@ entity no_port is
     pwdata               : in    std_logic_vector(31 downto 0);
     pstrb                : in    std_logic_vector(3 downto 0);
     prdata               : out   std_logic_vector(31 downto 0);
-    pslverr              : out   std_logic;
-
-    -- REG reg1
-    reg1_o               : out   std_logic_vector(31 downto 0)
+    pslverr              : out   std_logic
   );
 end no_port;
 
@@ -90,7 +87,6 @@ begin
   end process;
 
   -- Register reg1
-  reg1_o <= reg1_reg;
   process (pclk) begin
     if rising_edge(pclk) then
       if presetn = '0' then


### PR DESCRIPTION
If all registers in a memory map are of type `no-port`, the entity does not have any ports besides the interface ports. Since in VHDL, the interface ports are always generated with a `;`, the entity then has a trailing semicolon:
```vhdl
    ...
    prdata               : out   std_logic_vector(31 downto 0);
    pslverr              : out   std_logic;
  );
end no_port;
```
instead of (see after `std_logic`):
```vhdl
    ...
    prdata               : out   std_logic_vector(31 downto 0);
    pslverr              : out   std_logic
  );
end no_port;
```
This fix introduces an IO buffer in Python to which all strings are written first. Then, the very last semicolon gets removed before the buffer is written into the output file. Also, the `no_port` testcase is updated to verify this new behavior.