### PR TITLE
Verilog - Use appropriate assignment operator, split tests between Verilog and SV 

### DIFF
--- a/testfiles/bug-cernbe/repro.sv
+++ b/testfiles/bug-cernbe/repro.sv
@@ -41,7 +41,7 @@ module example
   assign VMEWrDone = wr_ack_int;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(Clk))
+  always_ff @(posedge(Clk))
   begin
     if (!rst_n)
       begin
@@ -63,7 +63,7 @@ module example
 
   // Register regA
   assign regA_o = regA_reg;
-  always @(posedge(Clk))
+  always_ff @(posedge(Clk))
   begin
     if (!rst_n)
       begin
@@ -82,7 +82,7 @@ module example
 
   // Interface sm
   assign sm_VMEWrData_o = wr_dat_d0;
-  always @(posedge(Clk))
+  always_ff @(posedge(Clk))
   begin
     if (!rst_n)
       sm_wt <= 1'b0;
@@ -90,79 +90,79 @@ module example
       sm_wt <= (sm_wt | sm_ws) & ~sm_VMEWrDone_i;
   end
   assign sm_VMEWrMem_o = sm_ws;
-  always @(VMEAddr, wr_adr_d0, sm_wt, sm_ws)
+  always_comb
   if ((sm_ws | sm_wt) == 1'b1)
-    sm_VMEAddr_o <= wr_adr_d0[1:1];
+    sm_VMEAddr_o = wr_adr_d0[1:1];
   else
-    sm_VMEAddr_o <= VMEAddr[1:1];
+    sm_VMEAddr_o = VMEAddr[1:1];
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0, regA_wack, sm_VMEWrDone_i)
+  always_comb
   begin
-    regA_wreq <= 2'b0;
-    sm_ws <= 1'b0;
+    regA_wreq = 2'b0;
+    sm_ws = 1'b0;
     case (wr_adr_d0[2:2])
     1'b0:
       case (wr_adr_d0[1:1])
       1'b0:
         begin
           // Reg regA
-          regA_wreq[1] <= wr_req_d0;
-          wr_ack_int <= regA_wack[1];
+          regA_wreq[1] = wr_req_d0;
+          wr_ack_int = regA_wack[1];
         end
       1'b1:
         begin
           // Reg regA
-          regA_wreq[0] <= wr_req_d0;
-          wr_ack_int <= regA_wack[0];
+          regA_wreq[0] = wr_req_d0;
+          wr_ack_int = regA_wack[0];
         end
       default:
-        wr_ack_int <= wr_req_d0;
+        wr_ack_int = wr_req_d0;
       endcase
     1'b1:
       begin
         // Submap sm
-        sm_ws <= wr_req_d0;
-        wr_ack_int <= sm_VMEWrDone_i;
+        sm_ws = wr_req_d0;
+        wr_ack_int = sm_VMEWrDone_i;
       end
     default:
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     endcase
   end
 
   // Process for read requests.
-  always @(VMEAddr, VMERdMem, regA_reg, sm_VMERdData_i, sm_VMERdDone_i)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {16{1'bx}};
-    sm_VMERdMem_o <= 1'b0;
+    rd_dat_d0 = {16{1'bx}};
+    sm_VMERdMem_o = 1'b0;
     case (VMEAddr[2:2])
     1'b0:
       case (VMEAddr[1:1])
       1'b0:
         begin
           // Reg regA
-          rd_ack_d0 <= VMERdMem;
-          rd_dat_d0 <= regA_reg[31:16];
+          rd_ack_d0 = VMERdMem;
+          rd_dat_d0 = regA_reg[31:16];
         end
       1'b1:
         begin
           // Reg regA
-          rd_ack_d0 <= VMERdMem;
-          rd_dat_d0 <= regA_reg[15:0];
+          rd_ack_d0 = VMERdMem;
+          rd_dat_d0 = regA_reg[15:0];
         end
       default:
-        rd_ack_d0 <= VMERdMem;
+        rd_ack_d0 = VMERdMem;
       endcase
     1'b1:
       begin
         // Submap sm
-        sm_VMERdMem_o <= VMERdMem;
-        rd_dat_d0 <= sm_VMERdData_i;
-        rd_ack_d0 <= sm_VMERdDone_i;
+        sm_VMERdMem_o = VMERdMem;
+        rd_dat_d0 = sm_VMERdData_i;
+        rd_ack_d0 = sm_VMERdDone_i;
       end
     default:
-      rd_ack_d0 <= VMERdMem;
+      rd_ack_d0 = VMERdMem;
     endcase
   end
 endmodule

--- a/testfiles/bug-cernbe/repro.v
+++ b/testfiles/bug-cernbe/repro.v
@@ -1,0 +1,168 @@
+
+module example
+  (
+    input   wire Clk,
+    input   wire Rst,
+    input   wire [2:1] VMEAddr,
+    output  reg [15:0] VMERdData,
+    input   wire [15:0] VMEWrData,
+    input   wire VMERdMem,
+    input   wire VMEWrMem,
+    output  wire VMERdDone,
+    output  wire VMEWrDone,
+
+    // The first register (with some fields)
+    output  wire [31:0] regA_o,
+
+    // CERN-BE bus sm
+    output  reg [1:1] sm_VMEAddr_o,
+    input   wire [15:0] sm_VMERdData_i,
+    output  wire [15:0] sm_VMEWrData_o,
+    output  reg sm_VMERdMem_o,
+    output  wire sm_VMEWrMem_o,
+    input   wire sm_VMERdDone_i,
+    input   wire sm_VMEWrDone_i
+  );
+  wire rst_n;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  reg [31:0] regA_reg;
+  reg [1:0] regA_wreq;
+  reg [1:0] regA_wack;
+  reg rd_ack_d0;
+  reg [15:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [2:1] wr_adr_d0;
+  reg [15:0] wr_dat_d0;
+  reg sm_ws;
+  reg sm_wt;
+  assign rst_n = ~Rst;
+  assign VMERdDone = rd_ack_int;
+  assign VMEWrDone = wr_ack_int;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(Clk))
+  begin
+    if (!rst_n)
+      begin
+        rd_ack_int <= 1'b0;
+        VMERdData <= 16'b0000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 2'b00;
+        wr_dat_d0 <= 16'b0000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        VMERdData <= rd_dat_d0;
+        wr_req_d0 <= VMEWrMem;
+        wr_adr_d0 <= VMEAddr;
+        wr_dat_d0 <= VMEWrData;
+      end
+  end
+
+  // Register regA
+  assign regA_o = regA_reg;
+  always @(posedge(Clk))
+  begin
+    if (!rst_n)
+      begin
+        regA_reg <= 32'b00000000000000000000000000000000;
+        regA_wack <= 2'b0;
+      end
+    else
+      begin
+        if (regA_wreq[0] == 1'b1)
+          regA_reg[15:0] <= wr_dat_d0;
+        if (regA_wreq[1] == 1'b1)
+          regA_reg[31:16] <= wr_dat_d0;
+        regA_wack <= regA_wreq;
+      end
+  end
+
+  // Interface sm
+  assign sm_VMEWrData_o = wr_dat_d0;
+  always @(posedge(Clk))
+  begin
+    if (!rst_n)
+      sm_wt <= 1'b0;
+    else
+      sm_wt <= (sm_wt | sm_ws) & ~sm_VMEWrDone_i;
+  end
+  assign sm_VMEWrMem_o = sm_ws;
+  always @(VMEAddr, wr_adr_d0, sm_wt, sm_ws)
+  if ((sm_ws | sm_wt) == 1'b1)
+    sm_VMEAddr_o = wr_adr_d0[1:1];
+  else
+    sm_VMEAddr_o = VMEAddr[1:1];
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, regA_wack, sm_VMEWrDone_i)
+  begin
+    regA_wreq = 2'b0;
+    sm_ws = 1'b0;
+    case (wr_adr_d0[2:2])
+    1'b0:
+      case (wr_adr_d0[1:1])
+      1'b0:
+        begin
+          // Reg regA
+          regA_wreq[1] = wr_req_d0;
+          wr_ack_int = regA_wack[1];
+        end
+      1'b1:
+        begin
+          // Reg regA
+          regA_wreq[0] = wr_req_d0;
+          wr_ack_int = regA_wack[0];
+        end
+      default:
+        wr_ack_int = wr_req_d0;
+      endcase
+    1'b1:
+      begin
+        // Submap sm
+        sm_ws = wr_req_d0;
+        wr_ack_int = sm_VMEWrDone_i;
+      end
+    default:
+      wr_ack_int = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always @(VMEAddr, VMERdMem, regA_reg, sm_VMERdData_i, sm_VMERdDone_i)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {16{1'bx}};
+    sm_VMERdMem_o = 1'b0;
+    case (VMEAddr[2:2])
+    1'b0:
+      case (VMEAddr[1:1])
+      1'b0:
+        begin
+          // Reg regA
+          rd_ack_d0 = VMERdMem;
+          rd_dat_d0 = regA_reg[31:16];
+        end
+      1'b1:
+        begin
+          // Reg regA
+          rd_ack_d0 = VMERdMem;
+          rd_dat_d0 = regA_reg[15:0];
+        end
+      default:
+        rd_ack_d0 = VMERdMem;
+      endcase
+    1'b1:
+      begin
+        // Submap sm
+        sm_VMERdMem_o = VMERdMem;
+        rd_dat_d0 = sm_VMERdData_i;
+        rd_ack_d0 = sm_VMERdDone_i;
+      end
+    default:
+      rd_ack_d0 = VMERdMem;
+    endcase
+  end
+endmodule

--- a/testfiles/bug-cernbe/sub_repro.sv
+++ b/testfiles/bug-cernbe/sub_repro.sv
@@ -33,7 +33,7 @@ module sub_repro
   assign VMEWrDone = wr_ack_int;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(Clk))
+  always_ff @(posedge(Clk))
   begin
     if (!rst_n)
       begin
@@ -55,7 +55,7 @@ module sub_repro
 
   // Register subrA
   assign subrA_o = subrA_reg;
-  always @(posedge(Clk))
+  always_ff @(posedge(Clk))
   begin
     if (!rst_n)
       begin
@@ -73,44 +73,44 @@ module sub_repro
   // Register subrB
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0, subrA_wack)
+  always_comb
   begin
-    subrA_wreq <= 1'b0;
+    subrA_wreq = 1'b0;
     case (wr_adr_d0[1:1])
     1'b0:
       begin
         // Reg subrA
-        subrA_wreq <= wr_req_d0;
-        wr_ack_int <= subrA_wack;
+        subrA_wreq = wr_req_d0;
+        wr_ack_int = subrA_wack;
       end
     1'b1:
       // Reg subrB
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     default:
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     endcase
   end
 
   // Process for read requests.
-  always @(VMEAddr, VMERdMem, subrA_reg, subrB_i)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {16{1'bx}};
+    rd_dat_d0 = {16{1'bx}};
     case (VMEAddr[1:1])
     1'b0:
       begin
         // Reg subrA
-        rd_ack_d0 <= VMERdMem;
-        rd_dat_d0 <= subrA_reg;
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = subrA_reg;
       end
     1'b1:
       begin
         // Reg subrB
-        rd_ack_d0 <= VMERdMem;
-        rd_dat_d0 <= subrB_i;
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = subrB_i;
       end
     default:
-      rd_ack_d0 <= VMERdMem;
+      rd_ack_d0 = VMERdMem;
     endcase
   end
 endmodule

--- a/testfiles/bug-cernbe/sub_repro.v
+++ b/testfiles/bug-cernbe/sub_repro.v
@@ -1,0 +1,116 @@
+
+module sub_repro
+  (
+    input   wire Clk,
+    input   wire Rst,
+    input   wire [1:1] VMEAddr,
+    output  reg [15:0] VMERdData,
+    input   wire [15:0] VMEWrData,
+    input   wire VMERdMem,
+    input   wire VMEWrMem,
+    output  wire VMERdDone,
+    output  wire VMEWrDone,
+
+    // The first register (with some fields)
+    output  wire [15:0] subrA_o,
+
+    // The first register (with some fields)
+    input   wire [15:0] subrB_i
+  );
+  wire rst_n;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  reg [15:0] subrA_reg;
+  reg subrA_wreq;
+  reg subrA_wack;
+  reg rd_ack_d0;
+  reg [15:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [1:1] wr_adr_d0;
+  reg [15:0] wr_dat_d0;
+  assign rst_n = ~Rst;
+  assign VMERdDone = rd_ack_int;
+  assign VMEWrDone = wr_ack_int;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(Clk))
+  begin
+    if (!rst_n)
+      begin
+        rd_ack_int <= 1'b0;
+        VMERdData <= 16'b0000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 1'b0;
+        wr_dat_d0 <= 16'b0000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        VMERdData <= rd_dat_d0;
+        wr_req_d0 <= VMEWrMem;
+        wr_adr_d0 <= VMEAddr;
+        wr_dat_d0 <= VMEWrData;
+      end
+  end
+
+  // Register subrA
+  assign subrA_o = subrA_reg;
+  always @(posedge(Clk))
+  begin
+    if (!rst_n)
+      begin
+        subrA_reg <= 16'b0000000000000000;
+        subrA_wack <= 1'b0;
+      end
+    else
+      begin
+        if (subrA_wreq == 1'b1)
+          subrA_reg <= wr_dat_d0;
+        subrA_wack <= subrA_wreq;
+      end
+  end
+
+  // Register subrB
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, subrA_wack)
+  begin
+    subrA_wreq = 1'b0;
+    case (wr_adr_d0[1:1])
+    1'b0:
+      begin
+        // Reg subrA
+        subrA_wreq = wr_req_d0;
+        wr_ack_int = subrA_wack;
+      end
+    1'b1:
+      // Reg subrB
+      wr_ack_int = wr_req_d0;
+    default:
+      wr_ack_int = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always @(VMEAddr, VMERdMem, subrA_reg, subrB_i)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {16{1'bx}};
+    case (VMEAddr[1:1])
+    1'b0:
+      begin
+        // Reg subrA
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = subrA_reg;
+      end
+    1'b1:
+      begin
+        // Reg subrB
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = subrB_i;
+      end
+    default:
+      rd_ack_d0 = VMERdMem;
+    endcase
+  end
+endmodule

--- a/testfiles/bug-empty/noinp.sv
+++ b/testfiles/bug-empty/noinp.sv
@@ -51,11 +51,11 @@ module noinp
   reg [31:0] wr_dat_d0;
 
   // WB decode signals
-  always @(wb_sel_i)
+  always_comb
   ;
   assign wb_en = wb_cyc_i & wb_stb_i;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_rip <= 1'b0;
@@ -64,7 +64,7 @@ module noinp
   end
   assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_wip <= 1'b0;
@@ -80,7 +80,7 @@ module noinp
   assign wb_err_o = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -102,7 +102,7 @@ module noinp
 
   // Register reg0
   assign noinp_inter.reg0 = reg0_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -119,7 +119,7 @@ module noinp
 
   // Register reg1
   assign noinp_inter.reg1 = reg1_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -135,42 +135,42 @@ module noinp
   end
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0, reg0_wack, reg1_wack)
+  always_comb
   begin
-    reg0_wreq <= 1'b0;
-    reg1_wreq <= 1'b0;
+    reg0_wreq = 1'b0;
+    reg1_wreq = 1'b0;
     case (wr_adr_d0[2:2])
     1'b0:
       begin
         // Reg reg0
-        reg0_wreq <= wr_req_d0;
-        wr_ack_int <= reg0_wack;
+        reg0_wreq = wr_req_d0;
+        wr_ack_int = reg0_wack;
       end
     1'b1:
       begin
         // Reg reg1
-        reg1_wreq <= wr_req_d0;
-        wr_ack_int <= reg1_wack;
+        reg1_wreq = wr_req_d0;
+        wr_ack_int = reg1_wack;
       end
     default:
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     endcase
   end
 
   // Process for read requests.
-  always @(wb_adr_i, rd_req_int)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     case (wb_adr_i[2:2])
     1'b0:
       // Reg reg0
-      rd_ack_d0 <= rd_req_int;
+      rd_ack_d0 = rd_req_int;
     1'b1:
       // Reg reg1
-      rd_ack_d0 <= rd_req_int;
+      rd_ack_d0 = rd_req_int;
     default:
-      rd_ack_d0 <= rd_req_int;
+      rd_ack_d0 = rd_req_int;
     endcase
   end
 endmodule

--- a/testfiles/bug-empty/noinp.v
+++ b/testfiles/bug-empty/noinp.v
@@ -1,0 +1,176 @@
+interface t_noinp_inter;
+  logic [31:0] reg0;
+  logic [31:0] reg1;
+  modport master(
+    output reg0,
+    output reg1
+  );
+  modport slave(
+    input reg0,
+    input reg1
+  );
+endinterface
+
+
+module noinp
+  (
+    input   wire rst_n_i,
+    input   wire clk_i,
+    input   wire wb_cyc_i,
+    input   wire wb_stb_i,
+    input   wire [2:2] wb_adr_i,
+    input   wire [3:0] wb_sel_i,
+    input   wire wb_we_i,
+    input   wire [31:0] wb_dat_i,
+    output  wire wb_ack_o,
+    output  wire wb_err_o,
+    output  wire wb_rty_o,
+    output  wire wb_stall_o,
+    output  reg [31:0] wb_dat_o,
+    // Wires and registers
+    t_noinp_inter.master noinp_inter
+  );
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg [31:0] reg0_reg;
+  reg reg0_wreq;
+  reg reg0_wack;
+  reg [31:0] reg1_reg;
+  reg reg1_wreq;
+  reg reg1_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [2:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+
+  // WB decode signals
+  always @(wb_sel_i)
+  ;
+  assign wb_en = wb_cyc_i & wb_stb_i;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb_we_i)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb_we_i)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb_we_i) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb_ack_o = ack_int;
+  assign wb_stall_o = ~ack_int & wb_en;
+  assign wb_rty_o = 1'b0;
+  assign wb_err_o = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        rd_ack_int <= 1'b0;
+        wb_dat_o <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 1'b0;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb_dat_o <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_adr_d0 <= wb_adr_i;
+        wr_dat_d0 <= wb_dat_i;
+      end
+  end
+
+  // Register reg0
+  assign noinp_inter.reg0 = reg0_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        reg0_reg <= 32'b00000000000000000000000000000000;
+        reg0_wack <= 1'b0;
+      end
+    else
+      begin
+        if (reg0_wreq == 1'b1)
+          reg0_reg <= wr_dat_d0;
+        reg0_wack <= reg0_wreq;
+      end
+  end
+
+  // Register reg1
+  assign noinp_inter.reg1 = reg1_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        reg1_reg <= 32'b00000000000000000000000100100011;
+        reg1_wack <= 1'b0;
+      end
+    else
+      begin
+        if (reg1_wreq == 1'b1)
+          reg1_reg <= wr_dat_d0;
+        reg1_wack <= reg1_wreq;
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, reg0_wack, reg1_wack)
+  begin
+    reg0_wreq = 1'b0;
+    reg1_wreq = 1'b0;
+    case (wr_adr_d0[2:2])
+    1'b0:
+      begin
+        // Reg reg0
+        reg0_wreq = wr_req_d0;
+        wr_ack_int = reg0_wack;
+      end
+    1'b1:
+      begin
+        // Reg reg1
+        reg1_wreq = wr_req_d0;
+        wr_ack_int = reg1_wack;
+      end
+    default:
+      wr_ack_int = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always @(wb_adr_i, rd_req_int)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    case (wb_adr_i[2:2])
+    1'b0:
+      // Reg reg0
+      rd_ack_d0 = rd_req_int;
+    1'b1:
+      // Reg reg1
+      rd_ack_d0 = rd_req_int;
+    default:
+      rd_ack_d0 = rd_req_int;
+    endcase
+  end
+endmodule

--- a/testfiles/bug-empty/noout.sv
+++ b/testfiles/bug-empty/noout.sv
@@ -44,11 +44,11 @@ module noout
   reg [2:2] wr_adr_d0;
 
   // WB decode signals
-  always @(wb_sel_i)
+  always_comb
   ;
   assign wb_en = wb_cyc_i & wb_stb_i;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_rip <= 1'b0;
@@ -57,7 +57,7 @@ module noout
   end
   assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_wip <= 1'b0;
@@ -73,7 +73,7 @@ module noout
   assign wb_err_o = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -96,38 +96,38 @@ module noout
   // Register reg1
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0)
+  always_comb
   case (wr_adr_d0[2:2])
   1'b0:
     // Reg reg0
-    wr_ack_int <= wr_req_d0;
+    wr_ack_int = wr_req_d0;
   1'b1:
     // Reg reg1
-    wr_ack_int <= wr_req_d0;
+    wr_ack_int = wr_req_d0;
   default:
-    wr_ack_int <= wr_req_d0;
+    wr_ack_int = wr_req_d0;
   endcase
 
   // Process for read requests.
-  always @(wb_adr_i, rd_req_int, noout_inter.reg0, noout_inter.reg1)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     case (wb_adr_i[2:2])
     1'b0:
       begin
         // Reg reg0
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0 <= noout_inter.reg0;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = noout_inter.reg0;
       end
     1'b1:
       begin
         // Reg reg1
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0 <= noout_inter.reg1;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = noout_inter.reg1;
       end
     default:
-      rd_ack_d0 <= rd_req_int;
+      rd_ack_d0 = rd_req_int;
     endcase
   end
 endmodule

--- a/testfiles/bug-empty/noout.v
+++ b/testfiles/bug-empty/noout.v
@@ -1,0 +1,133 @@
+interface t_noout_inter;
+  logic [31:0] reg0;
+  logic [31:0] reg1;
+  modport master(
+    input reg0,
+    input reg1
+  );
+  modport slave(
+    output reg0,
+    output reg1
+  );
+endinterface
+
+
+module noout
+  (
+    input   wire rst_n_i,
+    input   wire clk_i,
+    input   wire wb_cyc_i,
+    input   wire wb_stb_i,
+    input   wire [2:2] wb_adr_i,
+    input   wire [3:0] wb_sel_i,
+    input   wire wb_we_i,
+    input   wire [31:0] wb_dat_i,
+    output  wire wb_ack_o,
+    output  wire wb_err_o,
+    output  wire wb_rty_o,
+    output  wire wb_stall_o,
+    output  reg [31:0] wb_dat_o,
+    // Wires and registers
+    t_noout_inter.master noout_inter
+  );
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [2:2] wr_adr_d0;
+
+  // WB decode signals
+  always @(wb_sel_i)
+  ;
+  assign wb_en = wb_cyc_i & wb_stb_i;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb_we_i)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb_we_i)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb_we_i) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb_ack_o = ack_int;
+  assign wb_stall_o = ~ack_int & wb_en;
+  assign wb_rty_o = 1'b0;
+  assign wb_err_o = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        rd_ack_int <= 1'b0;
+        wb_dat_o <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 1'b0;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb_dat_o <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_adr_d0 <= wb_adr_i;
+      end
+  end
+
+  // Register reg0
+
+  // Register reg1
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0)
+  case (wr_adr_d0[2:2])
+  1'b0:
+    // Reg reg0
+    wr_ack_int = wr_req_d0;
+  1'b1:
+    // Reg reg1
+    wr_ack_int = wr_req_d0;
+  default:
+    wr_ack_int = wr_req_d0;
+  endcase
+
+  // Process for read requests.
+  always @(wb_adr_i, rd_req_int, noout_inter.reg0, noout_inter.reg1)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    case (wb_adr_i[2:2])
+    1'b0:
+      begin
+        // Reg reg0
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = noout_inter.reg0;
+      end
+    1'b1:
+      begin
+        // Reg reg1
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = noout_inter.reg1;
+      end
+    default:
+      rd_ack_d0 = rd_req_int;
+    endcase
+  end
+endmodule

--- a/testfiles/bug-gen_wt/m1.sv
+++ b/testfiles/bug-gen_wt/m1.sv
@@ -39,7 +39,7 @@ module m1
   assign VMEWrDone = wr_ack_int;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(Clk))
+  always_ff @(posedge(Clk))
   begin
     if (!rst_n)
       begin
@@ -61,7 +61,7 @@ module m1
 
   // Register r1
   assign r1_o = r1_reg;
-  always @(posedge(Clk))
+  always_ff @(posedge(Clk))
   begin
     if (!rst_n)
       begin
@@ -81,50 +81,50 @@ module m1
   assign sm2_VMEWrMem_o = sm2_ws;
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0, r1_wack, sm2_VMEWrDone_i)
+  always_comb
   begin
-    r1_wreq <= 1'b0;
-    sm2_ws <= 1'b0;
+    r1_wreq = 1'b0;
+    sm2_ws = 1'b0;
     case (wr_adr_d0[2:2])
     1'b0:
       begin
         // Reg r1
-        r1_wreq <= wr_req_d0;
-        wr_ack_int <= r1_wack;
+        r1_wreq = wr_req_d0;
+        wr_ack_int = r1_wack;
       end
     1'b1:
       begin
         // Submap sm2
-        sm2_ws <= wr_req_d0;
-        wr_ack_int <= sm2_VMEWrDone_i;
+        sm2_ws = wr_req_d0;
+        wr_ack_int = sm2_VMEWrDone_i;
       end
     default:
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     endcase
   end
 
   // Process for read requests.
-  always @(VMEAddr, VMERdMem, r1_reg, sm2_VMERdData_i, sm2_VMERdDone_i)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
-    sm2_VMERdMem_o <= 1'b0;
+    rd_dat_d0 = {32{1'bx}};
+    sm2_VMERdMem_o = 1'b0;
     case (VMEAddr[2:2])
     1'b0:
       begin
         // Reg r1
-        rd_ack_d0 <= VMERdMem;
-        rd_dat_d0 <= r1_reg;
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = r1_reg;
       end
     1'b1:
       begin
         // Submap sm2
-        sm2_VMERdMem_o <= VMERdMem;
-        rd_dat_d0 <= sm2_VMERdData_i;
-        rd_ack_d0 <= sm2_VMERdDone_i;
+        sm2_VMERdMem_o = VMERdMem;
+        rd_dat_d0 = sm2_VMERdData_i;
+        rd_ack_d0 = sm2_VMERdDone_i;
       end
     default:
-      rd_ack_d0 <= VMERdMem;
+      rd_ack_d0 = VMERdMem;
     endcase
   end
 endmodule

--- a/testfiles/bug-gen_wt/m1.v
+++ b/testfiles/bug-gen_wt/m1.v
@@ -1,0 +1,130 @@
+
+module m1
+  (
+    input   wire Clk,
+    input   wire Rst,
+    input   wire [2:2] VMEAddr,
+    output  reg [31:0] VMERdData,
+    input   wire [31:0] VMEWrData,
+    input   wire VMERdMem,
+    input   wire VMEWrMem,
+    output  wire VMERdDone,
+    output  wire VMEWrDone,
+
+    // REG r1
+    output  wire [31:0] r1_o,
+
+    // CERN-BE bus sm2
+    input   wire [31:0] sm2_VMERdData_i,
+    output  wire [31:0] sm2_VMEWrData_o,
+    output  reg sm2_VMERdMem_o,
+    output  wire sm2_VMEWrMem_o,
+    input   wire sm2_VMERdDone_i,
+    input   wire sm2_VMEWrDone_i
+  );
+  wire rst_n;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  reg [31:0] r1_reg;
+  reg r1_wreq;
+  reg r1_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [2:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+  reg sm2_ws;
+  assign rst_n = ~Rst;
+  assign VMERdDone = rd_ack_int;
+  assign VMEWrDone = wr_ack_int;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(Clk))
+  begin
+    if (!rst_n)
+      begin
+        rd_ack_int <= 1'b0;
+        VMERdData <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 1'b0;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        VMERdData <= rd_dat_d0;
+        wr_req_d0 <= VMEWrMem;
+        wr_adr_d0 <= VMEAddr;
+        wr_dat_d0 <= VMEWrData;
+      end
+  end
+
+  // Register r1
+  assign r1_o = r1_reg;
+  always @(posedge(Clk))
+  begin
+    if (!rst_n)
+      begin
+        r1_reg <= 32'b00000000000000000000000000000000;
+        r1_wack <= 1'b0;
+      end
+    else
+      begin
+        if (r1_wreq == 1'b1)
+          r1_reg <= wr_dat_d0;
+        r1_wack <= r1_wreq;
+      end
+  end
+
+  // Interface sm2
+  assign sm2_VMEWrData_o = wr_dat_d0;
+  assign sm2_VMEWrMem_o = sm2_ws;
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, r1_wack, sm2_VMEWrDone_i)
+  begin
+    r1_wreq = 1'b0;
+    sm2_ws = 1'b0;
+    case (wr_adr_d0[2:2])
+    1'b0:
+      begin
+        // Reg r1
+        r1_wreq = wr_req_d0;
+        wr_ack_int = r1_wack;
+      end
+    1'b1:
+      begin
+        // Submap sm2
+        sm2_ws = wr_req_d0;
+        wr_ack_int = sm2_VMEWrDone_i;
+      end
+    default:
+      wr_ack_int = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always @(VMEAddr, VMERdMem, r1_reg, sm2_VMERdData_i, sm2_VMERdDone_i)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    sm2_VMERdMem_o = 1'b0;
+    case (VMEAddr[2:2])
+    1'b0:
+      begin
+        // Reg r1
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = r1_reg;
+      end
+    1'b1:
+      begin
+        // Submap sm2
+        sm2_VMERdMem_o = VMERdMem;
+        rd_dat_d0 = sm2_VMERdData_i;
+        rd_ack_d0 = sm2_VMERdDone_i;
+      end
+    default:
+      rd_ack_d0 = VMERdMem;
+    endcase
+  end
+endmodule

--- a/testfiles/bug-memory/mem64ro.sv
+++ b/testfiles/bug-memory/mem64ro.sv
@@ -54,16 +54,16 @@ module mem64ro
   reg [3:0] DdrCapturesIndex_1_sel_int;
 
   // WB decode signals
-  always @(wb_sel_i)
+  always_comb
   begin
-    wr_sel[7:0] <= {8{wb_sel_i[0]}};
-    wr_sel[15:8] <= {8{wb_sel_i[1]}};
-    wr_sel[23:16] <= {8{wb_sel_i[2]}};
-    wr_sel[31:24] <= {8{wb_sel_i[3]}};
+    wr_sel[7:0] = {8{wb_sel_i[0]}};
+    wr_sel[15:8] = {8{wb_sel_i[1]}};
+    wr_sel[23:16] = {8{wb_sel_i[2]}};
+    wr_sel[31:24] = {8{wb_sel_i[3]}};
   end
   assign wb_en = wb_cyc_i & wb_stb_i;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_rip <= 1'b0;
@@ -72,7 +72,7 @@ module mem64ro
   end
   assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_wip <= 1'b0;
@@ -88,7 +88,7 @@ module mem64ro
   assign wb_err_o = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -112,7 +112,7 @@ module mem64ro
 
   // Register regA
   assign regA_field0_o = regA_field0_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -152,17 +152,17 @@ module mem64ro
       .wr_b_i(DdrCapturesIndex_DdrCaptures_we_i)
     );
   
-  always @(wr_sel_d0)
+  always_comb
   begin
-    DdrCapturesIndex_0_sel_int <= 4'b0;
+    DdrCapturesIndex_0_sel_int = 4'b0;
     if (~(wr_sel_d0[7:0] == 8'b0))
-      DdrCapturesIndex_0_sel_int[0] <= 1'b1;
+      DdrCapturesIndex_0_sel_int[0] = 1'b1;
     if (~(wr_sel_d0[15:8] == 8'b0))
-      DdrCapturesIndex_0_sel_int[1] <= 1'b1;
+      DdrCapturesIndex_0_sel_int[1] = 1'b1;
     if (~(wr_sel_d0[23:16] == 8'b0))
-      DdrCapturesIndex_0_sel_int[2] <= 1'b1;
+      DdrCapturesIndex_0_sel_int[2] = 1'b1;
     if (~(wr_sel_d0[31:24] == 8'b0))
-      DdrCapturesIndex_0_sel_int[3] <= 1'b1;
+      DdrCapturesIndex_0_sel_int[3] = 1'b1;
   end
   cheby_dpssram #(
       .g_data_width(32),
@@ -188,19 +188,19 @@ module mem64ro
       .wr_b_i(DdrCapturesIndex_DdrCaptures_we_i)
     );
   
-  always @(wr_sel_d0)
+  always_comb
   begin
-    DdrCapturesIndex_1_sel_int <= 4'b0;
+    DdrCapturesIndex_1_sel_int = 4'b0;
     if (~(wr_sel_d0[7:0] == 8'b0))
-      DdrCapturesIndex_1_sel_int[0] <= 1'b1;
+      DdrCapturesIndex_1_sel_int[0] = 1'b1;
     if (~(wr_sel_d0[15:8] == 8'b0))
-      DdrCapturesIndex_1_sel_int[1] <= 1'b1;
+      DdrCapturesIndex_1_sel_int[1] = 1'b1;
     if (~(wr_sel_d0[23:16] == 8'b0))
-      DdrCapturesIndex_1_sel_int[2] <= 1'b1;
+      DdrCapturesIndex_1_sel_int[2] = 1'b1;
     if (~(wr_sel_d0[31:24] == 8'b0))
-      DdrCapturesIndex_1_sel_int[3] <= 1'b1;
+      DdrCapturesIndex_1_sel_int[3] = 1'b1;
   end
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -215,70 +215,70 @@ module mem64ro
   end
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0, regA_wack)
+  always_comb
   begin
-    regA_wreq <= 1'b0;
+    regA_wreq = 1'b0;
     case (wr_adr_d0[9:9])
     1'b0:
       case (wr_adr_d0[8:2])
       7'b0000000:
         begin
           // Reg regA
-          regA_wreq <= wr_req_d0;
-          wr_ack_int <= regA_wack;
+          regA_wreq = wr_req_d0;
+          wr_ack_int = regA_wack;
         end
       default:
-        wr_ack_int <= wr_req_d0;
+        wr_ack_int = wr_req_d0;
       endcase
     1'b1:
       // Memory DdrCapturesIndex
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     default:
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     endcase
   end
 
   // Process for read requests.
-  always @(wb_adr_i, rd_req_int, regA_field0_reg, DdrCapturesIndex_DdrCaptures_int_dato0, DdrCapturesIndex_DdrCaptures_rack0, DdrCapturesIndex_DdrCaptures_int_dato1, DdrCapturesIndex_DdrCaptures_rack1)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
-    DdrCapturesIndex_DdrCaptures_rreq0 <= 1'b0;
-    DdrCapturesIndex_DdrCaptures_rreq1 <= 1'b0;
+    rd_dat_d0 = {32{1'bx}};
+    DdrCapturesIndex_DdrCaptures_rreq0 = 1'b0;
+    DdrCapturesIndex_DdrCaptures_rreq1 = 1'b0;
     case (wb_adr_i[9:9])
     1'b0:
       case (wb_adr_i[8:2])
       7'b0000000:
         begin
           // Reg regA
-          rd_ack_d0 <= rd_req_int;
-          rd_dat_d0[0] <= 1'b0;
-          rd_dat_d0[1] <= regA_field0_reg;
-          rd_dat_d0[31:2] <= 30'b0;
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0[0] = 1'b0;
+          rd_dat_d0[1] = regA_field0_reg;
+          rd_dat_d0[31:2] = 30'b0;
         end
       default:
-        rd_ack_d0 <= rd_req_int;
+        rd_ack_d0 = rd_req_int;
       endcase
     1'b1:
       // Memory DdrCapturesIndex
       case (wb_adr_i[2:2])
       1'b0:
         begin
-          rd_dat_d0 <= DdrCapturesIndex_DdrCaptures_int_dato0;
-          DdrCapturesIndex_DdrCaptures_rreq0 <= rd_req_int;
-          rd_ack_d0 <= DdrCapturesIndex_DdrCaptures_rack0;
+          rd_dat_d0 = DdrCapturesIndex_DdrCaptures_int_dato0;
+          DdrCapturesIndex_DdrCaptures_rreq0 = rd_req_int;
+          rd_ack_d0 = DdrCapturesIndex_DdrCaptures_rack0;
         end
       1'b1:
         begin
-          rd_dat_d0 <= DdrCapturesIndex_DdrCaptures_int_dato1;
-          DdrCapturesIndex_DdrCaptures_rreq1 <= rd_req_int;
-          rd_ack_d0 <= DdrCapturesIndex_DdrCaptures_rack1;
+          rd_dat_d0 = DdrCapturesIndex_DdrCaptures_int_dato1;
+          DdrCapturesIndex_DdrCaptures_rreq1 = rd_req_int;
+          rd_ack_d0 = DdrCapturesIndex_DdrCaptures_rack1;
         end
       default:
         ;
       endcase
     default:
-      rd_ack_d0 <= rd_req_int;
+      rd_ack_d0 = rd_req_int;
     endcase
   end
 endmodule

--- a/testfiles/bug-memory/mem64ro.v
+++ b/testfiles/bug-memory/mem64ro.v
@@ -1,0 +1,284 @@
+
+module mem64ro
+  (
+    input   wire rst_n_i,
+    input   wire clk_i,
+    input   wire wb_cyc_i,
+    input   wire wb_stb_i,
+    input   wire [9:2] wb_adr_i,
+    input   wire [3:0] wb_sel_i,
+    input   wire wb_we_i,
+    input   wire [31:0] wb_dat_i,
+    output  wire wb_ack_o,
+    output  wire wb_err_o,
+    output  wire wb_rty_o,
+    output  wire wb_stall_o,
+    output  reg [31:0] wb_dat_o,
+
+    // The first register (with some fields)
+    // 1-bit field
+    output  wire regA_field0_o,
+
+    // RAM port for DdrCapturesIndex
+    input   wire [5:0] DdrCapturesIndex_adr_i,
+    input   wire DdrCapturesIndex_DdrCaptures_we_i,
+    input   wire [63:0] DdrCapturesIndex_DdrCaptures_dat_i
+  );
+  reg [31:0] wr_sel;
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg regA_field0_reg;
+  reg regA_wreq;
+  reg regA_wack;
+  wire [31:0] DdrCapturesIndex_DdrCaptures_int_dato0;
+  wire [31:0] DdrCapturesIndex_DdrCaptures_int_dato1;
+  wire [31:0] DdrCapturesIndex_DdrCaptures_ext_dat0;
+  wire [31:0] DdrCapturesIndex_DdrCaptures_ext_dat1;
+  reg DdrCapturesIndex_DdrCaptures_rreq0;
+  reg DdrCapturesIndex_DdrCaptures_rreq1;
+  reg DdrCapturesIndex_DdrCaptures_rack0;
+  reg DdrCapturesIndex_DdrCaptures_rack1;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [9:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+  reg [31:0] wr_sel_d0;
+  reg [3:0] DdrCapturesIndex_0_sel_int;
+  reg [3:0] DdrCapturesIndex_1_sel_int;
+
+  // WB decode signals
+  always @(wb_sel_i)
+  begin
+    wr_sel[7:0] = {8{wb_sel_i[0]}};
+    wr_sel[15:8] = {8{wb_sel_i[1]}};
+    wr_sel[23:16] = {8{wb_sel_i[2]}};
+    wr_sel[31:24] = {8{wb_sel_i[3]}};
+  end
+  assign wb_en = wb_cyc_i & wb_stb_i;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb_we_i)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb_we_i)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb_we_i) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb_ack_o = ack_int;
+  assign wb_stall_o = ~ack_int & wb_en;
+  assign wb_rty_o = 1'b0;
+  assign wb_err_o = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        rd_ack_int <= 1'b0;
+        wb_dat_o <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 8'b00000000;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+        wr_sel_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb_dat_o <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_adr_d0 <= wb_adr_i;
+        wr_dat_d0 <= wb_dat_i;
+        wr_sel_d0 <= wr_sel;
+      end
+  end
+
+  // Register regA
+  assign regA_field0_o = regA_field0_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        regA_field0_reg <= 1'b0;
+        regA_wack <= 1'b0;
+      end
+    else
+      begin
+        if (regA_wreq == 1'b1)
+          regA_field0_reg <= wr_dat_d0[1];
+        regA_wack <= regA_wreq;
+      end
+  end
+
+  // Memory DdrCapturesIndex
+  cheby_dpssram #(
+      .g_data_width(32),
+      .g_size(64),
+      .g_addr_width(6),
+      .g_dual_clock(1'b0),
+      .g_use_bwsel(1'b1)
+    )
+  DdrCapturesIndex_DdrCaptures_raminst0 (
+      .clk_a_i(clk_i),
+      .clk_b_i(clk_i),
+      .addr_a_i(wb_adr_i[8:3]),
+      .bwsel_a_i(DdrCapturesIndex_0_sel_int),
+      .data_a_i({32{1'bx}}),
+      .data_a_o(DdrCapturesIndex_DdrCaptures_int_dato0),
+      .rd_a_i(DdrCapturesIndex_DdrCaptures_rreq0),
+      .wr_a_i(1'b0),
+      .addr_b_i(DdrCapturesIndex_adr_i),
+      .bwsel_b_i({4{1'b1}}),
+      .data_b_i(DdrCapturesIndex_DdrCaptures_dat_i[63:32]),
+      .data_b_o(DdrCapturesIndex_DdrCaptures_ext_dat0),
+      .rd_b_i(1'b0),
+      .wr_b_i(DdrCapturesIndex_DdrCaptures_we_i)
+    );
+  
+  always @(wr_sel_d0)
+  begin
+    DdrCapturesIndex_0_sel_int = 4'b0;
+    if (~(wr_sel_d0[7:0] == 8'b0))
+      DdrCapturesIndex_0_sel_int[0] = 1'b1;
+    if (~(wr_sel_d0[15:8] == 8'b0))
+      DdrCapturesIndex_0_sel_int[1] = 1'b1;
+    if (~(wr_sel_d0[23:16] == 8'b0))
+      DdrCapturesIndex_0_sel_int[2] = 1'b1;
+    if (~(wr_sel_d0[31:24] == 8'b0))
+      DdrCapturesIndex_0_sel_int[3] = 1'b1;
+  end
+  cheby_dpssram #(
+      .g_data_width(32),
+      .g_size(64),
+      .g_addr_width(6),
+      .g_dual_clock(1'b0),
+      .g_use_bwsel(1'b1)
+    )
+  DdrCapturesIndex_DdrCaptures_raminst1 (
+      .clk_a_i(clk_i),
+      .clk_b_i(clk_i),
+      .addr_a_i(wb_adr_i[8:3]),
+      .bwsel_a_i(DdrCapturesIndex_1_sel_int),
+      .data_a_i({32{1'bx}}),
+      .data_a_o(DdrCapturesIndex_DdrCaptures_int_dato1),
+      .rd_a_i(DdrCapturesIndex_DdrCaptures_rreq1),
+      .wr_a_i(1'b0),
+      .addr_b_i(DdrCapturesIndex_adr_i),
+      .bwsel_b_i({4{1'b1}}),
+      .data_b_i(DdrCapturesIndex_DdrCaptures_dat_i[31:0]),
+      .data_b_o(DdrCapturesIndex_DdrCaptures_ext_dat1),
+      .rd_b_i(1'b0),
+      .wr_b_i(DdrCapturesIndex_DdrCaptures_we_i)
+    );
+  
+  always @(wr_sel_d0)
+  begin
+    DdrCapturesIndex_1_sel_int = 4'b0;
+    if (~(wr_sel_d0[7:0] == 8'b0))
+      DdrCapturesIndex_1_sel_int[0] = 1'b1;
+    if (~(wr_sel_d0[15:8] == 8'b0))
+      DdrCapturesIndex_1_sel_int[1] = 1'b1;
+    if (~(wr_sel_d0[23:16] == 8'b0))
+      DdrCapturesIndex_1_sel_int[2] = 1'b1;
+    if (~(wr_sel_d0[31:24] == 8'b0))
+      DdrCapturesIndex_1_sel_int[3] = 1'b1;
+  end
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        DdrCapturesIndex_DdrCaptures_rack0 <= 1'b0;
+        DdrCapturesIndex_DdrCaptures_rack1 <= 1'b0;
+      end
+    else
+      begin
+        DdrCapturesIndex_DdrCaptures_rack0 <= DdrCapturesIndex_DdrCaptures_rreq0;
+        DdrCapturesIndex_DdrCaptures_rack1 <= DdrCapturesIndex_DdrCaptures_rreq1;
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, regA_wack)
+  begin
+    regA_wreq = 1'b0;
+    case (wr_adr_d0[9:9])
+    1'b0:
+      case (wr_adr_d0[8:2])
+      7'b0000000:
+        begin
+          // Reg regA
+          regA_wreq = wr_req_d0;
+          wr_ack_int = regA_wack;
+        end
+      default:
+        wr_ack_int = wr_req_d0;
+      endcase
+    1'b1:
+      // Memory DdrCapturesIndex
+      wr_ack_int = wr_req_d0;
+    default:
+      wr_ack_int = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always @(wb_adr_i, rd_req_int, regA_field0_reg, DdrCapturesIndex_DdrCaptures_int_dato0, DdrCapturesIndex_DdrCaptures_rack0, DdrCapturesIndex_DdrCaptures_int_dato1, DdrCapturesIndex_DdrCaptures_rack1)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    DdrCapturesIndex_DdrCaptures_rreq0 = 1'b0;
+    DdrCapturesIndex_DdrCaptures_rreq1 = 1'b0;
+    case (wb_adr_i[9:9])
+    1'b0:
+      case (wb_adr_i[8:2])
+      7'b0000000:
+        begin
+          // Reg regA
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0[0] = 1'b0;
+          rd_dat_d0[1] = regA_field0_reg;
+          rd_dat_d0[31:2] = 30'b0;
+        end
+      default:
+        rd_ack_d0 = rd_req_int;
+      endcase
+    1'b1:
+      // Memory DdrCapturesIndex
+      case (wb_adr_i[2:2])
+      1'b0:
+        begin
+          rd_dat_d0 = DdrCapturesIndex_DdrCaptures_int_dato0;
+          DdrCapturesIndex_DdrCaptures_rreq0 = rd_req_int;
+          rd_ack_d0 = DdrCapturesIndex_DdrCaptures_rack0;
+        end
+      1'b1:
+        begin
+          rd_dat_d0 = DdrCapturesIndex_DdrCaptures_int_dato1;
+          DdrCapturesIndex_DdrCaptures_rreq1 = rd_req_int;
+          rd_ack_d0 = DdrCapturesIndex_DdrCaptures_rack1;
+        end
+      default:
+        ;
+      endcase
+    default:
+      rd_ack_d0 = rd_req_int;
+    endcase
+  end
+endmodule

--- a/testfiles/bug-repmem/bran.sv
+++ b/testfiles/bug-repmem/bran.sv
@@ -205,12 +205,12 @@ module bran_wb
   reg [31:0] wr_dat_d0;
 
   // WB decode signals
-  always @(wb.sel)
+  always_comb
   ;
   assign adr_int = wb.adr[20:2];
   assign wb_en = wb.cyc & wb.stb;
 
-  always @(posedge(wb.clk))
+  always_ff @(posedge(wb.clk))
   begin
     if (!wb.rst_n)
       wb_rip <= 1'b0;
@@ -219,7 +219,7 @@ module bran_wb
   end
   assign rd_req_int = (wb_en & ~wb.we) & ~wb_rip;
 
-  always @(posedge(wb.clk))
+  always_ff @(posedge(wb.clk))
   begin
     if (!wb.rst_n)
       wb_wip <= 1'b0;
@@ -235,7 +235,7 @@ module bran_wb
   assign wb.err = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(wb.clk))
+  always_ff @(posedge(wb.clk))
   begin
     if (!wb.rst_n)
       begin
@@ -264,7 +264,7 @@ module bran_wb
   assign DisableADCStream_o = DisableADCStream_reg;
   assign EnableTurnEmulator_o = EnableTurnEmulator_reg;
   assign LHC_timing = LHCTiming_reg;
-  always @(posedge(wb.clk))
+  always_ff @(posedge(wb.clk))
   begin
     if (!wb.rst_n)
       begin
@@ -304,7 +304,7 @@ module bran_wb
 
   // Register TurnPeriod
   assign TurnPeriod_o = TurnPeriod_reg;
-  always @(posedge(wb.clk))
+  always_ff @(posedge(wb.clk))
   begin
     if (!wb.rst_n)
       begin
@@ -322,7 +322,7 @@ module bran_wb
 
   // Register TurnLength
   assign TurnLength_o = TurnLength_reg;
-  always @(posedge(wb.clk))
+  always_ff @(posedge(wb.clk))
   begin
     if (!wb.rst_n)
       begin
@@ -343,7 +343,7 @@ module bran_wb
   // Register FmcPower
   assign FmcPowerEnable_o = FmcPowerEnable_reg;
   assign DCDCSyncEnable_o = DCDCSyncEnable_reg;
-  always @(posedge(wb.clk))
+  always_ff @(posedge(wb.clk))
   begin
     if (!wb.rst_n)
       begin
@@ -364,7 +364,7 @@ module bran_wb
 
   // Register ADCPatternCheckCtrl
   assign PatternRst_o = PatternRst_reg;
-  always @(posedge(wb.clk))
+  always_ff @(posedge(wb.clk))
   begin
     if (!wb.rst_n)
       begin
@@ -384,7 +384,7 @@ module bran_wb
   assign ADCEnable_o = ADCEnable_reg;
   assign ADCManualSync_o = ADCManualSync_reg;
   assign ADCDisableAutoSync_o = ADCDisableAutoSync_reg;
-  always @(posedge(wb.clk))
+  always_ff @(posedge(wb.clk))
   begin
     if (!wb.rst_n)
       begin
@@ -415,7 +415,7 @@ module bran_wb
   assign SixxRst_o = SixxRst_reg;
   assign JesdLinkReady_o = JesdLinkReady_reg;
   assign JesdEnableSysref_o = JesdEnableSysref_reg;
-  always @(posedge(wb.clk))
+  always_ff @(posedge(wb.clk))
   begin
     if (!wb.rst_n)
       begin
@@ -446,7 +446,7 @@ module bran_wb
 
   // Register AdcSpiWrite
   assign AdcSpiWrite_o = AdcSpiWrite_reg;
-  always @(posedge(wb.clk))
+  always_ff @(posedge(wb.clk))
   begin
     if (!wb.rst_n)
       begin
@@ -468,7 +468,7 @@ module bran_wb
 
   // Register CummulativeTurns
   assign cummulative_turns_b32 = CummulativeTurns_reg;
-  always @(posedge(wb.clk))
+  always_ff @(posedge(wb.clk))
   begin
     if (!wb.rst_n)
       begin
@@ -485,7 +485,7 @@ module bran_wb
 
   // Register Debug
   assign OverrideTurnEmulatorTiming = OverrideTurnEmulatorTiming_reg;
-  always @(posedge(wb.clk))
+  always_ff @(posedge(wb.clk))
   begin
     if (!wb.rst_n)
       begin
@@ -501,7 +501,7 @@ module bran_wb
   end
 
   // Interface RawData0
-  always @(posedge(wb.clk))
+  always_ff @(posedge(wb.clk))
   begin
     if (!wb.rst_n)
       RawData0_rack <= 1'b0;
@@ -511,7 +511,7 @@ module bran_wb
   assign RawData0_addr_o = adr_int[17:2];
 
   // Interface RawData1
-  always @(posedge(wb.clk))
+  always_ff @(posedge(wb.clk))
   begin
     if (!wb.rst_n)
       RawData1_rack <= 1'b0;
@@ -521,7 +521,7 @@ module bran_wb
   assign RawData1_addr_o = adr_int[17:2];
 
   // Interface RawData2
-  always @(posedge(wb.clk))
+  always_ff @(posedge(wb.clk))
   begin
     if (!wb.rst_n)
       RawData2_rack <= 1'b0;
@@ -531,7 +531,7 @@ module bran_wb
   assign RawData2_addr_o = adr_int[17:2];
 
   // Interface RawData3
-  always @(posedge(wb.clk))
+  always_ff @(posedge(wb.clk))
   begin
     if (!wb.rst_n)
       RawData3_rack <= 1'b0;
@@ -541,311 +541,311 @@ module bran_wb
   assign RawData3_addr_o = adr_int[17:2];
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0, Ctrl_wack, TurnPeriod_wack, TurnLength_wack, FmcPower_wack, ADCPatternCheckCtrl_wack, ADCCtrl_wack, JesdLink_wack, AdcSpiWrite_wack, CummulativeTurns_wack, Debug_wack)
+  always_comb
   begin
-    Ctrl_wreq <= 1'b0;
-    TurnPeriod_wreq <= 1'b0;
-    TurnLength_wreq <= 1'b0;
-    FmcPower_wreq <= 1'b0;
-    ADCPatternCheckCtrl_wreq <= 1'b0;
-    ADCCtrl_wreq <= 1'b0;
-    JesdLink_wreq <= 1'b0;
-    AdcSpiWrite_wreq <= 1'b0;
-    CummulativeTurns_wreq <= 1'b0;
-    Debug_wreq <= 1'b0;
+    Ctrl_wreq = 1'b0;
+    TurnPeriod_wreq = 1'b0;
+    TurnLength_wreq = 1'b0;
+    FmcPower_wreq = 1'b0;
+    ADCPatternCheckCtrl_wreq = 1'b0;
+    ADCCtrl_wreq = 1'b0;
+    JesdLink_wreq = 1'b0;
+    AdcSpiWrite_wreq = 1'b0;
+    CummulativeTurns_wreq = 1'b0;
+    Debug_wreq = 1'b0;
     case (wr_adr_d0[20:18])
     3'b000:
       case (wr_adr_d0[17:2])
       16'b0000000000000000:
         // Reg Token
-        wr_ack_int <= wr_req_d0;
+        wr_ack_int = wr_req_d0;
       16'b0000000000000001:
         begin
           // Reg Ctrl
-          Ctrl_wreq <= wr_req_d0;
-          wr_ack_int <= Ctrl_wack;
+          Ctrl_wreq = wr_req_d0;
+          wr_ack_int = Ctrl_wack;
         end
       16'b0000000000000010:
         // Reg Stat
-        wr_ack_int <= wr_req_d0;
+        wr_ack_int = wr_req_d0;
       16'b0000000000000011:
         // Reg SysrefTicks
-        wr_ack_int <= wr_req_d0;
+        wr_ack_int = wr_req_d0;
       16'b0000000000000100:
         // Reg GWRevision
-        wr_ack_int <= wr_req_d0;
+        wr_ack_int = wr_req_d0;
       16'b0000000000000101:
         begin
           // Reg TurnPeriod
-          TurnPeriod_wreq <= wr_req_d0;
-          wr_ack_int <= TurnPeriod_wack;
+          TurnPeriod_wreq = wr_req_d0;
+          wr_ack_int = TurnPeriod_wack;
         end
       16'b0000000000000110:
         begin
           // Reg TurnLength
-          TurnLength_wreq <= wr_req_d0;
-          wr_ack_int <= TurnLength_wack;
+          TurnLength_wreq = wr_req_d0;
+          wr_ack_int = TurnLength_wack;
         end
       16'b0000000000000111:
         // Reg TurnsIntercepted
-        wr_ack_int <= wr_req_d0;
+        wr_ack_int = wr_req_d0;
       16'b0000000000001000:
         begin
           // Reg FmcPower
-          FmcPower_wreq <= wr_req_d0;
-          wr_ack_int <= FmcPower_wack;
+          FmcPower_wreq = wr_req_d0;
+          wr_ack_int = FmcPower_wack;
         end
       16'b0000000000001001:
         begin
           // Reg ADCPatternCheckCtrl
-          ADCPatternCheckCtrl_wreq <= wr_req_d0;
-          wr_ack_int <= ADCPatternCheckCtrl_wack;
+          ADCPatternCheckCtrl_wreq = wr_req_d0;
+          wr_ack_int = ADCPatternCheckCtrl_wack;
         end
       16'b0000000000001010:
         begin
           // Reg ADCCtrl
-          ADCCtrl_wreq <= wr_req_d0;
-          wr_ack_int <= ADCCtrl_wack;
+          ADCCtrl_wreq = wr_req_d0;
+          wr_ack_int = ADCCtrl_wack;
         end
       16'b0000000000001011:
         begin
           // Reg JesdLink
-          JesdLink_wreq <= wr_req_d0;
-          wr_ack_int <= JesdLink_wack;
+          JesdLink_wreq = wr_req_d0;
+          wr_ack_int = JesdLink_wack;
         end
       16'b0000000000001100:
         begin
           // Reg AdcSpiWrite
-          AdcSpiWrite_wreq <= wr_req_d0;
-          wr_ack_int <= AdcSpiWrite_wack;
+          AdcSpiWrite_wreq = wr_req_d0;
+          wr_ack_int = AdcSpiWrite_wack;
         end
       16'b0000000000001101:
         // Reg AdcSpiRead
-        wr_ack_int <= wr_req_d0;
+        wr_ack_int = wr_req_d0;
       16'b0000000000001110:
         // Reg SpiStatus
-        wr_ack_int <= wr_req_d0;
+        wr_ack_int = wr_req_d0;
       16'b0000000000001111:
         begin
           // Reg CummulativeTurns
-          CummulativeTurns_wreq <= wr_req_d0;
-          wr_ack_int <= CummulativeTurns_wack;
+          CummulativeTurns_wreq = wr_req_d0;
+          wr_ack_int = CummulativeTurns_wack;
         end
       16'b0000000000010000:
         begin
           // Reg Debug
-          Debug_wreq <= wr_req_d0;
-          wr_ack_int <= Debug_wack;
+          Debug_wreq = wr_req_d0;
+          wr_ack_int = Debug_wack;
         end
       default:
-        wr_ack_int <= wr_req_d0;
+        wr_ack_int = wr_req_d0;
       endcase
     3'b100:
       // Memory RawData0
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     3'b101:
       // Memory RawData1
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     3'b110:
       // Memory RawData2
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     3'b111:
       // Memory RawData3
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     default:
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     endcase
   end
 
   // Process for read requests.
-  always @(adr_int, rd_req_int, Token_i, Enable_reg, DisableADCStream_reg, EnableTurnEmulator_reg, LHCTiming_reg, VoltageFail_i, JesdRXNotReady_i, TurnEmulatorPLLError_i, TurnEmulatorError_i, NoTurnDetected_i, VfmcDisabled_i, std_bst_desynced, GBTPLLLol_i, std_fa_in_reset, PatternFail_i, DCDCSyncEnabled_i, SysrefFail_i, FmcLol_i, FmcLos_i, SysrefTicks_i, GWRevision_i, TurnPeriod_reg, TurnLength_reg, TurnsIntercepted_b32, FmcPowerEnable_reg, DCDCSyncEnable_reg, PatternRst_reg, ADCRst_reg, ADCEnable_reg, ADCManualSync_reg, ADCDisableAutoSync_reg, JesdXcvrRst_reg, JesdLinkRst_reg, JesdPLLRst_reg, JesdAvsRst_reg, SixxRst_reg, JesdLinkReady_reg, JesdEnableSysref_reg, AdcSpiRead_i, AdcSpiBusy_i, CummulativeTurns_reg, OverrideTurnEmulatorTiming_reg, RawData0_data_i, RawData0_rack, RawData1_data_i, RawData1_rack, RawData2_data_i, RawData2_rack, RawData3_data_i, RawData3_rack)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
-    RawData0_re <= 1'b0;
-    RawData1_re <= 1'b0;
-    RawData2_re <= 1'b0;
-    RawData3_re <= 1'b0;
+    rd_dat_d0 = {32{1'bx}};
+    RawData0_re = 1'b0;
+    RawData1_re = 1'b0;
+    RawData2_re = 1'b0;
+    RawData3_re = 1'b0;
     case (adr_int[20:18])
     3'b000:
       case (adr_int[17:2])
       16'b0000000000000000:
         begin
           // Reg Token
-          rd_ack_d0 <= rd_req_int;
-          rd_dat_d0 <= Token_i;
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0 = Token_i;
         end
       16'b0000000000000001:
         begin
           // Reg Ctrl
-          rd_ack_d0 <= rd_req_int;
-          rd_dat_d0[0] <= Enable_reg;
-          rd_dat_d0[1] <= 1'b0;
-          rd_dat_d0[2] <= 1'b0;
-          rd_dat_d0[3] <= 1'b0;
-          rd_dat_d0[4] <= DisableADCStream_reg;
-          rd_dat_d0[5] <= 1'b0;
-          rd_dat_d0[6] <= EnableTurnEmulator_reg;
-          rd_dat_d0[9:7] <= 3'b0;
-          rd_dat_d0[10] <= LHCTiming_reg;
-          rd_dat_d0[31:11] <= 21'b0;
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0[0] = Enable_reg;
+          rd_dat_d0[1] = 1'b0;
+          rd_dat_d0[2] = 1'b0;
+          rd_dat_d0[3] = 1'b0;
+          rd_dat_d0[4] = DisableADCStream_reg;
+          rd_dat_d0[5] = 1'b0;
+          rd_dat_d0[6] = EnableTurnEmulator_reg;
+          rd_dat_d0[9:7] = 3'b0;
+          rd_dat_d0[10] = LHCTiming_reg;
+          rd_dat_d0[31:11] = 21'b0;
         end
       16'b0000000000000010:
         begin
           // Reg Stat
-          rd_ack_d0 <= rd_req_int;
-          rd_dat_d0[7:0] <= VoltageFail_i;
-          rd_dat_d0[15:8] <= JesdRXNotReady_i;
-          rd_dat_d0[16] <= TurnEmulatorPLLError_i;
-          rd_dat_d0[17] <= 1'b0;
-          rd_dat_d0[18] <= TurnEmulatorError_i;
-          rd_dat_d0[19] <= NoTurnDetected_i;
-          rd_dat_d0[21:20] <= 2'b0;
-          rd_dat_d0[22] <= VfmcDisabled_i;
-          rd_dat_d0[23] <= std_bst_desynced;
-          rd_dat_d0[24] <= 1'b0;
-          rd_dat_d0[25] <= GBTPLLLol_i;
-          rd_dat_d0[26] <= std_fa_in_reset;
-          rd_dat_d0[27] <= PatternFail_i;
-          rd_dat_d0[28] <= DCDCSyncEnabled_i;
-          rd_dat_d0[29] <= SysrefFail_i;
-          rd_dat_d0[30] <= FmcLol_i;
-          rd_dat_d0[31] <= FmcLos_i;
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0[7:0] = VoltageFail_i;
+          rd_dat_d0[15:8] = JesdRXNotReady_i;
+          rd_dat_d0[16] = TurnEmulatorPLLError_i;
+          rd_dat_d0[17] = 1'b0;
+          rd_dat_d0[18] = TurnEmulatorError_i;
+          rd_dat_d0[19] = NoTurnDetected_i;
+          rd_dat_d0[21:20] = 2'b0;
+          rd_dat_d0[22] = VfmcDisabled_i;
+          rd_dat_d0[23] = std_bst_desynced;
+          rd_dat_d0[24] = 1'b0;
+          rd_dat_d0[25] = GBTPLLLol_i;
+          rd_dat_d0[26] = std_fa_in_reset;
+          rd_dat_d0[27] = PatternFail_i;
+          rd_dat_d0[28] = DCDCSyncEnabled_i;
+          rd_dat_d0[29] = SysrefFail_i;
+          rd_dat_d0[30] = FmcLol_i;
+          rd_dat_d0[31] = FmcLos_i;
         end
       16'b0000000000000011:
         begin
           // Reg SysrefTicks
-          rd_ack_d0 <= rd_req_int;
-          rd_dat_d0 <= SysrefTicks_i;
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0 = SysrefTicks_i;
         end
       16'b0000000000000100:
         begin
           // Reg GWRevision
-          rd_ack_d0 <= rd_req_int;
-          rd_dat_d0 <= GWRevision_i;
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0 = GWRevision_i;
         end
       16'b0000000000000101:
         begin
           // Reg TurnPeriod
-          rd_ack_d0 <= rd_req_int;
-          rd_dat_d0 <= TurnPeriod_reg;
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0 = TurnPeriod_reg;
         end
       16'b0000000000000110:
         begin
           // Reg TurnLength
-          rd_ack_d0 <= rd_req_int;
-          rd_dat_d0 <= TurnLength_reg;
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0 = TurnLength_reg;
         end
       16'b0000000000000111:
         begin
           // Reg TurnsIntercepted
-          rd_ack_d0 <= rd_req_int;
-          rd_dat_d0 <= TurnsIntercepted_b32;
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0 = TurnsIntercepted_b32;
         end
       16'b0000000000001000:
         begin
           // Reg FmcPower
-          rd_ack_d0 <= rd_req_int;
-          rd_dat_d0[0] <= FmcPowerEnable_reg;
-          rd_dat_d0[1] <= DCDCSyncEnable_reg;
-          rd_dat_d0[31:2] <= 30'b0;
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0[0] = FmcPowerEnable_reg;
+          rd_dat_d0[1] = DCDCSyncEnable_reg;
+          rd_dat_d0[31:2] = 30'b0;
         end
       16'b0000000000001001:
         begin
           // Reg ADCPatternCheckCtrl
-          rd_ack_d0 <= rd_req_int;
-          rd_dat_d0[0] <= PatternRst_reg;
-          rd_dat_d0[31:1] <= 31'b0;
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0[0] = PatternRst_reg;
+          rd_dat_d0[31:1] = 31'b0;
         end
       16'b0000000000001010:
         begin
           // Reg ADCCtrl
-          rd_ack_d0 <= rd_req_int;
-          rd_dat_d0[0] <= ADCRst_reg;
-          rd_dat_d0[1] <= ADCEnable_reg;
-          rd_dat_d0[5:2] <= 4'b0;
-          rd_dat_d0[6] <= ADCManualSync_reg;
-          rd_dat_d0[7] <= ADCDisableAutoSync_reg;
-          rd_dat_d0[31:8] <= 24'b0;
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0[0] = ADCRst_reg;
+          rd_dat_d0[1] = ADCEnable_reg;
+          rd_dat_d0[5:2] = 4'b0;
+          rd_dat_d0[6] = ADCManualSync_reg;
+          rd_dat_d0[7] = ADCDisableAutoSync_reg;
+          rd_dat_d0[31:8] = 24'b0;
         end
       16'b0000000000001011:
         begin
           // Reg JesdLink
-          rd_ack_d0 <= rd_req_int;
-          rd_dat_d0[0] <= JesdXcvrRst_reg;
-          rd_dat_d0[1] <= 1'b0;
-          rd_dat_d0[2] <= JesdLinkRst_reg;
-          rd_dat_d0[3] <= 1'b0;
-          rd_dat_d0[4] <= JesdPLLRst_reg;
-          rd_dat_d0[5] <= JesdAvsRst_reg;
-          rd_dat_d0[6] <= SixxRst_reg;
-          rd_dat_d0[7] <= 1'b0;
-          rd_dat_d0[8] <= JesdLinkReady_reg;
-          rd_dat_d0[9] <= JesdEnableSysref_reg;
-          rd_dat_d0[31:10] <= 22'b0;
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0[0] = JesdXcvrRst_reg;
+          rd_dat_d0[1] = 1'b0;
+          rd_dat_d0[2] = JesdLinkRst_reg;
+          rd_dat_d0[3] = 1'b0;
+          rd_dat_d0[4] = JesdPLLRst_reg;
+          rd_dat_d0[5] = JesdAvsRst_reg;
+          rd_dat_d0[6] = SixxRst_reg;
+          rd_dat_d0[7] = 1'b0;
+          rd_dat_d0[8] = JesdLinkReady_reg;
+          rd_dat_d0[9] = JesdEnableSysref_reg;
+          rd_dat_d0[31:10] = 22'b0;
         end
       16'b0000000000001100:
         // Reg AdcSpiWrite
-        rd_ack_d0 <= rd_req_int;
+        rd_ack_d0 = rd_req_int;
       16'b0000000000001101:
         begin
           // Reg AdcSpiRead
-          rd_ack_d0 <= rd_req_int;
-          rd_dat_d0 <= AdcSpiRead_i;
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0 = AdcSpiRead_i;
         end
       16'b0000000000001110:
         begin
           // Reg SpiStatus
-          rd_ack_d0 <= rd_req_int;
-          rd_dat_d0[0] <= AdcSpiBusy_i;
-          rd_dat_d0[31:1] <= 31'b0;
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0[0] = AdcSpiBusy_i;
+          rd_dat_d0[31:1] = 31'b0;
         end
       16'b0000000000001111:
         begin
           // Reg CummulativeTurns
-          rd_ack_d0 <= rd_req_int;
-          rd_dat_d0 <= CummulativeTurns_reg;
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0 = CummulativeTurns_reg;
         end
       16'b0000000000010000:
         begin
           // Reg Debug
-          rd_ack_d0 <= rd_req_int;
-          rd_dat_d0[0] <= OverrideTurnEmulatorTiming_reg;
-          rd_dat_d0[31:1] <= 31'b0;
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0[0] = OverrideTurnEmulatorTiming_reg;
+          rd_dat_d0[31:1] = 31'b0;
         end
       default:
-        rd_ack_d0 <= rd_req_int;
+        rd_ack_d0 = rd_req_int;
       endcase
     3'b100:
       begin
         // Memory RawData0
-        rd_dat_d0 <= RawData0_data_i;
-        rd_ack_d0 <= RawData0_rack;
-        RawData0_re <= rd_req_int;
+        rd_dat_d0 = RawData0_data_i;
+        rd_ack_d0 = RawData0_rack;
+        RawData0_re = rd_req_int;
       end
     3'b101:
       begin
         // Memory RawData1
-        rd_dat_d0 <= RawData1_data_i;
-        rd_ack_d0 <= RawData1_rack;
-        RawData1_re <= rd_req_int;
+        rd_dat_d0 = RawData1_data_i;
+        rd_ack_d0 = RawData1_rack;
+        RawData1_re = rd_req_int;
       end
     3'b110:
       begin
         // Memory RawData2
-        rd_dat_d0 <= RawData2_data_i;
-        rd_ack_d0 <= RawData2_rack;
-        RawData2_re <= rd_req_int;
+        rd_dat_d0 = RawData2_data_i;
+        rd_ack_d0 = RawData2_rack;
+        RawData2_re = rd_req_int;
       end
     3'b111:
       begin
         // Memory RawData3
-        rd_dat_d0 <= RawData3_data_i;
-        rd_ack_d0 <= RawData3_rack;
-        RawData3_re <= rd_req_int;
+        rd_dat_d0 = RawData3_data_i;
+        rd_ack_d0 = RawData3_rack;
+        RawData3_re = rd_req_int;
       end
     default:
-      rd_ack_d0 <= rd_req_int;
+      rd_ack_d0 = rd_req_int;
     endcase
   end
 endmodule

--- a/testfiles/bug-repmem/bran.v
+++ b/testfiles/bug-repmem/bran.v
@@ -1,0 +1,851 @@
+
+module bran_wb
+  (
+    t_wishbone.slave wb,
+
+    // Block identifier - returns 0xcafebeef
+    input   wire [31:0] Token_i,
+
+    // Common controls
+    // 1 enables the module
+    output  wire Enable_o,
+    // 1 clears BST_desync flag in stat
+    output  wire std_rst_bst_desync,
+    // 1 resets the frame aligner
+    output  wire std_reset_alignment,
+    // 1 to zeros instead of ADC data
+    output  wire DisableADCStream_o,
+    // 1 to use internal turn clock emulator
+    output  wire EnableTurnEmulator_o,
+    // Bit indicates whether turn emulator shall provide LHC or SPS timing. If this bit is set, the turn emulator will provide turn clock once every 3564 bunch clocks. Otherwise the turn emulator will emulate SPS timing with its 924 bunch slots
+    output  wire LHC_timing,
+
+    // General status work
+    // 1 indicates loss of signal JESD
+    input   wire FmcLos_i,
+    // 1 indicates loss of lock JESD
+    input   wire FmcLol_i,
+    // 1 indicates error of sysref
+    input   wire SysrefFail_i,
+    // 1 indicates DCDC sync is enabled
+    input   wire DCDCSyncEnabled_i,
+    // 1 indicates ADC pattern check failed
+    input   wire PatternFail_i,
+    // 1 indicates FA waiting for turn clock
+    input   wire std_fa_in_reset,
+    // 1 if GBT PLL is not locked
+    input   wire GBTPLLLol_i,
+    // 1 if BST turn and bunch clock do not  match
+    input   wire std_bst_desynced,
+    // 1 if FMC is NOT powered
+    input   wire VfmcDisabled_i,
+    // 1 if no turn mark arrives to capture block
+    input   wire NoTurnDetected_i,
+    // 1 if turn emulator is wrongly setup
+    input   wire TurnEmulatorError_i,
+    // 1 if turn emulator PLL is not locked
+    input   wire TurnEmulatorPLLError_i,
+    // 1 for each line not ready
+    input   wire [7:0] JesdRXNotReady_i,
+    // 1 indicates fail of DCDC converter
+    input   wire [7:0] VoltageFail_i,
+
+    // Number of ticks detected on sysref clock
+    input   wire [31:0] SysrefTicks_i,
+
+    // Compilation time of gateware
+    input   wire [31:0] GWRevision_i,
+
+    // Turn emulator period in 8ns increments
+    output  wire [31:0] TurnPeriod_o,
+    output  wire TurnPeriod_wr_o,
+
+    // Turn emulator length in 8ns increments
+    output  wire [31:0] TurnLength_o,
+    output  wire TurnLength_wr_o,
+
+    // Upcounts when turn HW or emulated detected
+    input   wire [31:0] TurnsIntercepted_b32,
+
+    // Power control of the FMC mezzanine
+    // Enables/disables power to FMC
+    output  wire FmcPowerEnable_o,
+    // Enables/disables synchronization of DCDC converters on the IAM
+    output  wire DCDCSyncEnable_o,
+
+    // ADC pattern checher module control
+    // Resets pattern checking
+    output  wire PatternRst_o,
+
+    // ADC specific control register
+    // ADC reset control
+    output  wire ADCRst_o,
+    // Enables ADC conversion
+    output  wire ADCEnable_o,
+    // Synchronization signal value
+    output  wire ADCManualSync_o,
+    // 1 = sync comes from ADCManualSync
+    output  wire ADCDisableAutoSync_o,
+
+    // JESD204B link interface control
+    // JESD PHY and MAC reset
+    output  wire JesdXcvrRst_o,
+    // JESD Link interface reset
+    output  wire JesdLinkRst_o,
+    // JESD GBT PLL reset
+    output  wire JesdPLLRst_o,
+    // MAC wishbone infterface reset
+    output  wire JesdAvsRst_o,
+    // 0-1-0 to reset the FMC PLL chip
+    output  wire SixxRst_o,
+    // Set link to ready state
+    output  wire JesdLinkReady_o,
+    // Enable/disable JESD sysref signal
+    output  wire JesdEnableSysref_o,
+
+    // ADC SPI write configuration interface
+    output  wire [31:0] AdcSpiWrite_o,
+    output  wire AdcSpiWrite_wr_o,
+
+    // ADC SPI read configuration interface
+    input   wire [31:0] AdcSpiRead_i,
+
+    // SPI status
+    // 1 if SPI sends data to ADC
+    input   wire AdcSpiBusy_i,
+
+    // For how many turns to accumulate data
+    output  wire [31:0] cummulative_turns_b32,
+
+    // Master-of-universe-tool
+    output  wire OverrideTurnEmulatorTiming,
+
+    // SRAM bus RawData0
+    output  wire [17:2] RawData0_addr_o,
+    input   wire [31:0] RawData0_data_i,
+
+    // SRAM bus RawData1
+    output  wire [17:2] RawData1_addr_o,
+    input   wire [31:0] RawData1_data_i,
+
+    // SRAM bus RawData2
+    output  wire [17:2] RawData2_addr_o,
+    input   wire [31:0] RawData2_data_i,
+
+    // SRAM bus RawData3
+    output  wire [17:2] RawData3_addr_o,
+    input   wire [31:0] RawData3_data_i
+  );
+  wire [20:2] adr_int;
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg Enable_reg;
+  reg RstBstDesync_reg;
+  reg FAReset_reg;
+  reg DisableADCStream_reg;
+  reg EnableTurnEmulator_reg;
+  reg LHCTiming_reg;
+  reg Ctrl_wreq;
+  reg Ctrl_wack;
+  reg [31:0] TurnPeriod_reg;
+  reg TurnPeriod_wreq;
+  reg TurnPeriod_wack;
+  reg [31:0] TurnLength_reg;
+  reg TurnLength_wreq;
+  reg TurnLength_wack;
+  reg FmcPowerEnable_reg;
+  reg DCDCSyncEnable_reg;
+  reg FmcPower_wreq;
+  reg FmcPower_wack;
+  reg PatternRst_reg;
+  reg ADCPatternCheckCtrl_wreq;
+  reg ADCPatternCheckCtrl_wack;
+  reg ADCRst_reg;
+  reg ADCEnable_reg;
+  reg ADCManualSync_reg;
+  reg ADCDisableAutoSync_reg;
+  reg ADCCtrl_wreq;
+  reg ADCCtrl_wack;
+  reg JesdXcvrRst_reg;
+  reg JesdLinkRst_reg;
+  reg JesdPLLRst_reg;
+  reg JesdAvsRst_reg;
+  reg SixxRst_reg;
+  reg JesdLinkReady_reg;
+  reg JesdEnableSysref_reg;
+  reg JesdLink_wreq;
+  reg JesdLink_wack;
+  reg [31:0] AdcSpiWrite_reg;
+  reg AdcSpiWrite_wreq;
+  reg AdcSpiWrite_wack;
+  reg [31:0] CummulativeTurns_reg;
+  reg CummulativeTurns_wreq;
+  reg CummulativeTurns_wack;
+  reg OverrideTurnEmulatorTiming_reg;
+  reg Debug_wreq;
+  reg Debug_wack;
+  reg RawData0_rack;
+  reg RawData0_re;
+  reg RawData1_rack;
+  reg RawData1_re;
+  reg RawData2_rack;
+  reg RawData2_re;
+  reg RawData3_rack;
+  reg RawData3_re;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [20:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+
+  // WB decode signals
+  always @(wb.sel)
+  ;
+  assign adr_int = wb.adr[20:2];
+  assign wb_en = wb.cyc & wb.stb;
+
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb.we)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb.we) & ~wb_rip;
+
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb.we)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb.we) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb.ack = ack_int;
+  assign wb.stall = ~ack_int & wb_en;
+  assign wb.rty = 1'b0;
+  assign wb.err = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      begin
+        rd_ack_int <= 1'b0;
+        wb.dati <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 19'b0000000000000000000;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb.dati <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_adr_d0 <= adr_int;
+        wr_dat_d0 <= wb.dato;
+      end
+  end
+
+  // Register Token
+
+  // Register Ctrl
+  assign Enable_o = Enable_reg;
+  assign std_rst_bst_desync = RstBstDesync_reg;
+  assign std_reset_alignment = FAReset_reg;
+  assign DisableADCStream_o = DisableADCStream_reg;
+  assign EnableTurnEmulator_o = EnableTurnEmulator_reg;
+  assign LHC_timing = LHCTiming_reg;
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      begin
+        Enable_reg <= 1'b0;
+        RstBstDesync_reg <= 1'b0;
+        FAReset_reg <= 1'b0;
+        DisableADCStream_reg <= 1'b0;
+        EnableTurnEmulator_reg <= 1'b0;
+        LHCTiming_reg <= 1'b0;
+        Ctrl_wack <= 1'b0;
+      end
+    else
+      begin
+        if (Ctrl_wreq == 1'b1)
+          begin
+            Enable_reg <= wr_dat_d0[0];
+            RstBstDesync_reg <= wr_dat_d0[1];
+            FAReset_reg <= wr_dat_d0[2];
+            DisableADCStream_reg <= wr_dat_d0[4];
+            EnableTurnEmulator_reg <= wr_dat_d0[6];
+            LHCTiming_reg <= wr_dat_d0[10];
+          end
+        else
+          begin
+            RstBstDesync_reg <= 1'b0;
+            FAReset_reg <= 1'b0;
+          end
+        Ctrl_wack <= Ctrl_wreq;
+      end
+  end
+
+  // Register Stat
+
+  // Register SysrefTicks
+
+  // Register GWRevision
+
+  // Register TurnPeriod
+  assign TurnPeriod_o = TurnPeriod_reg;
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      begin
+        TurnPeriod_reg <= 32'b00000000000000000000010000000000;
+        TurnPeriod_wack <= 1'b0;
+      end
+    else
+      begin
+        if (TurnPeriod_wreq == 1'b1)
+          TurnPeriod_reg <= wr_dat_d0;
+        TurnPeriod_wack <= TurnPeriod_wreq;
+      end
+  end
+  assign TurnPeriod_wr_o = TurnPeriod_wack;
+
+  // Register TurnLength
+  assign TurnLength_o = TurnLength_reg;
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      begin
+        TurnLength_reg <= 32'b00000000000000000000000000000011;
+        TurnLength_wack <= 1'b0;
+      end
+    else
+      begin
+        if (TurnLength_wreq == 1'b1)
+          TurnLength_reg <= wr_dat_d0;
+        TurnLength_wack <= TurnLength_wreq;
+      end
+  end
+  assign TurnLength_wr_o = TurnLength_wack;
+
+  // Register TurnsIntercepted
+
+  // Register FmcPower
+  assign FmcPowerEnable_o = FmcPowerEnable_reg;
+  assign DCDCSyncEnable_o = DCDCSyncEnable_reg;
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      begin
+        FmcPowerEnable_reg <= 1'b0;
+        DCDCSyncEnable_reg <= 1'b0;
+        FmcPower_wack <= 1'b0;
+      end
+    else
+      begin
+        if (FmcPower_wreq == 1'b1)
+          begin
+            FmcPowerEnable_reg <= wr_dat_d0[0];
+            DCDCSyncEnable_reg <= wr_dat_d0[1];
+          end
+        FmcPower_wack <= FmcPower_wreq;
+      end
+  end
+
+  // Register ADCPatternCheckCtrl
+  assign PatternRst_o = PatternRst_reg;
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      begin
+        PatternRst_reg <= 1'b0;
+        ADCPatternCheckCtrl_wack <= 1'b0;
+      end
+    else
+      begin
+        if (ADCPatternCheckCtrl_wreq == 1'b1)
+          PatternRst_reg <= wr_dat_d0[0];
+        ADCPatternCheckCtrl_wack <= ADCPatternCheckCtrl_wreq;
+      end
+  end
+
+  // Register ADCCtrl
+  assign ADCRst_o = ADCRst_reg;
+  assign ADCEnable_o = ADCEnable_reg;
+  assign ADCManualSync_o = ADCManualSync_reg;
+  assign ADCDisableAutoSync_o = ADCDisableAutoSync_reg;
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      begin
+        ADCRst_reg <= 1'b0;
+        ADCEnable_reg <= 1'b0;
+        ADCManualSync_reg <= 1'b0;
+        ADCDisableAutoSync_reg <= 1'b0;
+        ADCCtrl_wack <= 1'b0;
+      end
+    else
+      begin
+        if (ADCCtrl_wreq == 1'b1)
+          begin
+            ADCRst_reg <= wr_dat_d0[0];
+            ADCEnable_reg <= wr_dat_d0[1];
+            ADCManualSync_reg <= wr_dat_d0[6];
+            ADCDisableAutoSync_reg <= wr_dat_d0[7];
+          end
+        ADCCtrl_wack <= ADCCtrl_wreq;
+      end
+  end
+
+  // Register JesdLink
+  assign JesdXcvrRst_o = JesdXcvrRst_reg;
+  assign JesdLinkRst_o = JesdLinkRst_reg;
+  assign JesdPLLRst_o = JesdPLLRst_reg;
+  assign JesdAvsRst_o = JesdAvsRst_reg;
+  assign SixxRst_o = SixxRst_reg;
+  assign JesdLinkReady_o = JesdLinkReady_reg;
+  assign JesdEnableSysref_o = JesdEnableSysref_reg;
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      begin
+        JesdXcvrRst_reg <= 1'b0;
+        JesdLinkRst_reg <= 1'b0;
+        JesdPLLRst_reg <= 1'b0;
+        JesdAvsRst_reg <= 1'b0;
+        SixxRst_reg <= 1'b0;
+        JesdLinkReady_reg <= 1'b0;
+        JesdEnableSysref_reg <= 1'b0;
+        JesdLink_wack <= 1'b0;
+      end
+    else
+      begin
+        if (JesdLink_wreq == 1'b1)
+          begin
+            JesdXcvrRst_reg <= wr_dat_d0[0];
+            JesdLinkRst_reg <= wr_dat_d0[2];
+            JesdPLLRst_reg <= wr_dat_d0[4];
+            JesdAvsRst_reg <= wr_dat_d0[5];
+            SixxRst_reg <= wr_dat_d0[6];
+            JesdLinkReady_reg <= wr_dat_d0[8];
+            JesdEnableSysref_reg <= wr_dat_d0[9];
+          end
+        JesdLink_wack <= JesdLink_wreq;
+      end
+  end
+
+  // Register AdcSpiWrite
+  assign AdcSpiWrite_o = AdcSpiWrite_reg;
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      begin
+        AdcSpiWrite_reg <= 32'b00000000000000000000000000000000;
+        AdcSpiWrite_wack <= 1'b0;
+      end
+    else
+      begin
+        if (AdcSpiWrite_wreq == 1'b1)
+          AdcSpiWrite_reg <= wr_dat_d0;
+        AdcSpiWrite_wack <= AdcSpiWrite_wreq;
+      end
+  end
+  assign AdcSpiWrite_wr_o = AdcSpiWrite_wack;
+
+  // Register AdcSpiRead
+
+  // Register SpiStatus
+
+  // Register CummulativeTurns
+  assign cummulative_turns_b32 = CummulativeTurns_reg;
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      begin
+        CummulativeTurns_reg <= 32'b00000000000000000000000000000000;
+        CummulativeTurns_wack <= 1'b0;
+      end
+    else
+      begin
+        if (CummulativeTurns_wreq == 1'b1)
+          CummulativeTurns_reg <= wr_dat_d0;
+        CummulativeTurns_wack <= CummulativeTurns_wreq;
+      end
+  end
+
+  // Register Debug
+  assign OverrideTurnEmulatorTiming = OverrideTurnEmulatorTiming_reg;
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      begin
+        OverrideTurnEmulatorTiming_reg <= 1'b0;
+        Debug_wack <= 1'b0;
+      end
+    else
+      begin
+        if (Debug_wreq == 1'b1)
+          OverrideTurnEmulatorTiming_reg <= wr_dat_d0[0];
+        Debug_wack <= Debug_wreq;
+      end
+  end
+
+  // Interface RawData0
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      RawData0_rack <= 1'b0;
+    else
+      RawData0_rack <= RawData0_re & ~RawData0_rack;
+  end
+  assign RawData0_addr_o = adr_int[17:2];
+
+  // Interface RawData1
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      RawData1_rack <= 1'b0;
+    else
+      RawData1_rack <= RawData1_re & ~RawData1_rack;
+  end
+  assign RawData1_addr_o = adr_int[17:2];
+
+  // Interface RawData2
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      RawData2_rack <= 1'b0;
+    else
+      RawData2_rack <= RawData2_re & ~RawData2_rack;
+  end
+  assign RawData2_addr_o = adr_int[17:2];
+
+  // Interface RawData3
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      RawData3_rack <= 1'b0;
+    else
+      RawData3_rack <= RawData3_re & ~RawData3_rack;
+  end
+  assign RawData3_addr_o = adr_int[17:2];
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, Ctrl_wack, TurnPeriod_wack, TurnLength_wack, FmcPower_wack, ADCPatternCheckCtrl_wack, ADCCtrl_wack, JesdLink_wack, AdcSpiWrite_wack, CummulativeTurns_wack, Debug_wack)
+  begin
+    Ctrl_wreq = 1'b0;
+    TurnPeriod_wreq = 1'b0;
+    TurnLength_wreq = 1'b0;
+    FmcPower_wreq = 1'b0;
+    ADCPatternCheckCtrl_wreq = 1'b0;
+    ADCCtrl_wreq = 1'b0;
+    JesdLink_wreq = 1'b0;
+    AdcSpiWrite_wreq = 1'b0;
+    CummulativeTurns_wreq = 1'b0;
+    Debug_wreq = 1'b0;
+    case (wr_adr_d0[20:18])
+    3'b000:
+      case (wr_adr_d0[17:2])
+      16'b0000000000000000:
+        // Reg Token
+        wr_ack_int = wr_req_d0;
+      16'b0000000000000001:
+        begin
+          // Reg Ctrl
+          Ctrl_wreq = wr_req_d0;
+          wr_ack_int = Ctrl_wack;
+        end
+      16'b0000000000000010:
+        // Reg Stat
+        wr_ack_int = wr_req_d0;
+      16'b0000000000000011:
+        // Reg SysrefTicks
+        wr_ack_int = wr_req_d0;
+      16'b0000000000000100:
+        // Reg GWRevision
+        wr_ack_int = wr_req_d0;
+      16'b0000000000000101:
+        begin
+          // Reg TurnPeriod
+          TurnPeriod_wreq = wr_req_d0;
+          wr_ack_int = TurnPeriod_wack;
+        end
+      16'b0000000000000110:
+        begin
+          // Reg TurnLength
+          TurnLength_wreq = wr_req_d0;
+          wr_ack_int = TurnLength_wack;
+        end
+      16'b0000000000000111:
+        // Reg TurnsIntercepted
+        wr_ack_int = wr_req_d0;
+      16'b0000000000001000:
+        begin
+          // Reg FmcPower
+          FmcPower_wreq = wr_req_d0;
+          wr_ack_int = FmcPower_wack;
+        end
+      16'b0000000000001001:
+        begin
+          // Reg ADCPatternCheckCtrl
+          ADCPatternCheckCtrl_wreq = wr_req_d0;
+          wr_ack_int = ADCPatternCheckCtrl_wack;
+        end
+      16'b0000000000001010:
+        begin
+          // Reg ADCCtrl
+          ADCCtrl_wreq = wr_req_d0;
+          wr_ack_int = ADCCtrl_wack;
+        end
+      16'b0000000000001011:
+        begin
+          // Reg JesdLink
+          JesdLink_wreq = wr_req_d0;
+          wr_ack_int = JesdLink_wack;
+        end
+      16'b0000000000001100:
+        begin
+          // Reg AdcSpiWrite
+          AdcSpiWrite_wreq = wr_req_d0;
+          wr_ack_int = AdcSpiWrite_wack;
+        end
+      16'b0000000000001101:
+        // Reg AdcSpiRead
+        wr_ack_int = wr_req_d0;
+      16'b0000000000001110:
+        // Reg SpiStatus
+        wr_ack_int = wr_req_d0;
+      16'b0000000000001111:
+        begin
+          // Reg CummulativeTurns
+          CummulativeTurns_wreq = wr_req_d0;
+          wr_ack_int = CummulativeTurns_wack;
+        end
+      16'b0000000000010000:
+        begin
+          // Reg Debug
+          Debug_wreq = wr_req_d0;
+          wr_ack_int = Debug_wack;
+        end
+      default:
+        wr_ack_int = wr_req_d0;
+      endcase
+    3'b100:
+      // Memory RawData0
+      wr_ack_int = wr_req_d0;
+    3'b101:
+      // Memory RawData1
+      wr_ack_int = wr_req_d0;
+    3'b110:
+      // Memory RawData2
+      wr_ack_int = wr_req_d0;
+    3'b111:
+      // Memory RawData3
+      wr_ack_int = wr_req_d0;
+    default:
+      wr_ack_int = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always @(adr_int, rd_req_int, Token_i, Enable_reg, DisableADCStream_reg, EnableTurnEmulator_reg, LHCTiming_reg, VoltageFail_i, JesdRXNotReady_i, TurnEmulatorPLLError_i, TurnEmulatorError_i, NoTurnDetected_i, VfmcDisabled_i, std_bst_desynced, GBTPLLLol_i, std_fa_in_reset, PatternFail_i, DCDCSyncEnabled_i, SysrefFail_i, FmcLol_i, FmcLos_i, SysrefTicks_i, GWRevision_i, TurnPeriod_reg, TurnLength_reg, TurnsIntercepted_b32, FmcPowerEnable_reg, DCDCSyncEnable_reg, PatternRst_reg, ADCRst_reg, ADCEnable_reg, ADCManualSync_reg, ADCDisableAutoSync_reg, JesdXcvrRst_reg, JesdLinkRst_reg, JesdPLLRst_reg, JesdAvsRst_reg, SixxRst_reg, JesdLinkReady_reg, JesdEnableSysref_reg, AdcSpiRead_i, AdcSpiBusy_i, CummulativeTurns_reg, OverrideTurnEmulatorTiming_reg, RawData0_data_i, RawData0_rack, RawData1_data_i, RawData1_rack, RawData2_data_i, RawData2_rack, RawData3_data_i, RawData3_rack)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    RawData0_re = 1'b0;
+    RawData1_re = 1'b0;
+    RawData2_re = 1'b0;
+    RawData3_re = 1'b0;
+    case (adr_int[20:18])
+    3'b000:
+      case (adr_int[17:2])
+      16'b0000000000000000:
+        begin
+          // Reg Token
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0 = Token_i;
+        end
+      16'b0000000000000001:
+        begin
+          // Reg Ctrl
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0[0] = Enable_reg;
+          rd_dat_d0[1] = 1'b0;
+          rd_dat_d0[2] = 1'b0;
+          rd_dat_d0[3] = 1'b0;
+          rd_dat_d0[4] = DisableADCStream_reg;
+          rd_dat_d0[5] = 1'b0;
+          rd_dat_d0[6] = EnableTurnEmulator_reg;
+          rd_dat_d0[9:7] = 3'b0;
+          rd_dat_d0[10] = LHCTiming_reg;
+          rd_dat_d0[31:11] = 21'b0;
+        end
+      16'b0000000000000010:
+        begin
+          // Reg Stat
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0[7:0] = VoltageFail_i;
+          rd_dat_d0[15:8] = JesdRXNotReady_i;
+          rd_dat_d0[16] = TurnEmulatorPLLError_i;
+          rd_dat_d0[17] = 1'b0;
+          rd_dat_d0[18] = TurnEmulatorError_i;
+          rd_dat_d0[19] = NoTurnDetected_i;
+          rd_dat_d0[21:20] = 2'b0;
+          rd_dat_d0[22] = VfmcDisabled_i;
+          rd_dat_d0[23] = std_bst_desynced;
+          rd_dat_d0[24] = 1'b0;
+          rd_dat_d0[25] = GBTPLLLol_i;
+          rd_dat_d0[26] = std_fa_in_reset;
+          rd_dat_d0[27] = PatternFail_i;
+          rd_dat_d0[28] = DCDCSyncEnabled_i;
+          rd_dat_d0[29] = SysrefFail_i;
+          rd_dat_d0[30] = FmcLol_i;
+          rd_dat_d0[31] = FmcLos_i;
+        end
+      16'b0000000000000011:
+        begin
+          // Reg SysrefTicks
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0 = SysrefTicks_i;
+        end
+      16'b0000000000000100:
+        begin
+          // Reg GWRevision
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0 = GWRevision_i;
+        end
+      16'b0000000000000101:
+        begin
+          // Reg TurnPeriod
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0 = TurnPeriod_reg;
+        end
+      16'b0000000000000110:
+        begin
+          // Reg TurnLength
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0 = TurnLength_reg;
+        end
+      16'b0000000000000111:
+        begin
+          // Reg TurnsIntercepted
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0 = TurnsIntercepted_b32;
+        end
+      16'b0000000000001000:
+        begin
+          // Reg FmcPower
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0[0] = FmcPowerEnable_reg;
+          rd_dat_d0[1] = DCDCSyncEnable_reg;
+          rd_dat_d0[31:2] = 30'b0;
+        end
+      16'b0000000000001001:
+        begin
+          // Reg ADCPatternCheckCtrl
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0[0] = PatternRst_reg;
+          rd_dat_d0[31:1] = 31'b0;
+        end
+      16'b0000000000001010:
+        begin
+          // Reg ADCCtrl
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0[0] = ADCRst_reg;
+          rd_dat_d0[1] = ADCEnable_reg;
+          rd_dat_d0[5:2] = 4'b0;
+          rd_dat_d0[6] = ADCManualSync_reg;
+          rd_dat_d0[7] = ADCDisableAutoSync_reg;
+          rd_dat_d0[31:8] = 24'b0;
+        end
+      16'b0000000000001011:
+        begin
+          // Reg JesdLink
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0[0] = JesdXcvrRst_reg;
+          rd_dat_d0[1] = 1'b0;
+          rd_dat_d0[2] = JesdLinkRst_reg;
+          rd_dat_d0[3] = 1'b0;
+          rd_dat_d0[4] = JesdPLLRst_reg;
+          rd_dat_d0[5] = JesdAvsRst_reg;
+          rd_dat_d0[6] = SixxRst_reg;
+          rd_dat_d0[7] = 1'b0;
+          rd_dat_d0[8] = JesdLinkReady_reg;
+          rd_dat_d0[9] = JesdEnableSysref_reg;
+          rd_dat_d0[31:10] = 22'b0;
+        end
+      16'b0000000000001100:
+        // Reg AdcSpiWrite
+        rd_ack_d0 = rd_req_int;
+      16'b0000000000001101:
+        begin
+          // Reg AdcSpiRead
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0 = AdcSpiRead_i;
+        end
+      16'b0000000000001110:
+        begin
+          // Reg SpiStatus
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0[0] = AdcSpiBusy_i;
+          rd_dat_d0[31:1] = 31'b0;
+        end
+      16'b0000000000001111:
+        begin
+          // Reg CummulativeTurns
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0 = CummulativeTurns_reg;
+        end
+      16'b0000000000010000:
+        begin
+          // Reg Debug
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0[0] = OverrideTurnEmulatorTiming_reg;
+          rd_dat_d0[31:1] = 31'b0;
+        end
+      default:
+        rd_ack_d0 = rd_req_int;
+      endcase
+    3'b100:
+      begin
+        // Memory RawData0
+        rd_dat_d0 = RawData0_data_i;
+        rd_ack_d0 = RawData0_rack;
+        RawData0_re = rd_req_int;
+      end
+    3'b101:
+      begin
+        // Memory RawData1
+        rd_dat_d0 = RawData1_data_i;
+        rd_ack_d0 = RawData1_rack;
+        RawData1_re = rd_req_int;
+      end
+    3'b110:
+      begin
+        // Memory RawData2
+        rd_dat_d0 = RawData2_data_i;
+        rd_ack_d0 = RawData2_rack;
+        RawData2_re = rd_req_int;
+      end
+    3'b111:
+      begin
+        // Memory RawData3
+        rd_dat_d0 = RawData3_data_i;
+        rd_ack_d0 = RawData3_rack;
+        RawData3_re = rd_req_int;
+      end
+    default:
+      rd_ack_d0 = rd_req_int;
+    endcase
+  end
+endmodule

--- a/testfiles/crossbar/crossbar.sv
+++ b/testfiles/crossbar/crossbar.sv
@@ -53,10 +53,10 @@ module crossbar_wb
   // WB decode signals
   always_comb
   begin
-    wr_sel[7:0] <= {8{wb.sel[0]}};
-    wr_sel[15:8] <= {8{wb.sel[1]}};
-    wr_sel[23:16] <= {8{wb.sel[2]}};
-    wr_sel[31:24] <= {8{wb.sel[3]}};
+    wr_sel[7:0] = {8{wb.sel[0]}};
+    wr_sel[15:8] = {8{wb.sel[1]}};
+    wr_sel[23:16] = {8{wb.sel[2]}};
+    wr_sel[31:24] = {8{wb.sel[3]}};
   end
   assign adr_int = wb.adr[17:2];
   assign wb_en = wb.cyc & wb.stb;
@@ -130,15 +130,15 @@ module crossbar_wb
   assign jesdavalon.adr = {22'b0, adr_int[9:2], 2'b0};
   always_comb
   begin
-    jesdavalon.sel <= 4'b0;
+    jesdavalon.sel = 4'b0;
     if (~(wr_sel_d0[7:0] == 8'b0))
-      jesdavalon.sel[0] <= 1'b1;
+      jesdavalon.sel[0] = 1'b1;
     if (~(wr_sel_d0[15:8] == 8'b0))
-      jesdavalon.sel[1] <= 1'b1;
+      jesdavalon.sel[1] = 1'b1;
     if (~(wr_sel_d0[23:16] == 8'b0))
-      jesdavalon.sel[2] <= 1'b1;
+      jesdavalon.sel[2] = 1'b1;
     if (~(wr_sel_d0[31:24] == 8'b0))
-      jesdavalon.sel[3] <= 1'b1;
+      jesdavalon.sel[3] = 1'b1;
   end
   assign jesdavalon.we = jesdavalon_wt;
   assign jesdavalon.dato = wr_dat_d0;
@@ -165,15 +165,15 @@ module crossbar_wb
   assign i2ctowb.adr = {18'b0, adr_int[13:2], 2'b0};
   always_comb
   begin
-    i2ctowb.sel <= 4'b0;
+    i2ctowb.sel = 4'b0;
     if (~(wr_sel_d0[7:0] == 8'b0))
-      i2ctowb.sel[0] <= 1'b1;
+      i2ctowb.sel[0] = 1'b1;
     if (~(wr_sel_d0[15:8] == 8'b0))
-      i2ctowb.sel[1] <= 1'b1;
+      i2ctowb.sel[1] = 1'b1;
     if (~(wr_sel_d0[23:16] == 8'b0))
-      i2ctowb.sel[2] <= 1'b1;
+      i2ctowb.sel[2] = 1'b1;
     if (~(wr_sel_d0[31:24] == 8'b0))
-      i2ctowb.sel[3] <= 1'b1;
+      i2ctowb.sel[3] = 1'b1;
   end
   assign i2ctowb.we = i2ctowb_wt;
   assign i2ctowb.dato = wr_dat_d0;
@@ -200,15 +200,15 @@ module crossbar_wb
   assign bran.adr = {15'b0, adr_int[16:2], 2'b0};
   always_comb
   begin
-    bran.sel <= 4'b0;
+    bran.sel = 4'b0;
     if (~(wr_sel_d0[7:0] == 8'b0))
-      bran.sel[0] <= 1'b1;
+      bran.sel[0] = 1'b1;
     if (~(wr_sel_d0[15:8] == 8'b0))
-      bran.sel[1] <= 1'b1;
+      bran.sel[1] = 1'b1;
     if (~(wr_sel_d0[23:16] == 8'b0))
-      bran.sel[2] <= 1'b1;
+      bran.sel[2] = 1'b1;
     if (~(wr_sel_d0[31:24] == 8'b0))
-      bran.sel[3] <= 1'b1;
+      bran.sel[3] = 1'b1;
   end
   assign bran.we = bran_wt;
   assign bran.dato = wr_dat_d0;
@@ -216,35 +216,35 @@ module crossbar_wb
   // Process for write requests.
   always_comb
   begin
-    jesdavalon_we <= 1'b0;
-    i2ctowb_we <= 1'b0;
-    bran_we <= 1'b0;
+    jesdavalon_we = 1'b0;
+    i2ctowb_we = 1'b0;
+    bran_we = 1'b0;
     case (wr_adr_d0[17:17])
     1'b0:
       case (wr_adr_d0[16:14])
       3'b000:
         begin
           // Submap jesdavalon
-          jesdavalon_we <= wr_req_d0;
-          wr_ack_int <= jesdavalon_wack;
+          jesdavalon_we = wr_req_d0;
+          wr_ack_int = jesdavalon_wack;
         end
       3'b001:
         begin
           // Submap i2ctowb
-          i2ctowb_we <= wr_req_d0;
-          wr_ack_int <= i2ctowb_wack;
+          i2ctowb_we = wr_req_d0;
+          wr_ack_int = i2ctowb_wack;
         end
       default:
-        wr_ack_int <= wr_req_d0;
+        wr_ack_int = wr_req_d0;
       endcase
     1'b1:
       begin
         // Submap bran
-        bran_we <= wr_req_d0;
-        wr_ack_int <= bran_wack;
+        bran_we = wr_req_d0;
+        wr_ack_int = bran_wack;
       end
     default:
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     endcase
   end
 
@@ -252,39 +252,39 @@ module crossbar_wb
   always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
-    jesdavalon_re <= 1'b0;
-    i2ctowb_re <= 1'b0;
-    bran_re <= 1'b0;
+    rd_dat_d0 = {32{1'bx}};
+    jesdavalon_re = 1'b0;
+    i2ctowb_re = 1'b0;
+    bran_re = 1'b0;
     case (adr_int[17:17])
     1'b0:
       case (adr_int[16:14])
       3'b000:
         begin
           // Submap jesdavalon
-          jesdavalon_re <= rd_req_int;
-          rd_dat_d0 <= jesdavalon.dati;
-          rd_ack_d0 <= jesdavalon_rack;
+          jesdavalon_re = rd_req_int;
+          rd_dat_d0 = jesdavalon.dati;
+          rd_ack_d0 = jesdavalon_rack;
         end
       3'b001:
         begin
           // Submap i2ctowb
-          i2ctowb_re <= rd_req_int;
-          rd_dat_d0 <= i2ctowb.dati;
-          rd_ack_d0 <= i2ctowb_rack;
+          i2ctowb_re = rd_req_int;
+          rd_dat_d0 = i2ctowb.dati;
+          rd_ack_d0 = i2ctowb_rack;
         end
       default:
-        rd_ack_d0 <= rd_req_int;
+        rd_ack_d0 = rd_req_int;
       endcase
     1'b1:
       begin
         // Submap bran
-        bran_re <= rd_req_int;
-        rd_dat_d0 <= bran.dati;
-        rd_ack_d0 <= bran_rack;
+        bran_re = rd_req_int;
+        rd_dat_d0 = bran.dati;
+        rd_ack_d0 = bran_rack;
       end
     default:
-      rd_ack_d0 <= rd_req_int;
+      rd_ack_d0 = rd_req_int;
     endcase
   end
 endmodule

--- a/testfiles/crossbar/crossbar.v
+++ b/testfiles/crossbar/crossbar.v
@@ -53,10 +53,10 @@ module crossbar_wb
   // WB decode signals
   always @(wb.sel)
   begin
-    wr_sel[7:0] <= {8{wb.sel[0]}};
-    wr_sel[15:8] <= {8{wb.sel[1]}};
-    wr_sel[23:16] <= {8{wb.sel[2]}};
-    wr_sel[31:24] <= {8{wb.sel[3]}};
+    wr_sel[7:0] = {8{wb.sel[0]}};
+    wr_sel[15:8] = {8{wb.sel[1]}};
+    wr_sel[23:16] = {8{wb.sel[2]}};
+    wr_sel[31:24] = {8{wb.sel[3]}};
   end
   assign adr_int = wb.adr[17:2];
   assign wb_en = wb.cyc & wb.stb;
@@ -130,15 +130,15 @@ module crossbar_wb
   assign jesdavalon.adr = {22'b0, adr_int[9:2], 2'b0};
   always @(wr_sel_d0)
   begin
-    jesdavalon.sel <= 4'b0;
+    jesdavalon.sel = 4'b0;
     if (~(wr_sel_d0[7:0] == 8'b0))
-      jesdavalon.sel[0] <= 1'b1;
+      jesdavalon.sel[0] = 1'b1;
     if (~(wr_sel_d0[15:8] == 8'b0))
-      jesdavalon.sel[1] <= 1'b1;
+      jesdavalon.sel[1] = 1'b1;
     if (~(wr_sel_d0[23:16] == 8'b0))
-      jesdavalon.sel[2] <= 1'b1;
+      jesdavalon.sel[2] = 1'b1;
     if (~(wr_sel_d0[31:24] == 8'b0))
-      jesdavalon.sel[3] <= 1'b1;
+      jesdavalon.sel[3] = 1'b1;
   end
   assign jesdavalon.we = jesdavalon_wt;
   assign jesdavalon.dato = wr_dat_d0;
@@ -165,15 +165,15 @@ module crossbar_wb
   assign i2ctowb.adr = {18'b0, adr_int[13:2], 2'b0};
   always @(wr_sel_d0)
   begin
-    i2ctowb.sel <= 4'b0;
+    i2ctowb.sel = 4'b0;
     if (~(wr_sel_d0[7:0] == 8'b0))
-      i2ctowb.sel[0] <= 1'b1;
+      i2ctowb.sel[0] = 1'b1;
     if (~(wr_sel_d0[15:8] == 8'b0))
-      i2ctowb.sel[1] <= 1'b1;
+      i2ctowb.sel[1] = 1'b1;
     if (~(wr_sel_d0[23:16] == 8'b0))
-      i2ctowb.sel[2] <= 1'b1;
+      i2ctowb.sel[2] = 1'b1;
     if (~(wr_sel_d0[31:24] == 8'b0))
-      i2ctowb.sel[3] <= 1'b1;
+      i2ctowb.sel[3] = 1'b1;
   end
   assign i2ctowb.we = i2ctowb_wt;
   assign i2ctowb.dato = wr_dat_d0;
@@ -200,15 +200,15 @@ module crossbar_wb
   assign bran.adr = {15'b0, adr_int[16:2], 2'b0};
   always @(wr_sel_d0)
   begin
-    bran.sel <= 4'b0;
+    bran.sel = 4'b0;
     if (~(wr_sel_d0[7:0] == 8'b0))
-      bran.sel[0] <= 1'b1;
+      bran.sel[0] = 1'b1;
     if (~(wr_sel_d0[15:8] == 8'b0))
-      bran.sel[1] <= 1'b1;
+      bran.sel[1] = 1'b1;
     if (~(wr_sel_d0[23:16] == 8'b0))
-      bran.sel[2] <= 1'b1;
+      bran.sel[2] = 1'b1;
     if (~(wr_sel_d0[31:24] == 8'b0))
-      bran.sel[3] <= 1'b1;
+      bran.sel[3] = 1'b1;
   end
   assign bran.we = bran_wt;
   assign bran.dato = wr_dat_d0;
@@ -216,35 +216,35 @@ module crossbar_wb
   // Process for write requests.
   always @(wr_adr_d0, wr_req_d0, jesdavalon_wack, i2ctowb_wack, bran_wack)
   begin
-    jesdavalon_we <= 1'b0;
-    i2ctowb_we <= 1'b0;
-    bran_we <= 1'b0;
+    jesdavalon_we = 1'b0;
+    i2ctowb_we = 1'b0;
+    bran_we = 1'b0;
     case (wr_adr_d0[17:17])
     1'b0:
       case (wr_adr_d0[16:14])
       3'b000:
         begin
           // Submap jesdavalon
-          jesdavalon_we <= wr_req_d0;
-          wr_ack_int <= jesdavalon_wack;
+          jesdavalon_we = wr_req_d0;
+          wr_ack_int = jesdavalon_wack;
         end
       3'b001:
         begin
           // Submap i2ctowb
-          i2ctowb_we <= wr_req_d0;
-          wr_ack_int <= i2ctowb_wack;
+          i2ctowb_we = wr_req_d0;
+          wr_ack_int = i2ctowb_wack;
         end
       default:
-        wr_ack_int <= wr_req_d0;
+        wr_ack_int = wr_req_d0;
       endcase
     1'b1:
       begin
         // Submap bran
-        bran_we <= wr_req_d0;
-        wr_ack_int <= bran_wack;
+        bran_we = wr_req_d0;
+        wr_ack_int = bran_wack;
       end
     default:
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     endcase
   end
 
@@ -252,39 +252,39 @@ module crossbar_wb
   always @(adr_int, rd_req_int, jesdavalon.dati, jesdavalon_rack, i2ctowb.dati, i2ctowb_rack, bran.dati, bran_rack)
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
-    jesdavalon_re <= 1'b0;
-    i2ctowb_re <= 1'b0;
-    bran_re <= 1'b0;
+    rd_dat_d0 = {32{1'bx}};
+    jesdavalon_re = 1'b0;
+    i2ctowb_re = 1'b0;
+    bran_re = 1'b0;
     case (adr_int[17:17])
     1'b0:
       case (adr_int[16:14])
       3'b000:
         begin
           // Submap jesdavalon
-          jesdavalon_re <= rd_req_int;
-          rd_dat_d0 <= jesdavalon.dati;
-          rd_ack_d0 <= jesdavalon_rack;
+          jesdavalon_re = rd_req_int;
+          rd_dat_d0 = jesdavalon.dati;
+          rd_ack_d0 = jesdavalon_rack;
         end
       3'b001:
         begin
           // Submap i2ctowb
-          i2ctowb_re <= rd_req_int;
-          rd_dat_d0 <= i2ctowb.dati;
-          rd_ack_d0 <= i2ctowb_rack;
+          i2ctowb_re = rd_req_int;
+          rd_dat_d0 = i2ctowb.dati;
+          rd_ack_d0 = i2ctowb_rack;
         end
       default:
-        rd_ack_d0 <= rd_req_int;
+        rd_ack_d0 = rd_req_int;
       endcase
     1'b1:
       begin
         // Submap bran
-        bran_re <= rd_req_int;
-        rd_dat_d0 <= bran.dati;
-        rd_ack_d0 <= bran_rack;
+        bran_re = rd_req_int;
+        rd_dat_d0 = bran.dati;
+        rd_ack_d0 = bran_rack;
       end
     default:
-      rd_ack_d0 <= rd_req_int;
+      rd_ack_d0 = rd_req_int;
     endcase
   end
 endmodule

--- a/testfiles/features/axi4_byte.sv
+++ b/testfiles/features/axi4_byte.sv
@@ -58,7 +58,7 @@ module sreg
   assign awready = ~axi_awset;
   assign wready = ~axi_wset;
   assign bvalid = axi_wdone;
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -97,7 +97,7 @@ module sreg
   // AR and R channels
   assign arready = ~axi_arset;
   assign rvalid = axi_rdone;
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -130,7 +130,7 @@ module sreg
   assign rresp = 2'b00;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -152,7 +152,7 @@ module sreg
 
   // Register areg
   assign areg_o = areg_reg;
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -169,7 +169,7 @@ module sreg
 
   // Register breg
   assign breg_o = breg_reg;
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -185,48 +185,48 @@ module sreg
   end
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0, areg_wack, breg_wack)
+  always_comb
   begin
-    areg_wreq <= 1'b0;
-    breg_wreq <= 1'b0;
+    areg_wreq = 1'b0;
+    breg_wreq = 1'b0;
     case (wr_adr_d0[2:2])
     1'b0:
       begin
         // Reg areg
-        areg_wreq <= wr_req_d0;
-        wr_ack <= areg_wack;
+        areg_wreq = wr_req_d0;
+        wr_ack = areg_wack;
       end
     1'b1:
       begin
         // Reg breg
-        breg_wreq <= wr_req_d0;
-        wr_ack <= breg_wack;
+        breg_wreq = wr_req_d0;
+        wr_ack = breg_wack;
       end
     default:
-      wr_ack <= wr_req_d0;
+      wr_ack = wr_req_d0;
     endcase
   end
 
   // Process for read requests.
-  always @(rd_addr, rd_req, areg_reg, breg_reg)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     case (rd_addr[2:2])
     1'b0:
       begin
         // Reg areg
-        rd_ack_d0 <= rd_req;
-        rd_dat_d0 <= areg_reg;
+        rd_ack_d0 = rd_req;
+        rd_dat_d0 = areg_reg;
       end
     1'b1:
       begin
         // Reg breg
-        rd_ack_d0 <= rd_req;
-        rd_dat_d0 <= breg_reg;
+        rd_ack_d0 = rd_req;
+        rd_dat_d0 = breg_reg;
       end
     default:
-      rd_ack_d0 <= rd_req;
+      rd_ack_d0 = rd_req;
     endcase
   end
 endmodule

--- a/testfiles/features/axi4_byte.v
+++ b/testfiles/features/axi4_byte.v
@@ -1,0 +1,232 @@
+
+module sreg
+  (
+    input   wire aclk,
+    input   wire areset_n,
+    input   wire awvalid,
+    output  wire awready,
+    input   wire [2:0] awaddr,
+    input   wire [2:0] awprot,
+    input   wire wvalid,
+    output  wire wready,
+    input   wire [31:0] wdata,
+    input   wire [3:0] wstrb,
+    output  wire bvalid,
+    input   wire bready,
+    output  wire [1:0] bresp,
+    input   wire arvalid,
+    output  wire arready,
+    input   wire [2:0] araddr,
+    input   wire [2:0] arprot,
+    output  wire rvalid,
+    input   wire rready,
+    output  reg [31:0] rdata,
+    output  wire [1:0] rresp,
+
+    // REG areg
+    output  wire [31:0] areg_o,
+
+    // REG breg
+    output  wire [31:0] breg_o
+  );
+  reg wr_req;
+  reg wr_ack;
+  reg [2:2] wr_addr;
+  reg [31:0] wr_data;
+  reg axi_awset;
+  reg axi_wset;
+  reg axi_wdone;
+  reg rd_req;
+  reg rd_ack;
+  reg [2:2] rd_addr;
+  reg [31:0] rd_data;
+  reg axi_arset;
+  reg axi_rdone;
+  reg [31:0] areg_reg;
+  reg areg_wreq;
+  reg areg_wack;
+  reg [31:0] breg_reg;
+  reg breg_wreq;
+  reg breg_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [2:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+
+  // AW, W and B channels
+  assign awready = ~axi_awset;
+  assign wready = ~axi_wset;
+  assign bvalid = axi_wdone;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        wr_req <= 1'b0;
+        axi_awset <= 1'b0;
+        axi_wset <= 1'b0;
+        axi_wdone <= 1'b0;
+      end
+    else
+      begin
+        wr_req <= 1'b0;
+        if (awvalid == 1'b1 & axi_awset == 1'b0)
+          begin
+            wr_addr <= awaddr[2:2];
+            axi_awset <= 1'b1;
+            wr_req <= axi_wset;
+          end
+        if (wvalid == 1'b1 & axi_wset == 1'b0)
+          begin
+            wr_data <= wdata;
+            axi_wset <= 1'b1;
+            wr_req <= axi_awset | awvalid;
+          end
+        if ((axi_wdone & bready) == 1'b1)
+          begin
+            axi_wset <= 1'b0;
+            axi_awset <= 1'b0;
+            axi_wdone <= 1'b0;
+          end
+        if (wr_ack == 1'b1)
+          axi_wdone <= 1'b1;
+      end
+  end
+  assign bresp = 2'b00;
+
+  // AR and R channels
+  assign arready = ~axi_arset;
+  assign rvalid = axi_rdone;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        rd_req <= 1'b0;
+        axi_arset <= 1'b0;
+        axi_rdone <= 1'b0;
+        rdata <= 32'b0;
+      end
+    else
+      begin
+        rd_req <= 1'b0;
+        if (arvalid == 1'b1 & axi_arset == 1'b0)
+          begin
+            rd_addr <= araddr[2:2];
+            axi_arset <= 1'b1;
+            rd_req <= 1'b1;
+          end
+        if ((axi_rdone & rready) == 1'b1)
+          begin
+            axi_arset <= 1'b0;
+            axi_rdone <= 1'b0;
+          end
+        if (rd_ack == 1'b1)
+          begin
+            axi_rdone <= 1'b1;
+            rdata <= rd_data;
+          end
+      end
+  end
+  assign rresp = 2'b00;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        rd_ack <= 1'b0;
+        rd_data <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 1'b0;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack <= rd_ack_d0;
+        rd_data <= rd_dat_d0;
+        wr_req_d0 <= wr_req;
+        wr_adr_d0 <= wr_addr;
+        wr_dat_d0 <= wr_data;
+      end
+  end
+
+  // Register areg
+  assign areg_o = areg_reg;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        areg_reg <= 32'b00000000000000000000000000000000;
+        areg_wack <= 1'b0;
+      end
+    else
+      begin
+        if (areg_wreq == 1'b1)
+          areg_reg <= wr_dat_d0;
+        areg_wack <= areg_wreq;
+      end
+  end
+
+  // Register breg
+  assign breg_o = breg_reg;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        breg_reg <= 32'b00000000000000000000000000000000;
+        breg_wack <= 1'b0;
+      end
+    else
+      begin
+        if (breg_wreq == 1'b1)
+          breg_reg <= wr_dat_d0;
+        breg_wack <= breg_wreq;
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, areg_wack, breg_wack)
+  begin
+    areg_wreq = 1'b0;
+    breg_wreq = 1'b0;
+    case (wr_adr_d0[2:2])
+    1'b0:
+      begin
+        // Reg areg
+        areg_wreq = wr_req_d0;
+        wr_ack = areg_wack;
+      end
+    1'b1:
+      begin
+        // Reg breg
+        breg_wreq = wr_req_d0;
+        wr_ack = breg_wack;
+      end
+    default:
+      wr_ack = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always @(rd_addr, rd_req, areg_reg, breg_reg)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    case (rd_addr[2:2])
+    1'b0:
+      begin
+        // Reg areg
+        rd_ack_d0 = rd_req;
+        rd_dat_d0 = areg_reg;
+      end
+    1'b1:
+      begin
+        // Reg breg
+        rd_ack_d0 = rd_req;
+        rd_dat_d0 = breg_reg;
+      end
+    default:
+      rd_ack_d0 = rd_req;
+    endcase
+  end
+endmodule

--- a/testfiles/features/axi4_byte_async_rst.sv
+++ b/testfiles/features/axi4_byte_async_rst.sv
@@ -187,23 +187,23 @@ module sreg
   // Process for write requests.
   always @(wr_adr_d0, wr_req_d0, areg_wack, breg_wack)
   begin
-    areg_wreq <= 1'b0;
-    breg_wreq <= 1'b0;
+    areg_wreq = 1'b0;
+    breg_wreq = 1'b0;
     case (wr_adr_d0[2:2])
     1'b0:
       begin
         // Reg areg
-        areg_wreq <= wr_req_d0;
-        wr_ack <= areg_wack;
+        areg_wreq = wr_req_d0;
+        wr_ack = areg_wack;
       end
     1'b1:
       begin
         // Reg breg
-        breg_wreq <= wr_req_d0;
-        wr_ack <= breg_wack;
+        breg_wreq = wr_req_d0;
+        wr_ack = breg_wack;
       end
     default:
-      wr_ack <= wr_req_d0;
+      wr_ack = wr_req_d0;
     endcase
   end
 
@@ -211,22 +211,22 @@ module sreg
   always @(rd_addr, rd_req, areg_reg, breg_reg)
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     case (rd_addr[2:2])
     1'b0:
       begin
         // Reg areg
-        rd_ack_d0 <= rd_req;
-        rd_dat_d0 <= areg_reg;
+        rd_ack_d0 = rd_req;
+        rd_dat_d0 = areg_reg;
       end
     1'b1:
       begin
         // Reg breg
-        rd_ack_d0 <= rd_req;
-        rd_dat_d0 <= breg_reg;
+        rd_ack_d0 = rd_req;
+        rd_dat_d0 = breg_reg;
       end
     default:
-      rd_ack_d0 <= rd_req;
+      rd_ack_d0 = rd_req;
     endcase
   end
 endmodule

--- a/testfiles/features/axi4_submap_wb.sv
+++ b/testfiles/features/axi4_submap_wb.sv
@@ -58,16 +58,16 @@ module axi4_submap_wb
   reg [31:0] wr_sel_d0;
 
   // WB decode signals
-  always @(wb_sel_i)
+  always_comb
   begin
-    wr_sel[7:0] <= {8{wb_sel_i[0]}};
-    wr_sel[15:8] <= {8{wb_sel_i[1]}};
-    wr_sel[23:16] <= {8{wb_sel_i[2]}};
-    wr_sel[31:24] <= {8{wb_sel_i[3]}};
+    wr_sel[7:0] = {8{wb_sel_i[0]}};
+    wr_sel[15:8] = {8{wb_sel_i[1]}};
+    wr_sel[23:16] = {8{wb_sel_i[2]}};
+    wr_sel[31:24] = {8{wb_sel_i[3]}};
   end
   assign wb_en = wb_cyc_i & wb_stb_i;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_rip <= 1'b0;
@@ -76,7 +76,7 @@ module axi4_submap_wb
   end
   assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_wip <= 1'b0;
@@ -92,7 +92,7 @@ module axi4_submap_wb
   assign wb_err_o = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -120,24 +120,24 @@ module axi4_submap_wb
   assign blk_awprot_o = 3'b000;
   assign blk_wvalid_o = blk_w_val;
   assign blk_wdata_o = wr_dat_d0;
-  always @(wr_sel_d0)
+  always_comb
   begin
-    blk_wstrb_o <= 4'b0;
+    blk_wstrb_o = 4'b0;
     if (~(wr_sel_d0[7:0] == 8'b0))
-      blk_wstrb_o[0] <= 1'b1;
+      blk_wstrb_o[0] = 1'b1;
     if (~(wr_sel_d0[15:8] == 8'b0))
-      blk_wstrb_o[1] <= 1'b1;
+      blk_wstrb_o[1] = 1'b1;
     if (~(wr_sel_d0[23:16] == 8'b0))
-      blk_wstrb_o[2] <= 1'b1;
+      blk_wstrb_o[2] = 1'b1;
     if (~(wr_sel_d0[31:24] == 8'b0))
-      blk_wstrb_o[3] <= 1'b1;
+      blk_wstrb_o[3] = 1'b1;
   end
   assign blk_bready_o = 1'b1;
   assign blk_arvalid_o = blk_ar_val;
   assign blk_araddr_o = {wb_adr_i[2:2], 2'b00};
   assign blk_arprot_o = 3'b000;
   assign blk_rready_o = 1'b1;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -154,23 +154,23 @@ module axi4_submap_wb
   end
 
   // Process for write requests.
-  always @(wr_req_d0, blk_bvalid_i)
+  always_comb
   begin
-    blk_wr <= 1'b0;
+    blk_wr = 1'b0;
     // Submap blk
-    blk_wr <= wr_req_d0;
-    wr_ack_int <= blk_bvalid_i;
+    blk_wr = wr_req_d0;
+    wr_ack_int = blk_bvalid_i;
   end
 
   // Process for read requests.
-  always @(rd_req_int, blk_rdata_i, blk_rvalid_i)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
-    blk_rd <= 1'b0;
+    rd_dat_d0 = {32{1'bx}};
+    blk_rd = 1'b0;
     // Submap blk
-    blk_rd <= rd_req_int;
-    rd_dat_d0 <= blk_rdata_i;
-    rd_ack_d0 <= blk_rvalid_i;
+    blk_rd = rd_req_int;
+    rd_dat_d0 = blk_rdata_i;
+    rd_ack_d0 = blk_rvalid_i;
   end
 endmodule

--- a/testfiles/features/axi4_submap_wb.v
+++ b/testfiles/features/axi4_submap_wb.v
@@ -1,0 +1,176 @@
+
+module axi4_submap_wb
+  (
+    input   wire rst_n_i,
+    input   wire clk_i,
+    input   wire wb_cyc_i,
+    input   wire wb_stb_i,
+    input   wire [2:2] wb_adr_i,
+    input   wire [3:0] wb_sel_i,
+    input   wire wb_we_i,
+    input   wire [31:0] wb_dat_i,
+    output  wire wb_ack_o,
+    output  wire wb_err_o,
+    output  wire wb_rty_o,
+    output  wire wb_stall_o,
+    output  reg [31:0] wb_dat_o,
+
+    // AXI-4 lite bus blk
+    output  wire blk_awvalid_o,
+    input   wire blk_awready_i,
+    output  wire [2:0] blk_awaddr_o,
+    output  wire [2:0] blk_awprot_o,
+    output  wire blk_wvalid_o,
+    input   wire blk_wready_i,
+    output  wire [31:0] blk_wdata_o,
+    output  reg [3:0] blk_wstrb_o,
+    input   wire blk_bvalid_i,
+    output  wire blk_bready_o,
+    input   wire [1:0] blk_bresp_i,
+    output  wire blk_arvalid_o,
+    input   wire blk_arready_i,
+    output  wire [2:0] blk_araddr_o,
+    output  wire [2:0] blk_arprot_o,
+    input   wire blk_rvalid_i,
+    output  wire blk_rready_o,
+    input   wire [31:0] blk_rdata_i,
+    input   wire [1:0] blk_rresp_i
+  );
+  reg [31:0] wr_sel;
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg blk_aw_val;
+  reg blk_w_val;
+  reg blk_ar_val;
+  reg blk_rd;
+  reg blk_wr;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [2:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+  reg [31:0] wr_sel_d0;
+
+  // WB decode signals
+  always @(wb_sel_i)
+  begin
+    wr_sel[7:0] = {8{wb_sel_i[0]}};
+    wr_sel[15:8] = {8{wb_sel_i[1]}};
+    wr_sel[23:16] = {8{wb_sel_i[2]}};
+    wr_sel[31:24] = {8{wb_sel_i[3]}};
+  end
+  assign wb_en = wb_cyc_i & wb_stb_i;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb_we_i)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb_we_i)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb_we_i) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb_ack_o = ack_int;
+  assign wb_stall_o = ~ack_int & wb_en;
+  assign wb_rty_o = 1'b0;
+  assign wb_err_o = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        rd_ack_int <= 1'b0;
+        wb_dat_o <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 1'b0;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+        wr_sel_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb_dat_o <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_adr_d0 <= wb_adr_i;
+        wr_dat_d0 <= wb_dat_i;
+        wr_sel_d0 <= wr_sel;
+      end
+  end
+
+  // Interface blk
+  assign blk_awvalid_o = blk_aw_val;
+  assign blk_awaddr_o = {wr_adr_d0[2:2], 2'b00};
+  assign blk_awprot_o = 3'b000;
+  assign blk_wvalid_o = blk_w_val;
+  assign blk_wdata_o = wr_dat_d0;
+  always @(wr_sel_d0)
+  begin
+    blk_wstrb_o = 4'b0;
+    if (~(wr_sel_d0[7:0] == 8'b0))
+      blk_wstrb_o[0] = 1'b1;
+    if (~(wr_sel_d0[15:8] == 8'b0))
+      blk_wstrb_o[1] = 1'b1;
+    if (~(wr_sel_d0[23:16] == 8'b0))
+      blk_wstrb_o[2] = 1'b1;
+    if (~(wr_sel_d0[31:24] == 8'b0))
+      blk_wstrb_o[3] = 1'b1;
+  end
+  assign blk_bready_o = 1'b1;
+  assign blk_arvalid_o = blk_ar_val;
+  assign blk_araddr_o = {wb_adr_i[2:2], 2'b00};
+  assign blk_arprot_o = 3'b000;
+  assign blk_rready_o = 1'b1;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        blk_aw_val <= 1'b0;
+        blk_w_val <= 1'b0;
+        blk_ar_val <= 1'b0;
+      end
+    else
+      begin
+        blk_aw_val <= blk_wr | (blk_aw_val & ~blk_awready_i);
+        blk_w_val <= blk_wr | (blk_w_val & ~blk_wready_i);
+        blk_ar_val <= blk_rd | (blk_ar_val & ~blk_arready_i);
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_req_d0, blk_bvalid_i)
+  begin
+    blk_wr = 1'b0;
+    // Submap blk
+    blk_wr = wr_req_d0;
+    wr_ack_int = blk_bvalid_i;
+  end
+
+  // Process for read requests.
+  always @(rd_req_int, blk_rdata_i, blk_rvalid_i)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    blk_rd = 1'b0;
+    // Submap blk
+    blk_rd = rd_req_int;
+    rd_dat_d0 = blk_rdata_i;
+    rd_ack_d0 = blk_rvalid_i;
+  end
+endmodule

--- a/testfiles/features/axi4_submap_wb_async_rst.sv
+++ b/testfiles/features/axi4_submap_wb_async_rst.sv
@@ -60,10 +60,10 @@ module axi4_submap_wb
   // WB decode signals
   always @(wb_sel_i)
   begin
-    wr_sel[7:0] <= {8{wb_sel_i[0]}};
-    wr_sel[15:8] <= {8{wb_sel_i[1]}};
-    wr_sel[23:16] <= {8{wb_sel_i[2]}};
-    wr_sel[31:24] <= {8{wb_sel_i[3]}};
+    wr_sel[7:0] = {8{wb_sel_i[0]}};
+    wr_sel[15:8] = {8{wb_sel_i[1]}};
+    wr_sel[23:16] = {8{wb_sel_i[2]}};
+    wr_sel[31:24] = {8{wb_sel_i[3]}};
   end
   assign wb_en = wb_cyc_i & wb_stb_i;
 
@@ -122,15 +122,15 @@ module axi4_submap_wb
   assign blk_wdata_o = wr_dat_d0;
   always @(wr_sel_d0)
   begin
-    blk_wstrb_o <= 4'b0;
+    blk_wstrb_o = 4'b0;
     if (~(wr_sel_d0[7:0] == 8'b0))
-      blk_wstrb_o[0] <= 1'b1;
+      blk_wstrb_o[0] = 1'b1;
     if (~(wr_sel_d0[15:8] == 8'b0))
-      blk_wstrb_o[1] <= 1'b1;
+      blk_wstrb_o[1] = 1'b1;
     if (~(wr_sel_d0[23:16] == 8'b0))
-      blk_wstrb_o[2] <= 1'b1;
+      blk_wstrb_o[2] = 1'b1;
     if (~(wr_sel_d0[31:24] == 8'b0))
-      blk_wstrb_o[3] <= 1'b1;
+      blk_wstrb_o[3] = 1'b1;
   end
   assign blk_bready_o = 1'b1;
   assign blk_arvalid_o = blk_ar_val;
@@ -156,21 +156,21 @@ module axi4_submap_wb
   // Process for write requests.
   always @(wr_req_d0, blk_bvalid_i)
   begin
-    blk_wr <= 1'b0;
+    blk_wr = 1'b0;
     // Submap blk
-    blk_wr <= wr_req_d0;
-    wr_ack_int <= blk_bvalid_i;
+    blk_wr = wr_req_d0;
+    wr_ack_int = blk_bvalid_i;
   end
 
   // Process for read requests.
   always @(rd_req_int, blk_rdata_i, blk_rvalid_i)
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
-    blk_rd <= 1'b0;
+    rd_dat_d0 = {32{1'bx}};
+    blk_rd = 1'b0;
     // Submap blk
-    blk_rd <= rd_req_int;
-    rd_dat_d0 <= blk_rdata_i;
-    rd_ack_d0 <= blk_rvalid_i;
+    blk_rd = rd_req_int;
+    rd_dat_d0 = blk_rdata_i;
+    rd_ack_d0 = blk_rvalid_i;
   end
 endmodule

--- a/testfiles/features/axi4_word.sv
+++ b/testfiles/features/axi4_word.sv
@@ -58,7 +58,7 @@ module sreg
   assign awready = ~axi_awset;
   assign wready = ~axi_wset;
   assign bvalid = axi_wdone;
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -97,7 +97,7 @@ module sreg
   // AR and R channels
   assign arready = ~axi_arset;
   assign rvalid = axi_rdone;
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -130,7 +130,7 @@ module sreg
   assign rresp = 2'b00;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -152,7 +152,7 @@ module sreg
 
   // Register areg
   assign areg_o = areg_reg;
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -169,7 +169,7 @@ module sreg
 
   // Register breg
   assign breg_o = breg_reg;
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -185,48 +185,48 @@ module sreg
   end
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0, areg_wack, breg_wack)
+  always_comb
   begin
-    areg_wreq <= 1'b0;
-    breg_wreq <= 1'b0;
+    areg_wreq = 1'b0;
+    breg_wreq = 1'b0;
     case (wr_adr_d0[2:2])
     1'b0:
       begin
         // Reg areg
-        areg_wreq <= wr_req_d0;
-        wr_ack <= areg_wack;
+        areg_wreq = wr_req_d0;
+        wr_ack = areg_wack;
       end
     1'b1:
       begin
         // Reg breg
-        breg_wreq <= wr_req_d0;
-        wr_ack <= breg_wack;
+        breg_wreq = wr_req_d0;
+        wr_ack = breg_wack;
       end
     default:
-      wr_ack <= wr_req_d0;
+      wr_ack = wr_req_d0;
     endcase
   end
 
   // Process for read requests.
-  always @(rd_addr, rd_req, areg_reg, breg_reg)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     case (rd_addr[2:2])
     1'b0:
       begin
         // Reg areg
-        rd_ack_d0 <= rd_req;
-        rd_dat_d0 <= areg_reg;
+        rd_ack_d0 = rd_req;
+        rd_dat_d0 = areg_reg;
       end
     1'b1:
       begin
         // Reg breg
-        rd_ack_d0 <= rd_req;
-        rd_dat_d0 <= breg_reg;
+        rd_ack_d0 = rd_req;
+        rd_dat_d0 = breg_reg;
       end
     default:
-      rd_ack_d0 <= rd_req;
+      rd_ack_d0 = rd_req;
     endcase
   end
 endmodule

--- a/testfiles/features/axi4_word.v
+++ b/testfiles/features/axi4_word.v
@@ -1,0 +1,232 @@
+
+module sreg
+  (
+    input   wire aclk,
+    input   wire areset_n,
+    input   wire awvalid,
+    output  wire awready,
+    input   wire [2:2] awaddr,
+    input   wire [2:0] awprot,
+    input   wire wvalid,
+    output  wire wready,
+    input   wire [31:0] wdata,
+    input   wire [3:0] wstrb,
+    output  wire bvalid,
+    input   wire bready,
+    output  wire [1:0] bresp,
+    input   wire arvalid,
+    output  wire arready,
+    input   wire [2:2] araddr,
+    input   wire [2:0] arprot,
+    output  wire rvalid,
+    input   wire rready,
+    output  reg [31:0] rdata,
+    output  wire [1:0] rresp,
+
+    // REG areg
+    output  wire [31:0] areg_o,
+
+    // REG breg
+    output  wire [31:0] breg_o
+  );
+  reg wr_req;
+  reg wr_ack;
+  reg [2:2] wr_addr;
+  reg [31:0] wr_data;
+  reg axi_awset;
+  reg axi_wset;
+  reg axi_wdone;
+  reg rd_req;
+  reg rd_ack;
+  reg [2:2] rd_addr;
+  reg [31:0] rd_data;
+  reg axi_arset;
+  reg axi_rdone;
+  reg [31:0] areg_reg;
+  reg areg_wreq;
+  reg areg_wack;
+  reg [31:0] breg_reg;
+  reg breg_wreq;
+  reg breg_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [2:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+
+  // AW, W and B channels
+  assign awready = ~axi_awset;
+  assign wready = ~axi_wset;
+  assign bvalid = axi_wdone;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        wr_req <= 1'b0;
+        axi_awset <= 1'b0;
+        axi_wset <= 1'b0;
+        axi_wdone <= 1'b0;
+      end
+    else
+      begin
+        wr_req <= 1'b0;
+        if (awvalid == 1'b1 & axi_awset == 1'b0)
+          begin
+            wr_addr <= awaddr;
+            axi_awset <= 1'b1;
+            wr_req <= axi_wset;
+          end
+        if (wvalid == 1'b1 & axi_wset == 1'b0)
+          begin
+            wr_data <= wdata;
+            axi_wset <= 1'b1;
+            wr_req <= axi_awset | awvalid;
+          end
+        if ((axi_wdone & bready) == 1'b1)
+          begin
+            axi_wset <= 1'b0;
+            axi_awset <= 1'b0;
+            axi_wdone <= 1'b0;
+          end
+        if (wr_ack == 1'b1)
+          axi_wdone <= 1'b1;
+      end
+  end
+  assign bresp = 2'b00;
+
+  // AR and R channels
+  assign arready = ~axi_arset;
+  assign rvalid = axi_rdone;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        rd_req <= 1'b0;
+        axi_arset <= 1'b0;
+        axi_rdone <= 1'b0;
+        rdata <= 32'b0;
+      end
+    else
+      begin
+        rd_req <= 1'b0;
+        if (arvalid == 1'b1 & axi_arset == 1'b0)
+          begin
+            rd_addr <= araddr;
+            axi_arset <= 1'b1;
+            rd_req <= 1'b1;
+          end
+        if ((axi_rdone & rready) == 1'b1)
+          begin
+            axi_arset <= 1'b0;
+            axi_rdone <= 1'b0;
+          end
+        if (rd_ack == 1'b1)
+          begin
+            axi_rdone <= 1'b1;
+            rdata <= rd_data;
+          end
+      end
+  end
+  assign rresp = 2'b00;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        rd_ack <= 1'b0;
+        rd_data <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 1'b0;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack <= rd_ack_d0;
+        rd_data <= rd_dat_d0;
+        wr_req_d0 <= wr_req;
+        wr_adr_d0 <= wr_addr;
+        wr_dat_d0 <= wr_data;
+      end
+  end
+
+  // Register areg
+  assign areg_o = areg_reg;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        areg_reg <= 32'b00000000000000000000000000000000;
+        areg_wack <= 1'b0;
+      end
+    else
+      begin
+        if (areg_wreq == 1'b1)
+          areg_reg <= wr_dat_d0;
+        areg_wack <= areg_wreq;
+      end
+  end
+
+  // Register breg
+  assign breg_o = breg_reg;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        breg_reg <= 32'b00000000000000000000000000000000;
+        breg_wack <= 1'b0;
+      end
+    else
+      begin
+        if (breg_wreq == 1'b1)
+          breg_reg <= wr_dat_d0;
+        breg_wack <= breg_wreq;
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, areg_wack, breg_wack)
+  begin
+    areg_wreq = 1'b0;
+    breg_wreq = 1'b0;
+    case (wr_adr_d0[2:2])
+    1'b0:
+      begin
+        // Reg areg
+        areg_wreq = wr_req_d0;
+        wr_ack = areg_wack;
+      end
+    1'b1:
+      begin
+        // Reg breg
+        breg_wreq = wr_req_d0;
+        wr_ack = breg_wack;
+      end
+    default:
+      wr_ack = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always @(rd_addr, rd_req, areg_reg, breg_reg)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    case (rd_addr[2:2])
+    1'b0:
+      begin
+        // Reg areg
+        rd_ack_d0 = rd_req;
+        rd_dat_d0 = areg_reg;
+      end
+    1'b1:
+      begin
+        // Reg breg
+        rd_ack_d0 = rd_req;
+        rd_dat_d0 = breg_reg;
+      end
+    default:
+      rd_ack_d0 = rd_req;
+    endcase
+  end
+endmodule

--- a/testfiles/features/axi4_word_async_rst.sv
+++ b/testfiles/features/axi4_word_async_rst.sv
@@ -187,23 +187,23 @@ module sreg
   // Process for write requests.
   always @(wr_adr_d0, wr_req_d0, areg_wack, breg_wack)
   begin
-    areg_wreq <= 1'b0;
-    breg_wreq <= 1'b0;
+    areg_wreq = 1'b0;
+    breg_wreq = 1'b0;
     case (wr_adr_d0[2:2])
     1'b0:
       begin
         // Reg areg
-        areg_wreq <= wr_req_d0;
-        wr_ack <= areg_wack;
+        areg_wreq = wr_req_d0;
+        wr_ack = areg_wack;
       end
     1'b1:
       begin
         // Reg breg
-        breg_wreq <= wr_req_d0;
-        wr_ack <= breg_wack;
+        breg_wreq = wr_req_d0;
+        wr_ack = breg_wack;
       end
     default:
-      wr_ack <= wr_req_d0;
+      wr_ack = wr_req_d0;
     endcase
   end
 
@@ -211,22 +211,22 @@ module sreg
   always @(rd_addr, rd_req, areg_reg, breg_reg)
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     case (rd_addr[2:2])
     1'b0:
       begin
         // Reg areg
-        rd_ack_d0 <= rd_req;
-        rd_dat_d0 <= areg_reg;
+        rd_ack_d0 = rd_req;
+        rd_dat_d0 = areg_reg;
       end
     1'b1:
       begin
         // Reg breg
-        rd_ack_d0 <= rd_req;
-        rd_dat_d0 <= breg_reg;
+        rd_ack_d0 = rd_req;
+        rd_dat_d0 = breg_reg;
       end
     default:
-      rd_ack_d0 <= rd_req;
+      rd_ack_d0 = rd_req;
     endcase
   end
 endmodule

--- a/testfiles/features/blkprefix1.sv
+++ b/testfiles/features/blkprefix1.sv
@@ -44,11 +44,11 @@ module blkprefix1
   reg [31:0] wr_dat_d0;
 
   // WB decode signals
-  always @(wb_sel_i)
+  always_comb
   ;
   assign wb_en = wb_cyc_i & wb_stb_i;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_rip <= 1'b0;
@@ -57,7 +57,7 @@ module blkprefix1
   end
   assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_wip <= 1'b0;
@@ -73,7 +73,7 @@ module blkprefix1
   assign wb_err_o = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -96,7 +96,7 @@ module blkprefix1
   // Register r2
   assign r2_f1_o = b1_r2_f1_reg;
   assign r2_f2_o = b1_r2_f2_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -117,7 +117,7 @@ module blkprefix1
 
   // Register r3
   assign r3_f1_o = b2_r3_f1_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -133,52 +133,52 @@ module blkprefix1
   end
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0, r2_wack, r3_wack)
+  always_comb
   begin
-    r2_wreq <= 1'b0;
-    r3_wreq <= 1'b0;
+    r2_wreq = 1'b0;
+    r3_wreq = 1'b0;
     case (wr_adr_d0[2:2])
     1'b0:
       begin
         // Reg r2
-        r2_wreq <= wr_req_d0;
-        wr_ack_int <= r2_wack;
+        r2_wreq = wr_req_d0;
+        wr_ack_int = r2_wack;
       end
     1'b1:
       begin
         // Reg r3
-        r3_wreq <= wr_req_d0;
-        wr_ack_int <= r3_wack;
+        r3_wreq = wr_req_d0;
+        wr_ack_int = r3_wack;
       end
     default:
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     endcase
   end
 
   // Process for read requests.
-  always @(wb_adr_i, rd_req_int, b1_r2_f1_reg, b1_r2_f2_reg, b2_r3_f1_reg)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     case (wb_adr_i[2:2])
     1'b0:
       begin
         // Reg r2
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0[2:0] <= b1_r2_f1_reg;
-        rd_dat_d0[3] <= 1'b0;
-        rd_dat_d0[4] <= b1_r2_f2_reg;
-        rd_dat_d0[31:5] <= 27'b0;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0[2:0] = b1_r2_f1_reg;
+        rd_dat_d0[3] = 1'b0;
+        rd_dat_d0[4] = b1_r2_f2_reg;
+        rd_dat_d0[31:5] = 27'b0;
       end
     1'b1:
       begin
         // Reg r3
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0[2:0] <= b2_r3_f1_reg;
-        rd_dat_d0[31:3] <= 29'b0;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0[2:0] = b2_r3_f1_reg;
+        rd_dat_d0[31:3] = 29'b0;
       end
     default:
-      rd_ack_d0 <= rd_req_int;
+      rd_ack_d0 = rd_req_int;
     endcase
   end
 endmodule

--- a/testfiles/features/blkprefix1.v
+++ b/testfiles/features/blkprefix1.v
@@ -1,0 +1,184 @@
+
+module blkprefix1
+  (
+    input   wire rst_n_i,
+    input   wire clk_i,
+    input   wire wb_cyc_i,
+    input   wire wb_stb_i,
+    input   wire [2:2] wb_adr_i,
+    input   wire [3:0] wb_sel_i,
+    input   wire wb_we_i,
+    input   wire [31:0] wb_dat_i,
+    output  wire wb_ack_o,
+    output  wire wb_err_o,
+    output  wire wb_rty_o,
+    output  wire wb_stall_o,
+    output  reg [31:0] wb_dat_o,
+
+    // REG r2
+    output  wire [2:0] r2_f1_o,
+    output  wire r2_f2_o,
+
+    // REG r3
+    output  wire [2:0] r3_f1_o
+  );
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg [2:0] b1_r2_f1_reg;
+  reg b1_r2_f2_reg;
+  reg r2_wreq;
+  reg r2_wack;
+  reg [2:0] b2_r3_f1_reg;
+  reg r3_wreq;
+  reg r3_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [2:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+
+  // WB decode signals
+  always @(wb_sel_i)
+  ;
+  assign wb_en = wb_cyc_i & wb_stb_i;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb_we_i)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb_we_i)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb_we_i) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb_ack_o = ack_int;
+  assign wb_stall_o = ~ack_int & wb_en;
+  assign wb_rty_o = 1'b0;
+  assign wb_err_o = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        rd_ack_int <= 1'b0;
+        wb_dat_o <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 1'b0;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb_dat_o <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_adr_d0 <= wb_adr_i;
+        wr_dat_d0 <= wb_dat_i;
+      end
+  end
+
+  // Register r2
+  assign r2_f1_o = b1_r2_f1_reg;
+  assign r2_f2_o = b1_r2_f2_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        b1_r2_f1_reg <= 3'b000;
+        b1_r2_f2_reg <= 1'b0;
+        r2_wack <= 1'b0;
+      end
+    else
+      begin
+        if (r2_wreq == 1'b1)
+          begin
+            b1_r2_f1_reg <= wr_dat_d0[2:0];
+            b1_r2_f2_reg <= wr_dat_d0[4];
+          end
+        r2_wack <= r2_wreq;
+      end
+  end
+
+  // Register r3
+  assign r3_f1_o = b2_r3_f1_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        b2_r3_f1_reg <= 3'b000;
+        r3_wack <= 1'b0;
+      end
+    else
+      begin
+        if (r3_wreq == 1'b1)
+          b2_r3_f1_reg <= wr_dat_d0[2:0];
+        r3_wack <= r3_wreq;
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, r2_wack, r3_wack)
+  begin
+    r2_wreq = 1'b0;
+    r3_wreq = 1'b0;
+    case (wr_adr_d0[2:2])
+    1'b0:
+      begin
+        // Reg r2
+        r2_wreq = wr_req_d0;
+        wr_ack_int = r2_wack;
+      end
+    1'b1:
+      begin
+        // Reg r3
+        r3_wreq = wr_req_d0;
+        wr_ack_int = r3_wack;
+      end
+    default:
+      wr_ack_int = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always @(wb_adr_i, rd_req_int, b1_r2_f1_reg, b1_r2_f2_reg, b2_r3_f1_reg)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    case (wb_adr_i[2:2])
+    1'b0:
+      begin
+        // Reg r2
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0[2:0] = b1_r2_f1_reg;
+        rd_dat_d0[3] = 1'b0;
+        rd_dat_d0[4] = b1_r2_f2_reg;
+        rd_dat_d0[31:5] = 27'b0;
+      end
+    1'b1:
+      begin
+        // Reg r3
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0[2:0] = b2_r3_f1_reg;
+        rd_dat_d0[31:3] = 29'b0;
+      end
+    default:
+      rd_ack_d0 = rd_req_int;
+    endcase
+  end
+endmodule

--- a/testfiles/features/blkprefix2.sv
+++ b/testfiles/features/blkprefix2.sv
@@ -44,11 +44,11 @@ module blkprefix2
   reg [31:0] wr_dat_d0;
 
   // WB decode signals
-  always @(wb_sel_i)
+  always_comb
   ;
   assign wb_en = wb_cyc_i & wb_stb_i;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_rip <= 1'b0;
@@ -57,7 +57,7 @@ module blkprefix2
   end
   assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_wip <= 1'b0;
@@ -73,7 +73,7 @@ module blkprefix2
   assign wb_err_o = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -96,7 +96,7 @@ module blkprefix2
   // Register r2
   assign r2_f1_o = b1_r2_f1_reg;
   assign r2_f2_o = b1_r2_f2_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -117,7 +117,7 @@ module blkprefix2
 
   // Register r3
   assign r3_f1_o = b2_r3_f1_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -133,52 +133,52 @@ module blkprefix2
   end
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0, r2_wack, r3_wack)
+  always_comb
   begin
-    r2_wreq <= 1'b0;
-    r3_wreq <= 1'b0;
+    r2_wreq = 1'b0;
+    r3_wreq = 1'b0;
     case (wr_adr_d0[2:2])
     1'b0:
       begin
         // Reg r2
-        r2_wreq <= wr_req_d0;
-        wr_ack_int <= r2_wack;
+        r2_wreq = wr_req_d0;
+        wr_ack_int = r2_wack;
       end
     1'b1:
       begin
         // Reg r3
-        r3_wreq <= wr_req_d0;
-        wr_ack_int <= r3_wack;
+        r3_wreq = wr_req_d0;
+        wr_ack_int = r3_wack;
       end
     default:
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     endcase
   end
 
   // Process for read requests.
-  always @(wb_adr_i, rd_req_int, b1_r2_f1_reg, b1_r2_f2_reg, b2_r3_f1_reg)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     case (wb_adr_i[2:2])
     1'b0:
       begin
         // Reg r2
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0[2:0] <= b1_r2_f1_reg;
-        rd_dat_d0[3] <= 1'b0;
-        rd_dat_d0[4] <= b1_r2_f2_reg;
-        rd_dat_d0[31:5] <= 27'b0;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0[2:0] = b1_r2_f1_reg;
+        rd_dat_d0[3] = 1'b0;
+        rd_dat_d0[4] = b1_r2_f2_reg;
+        rd_dat_d0[31:5] = 27'b0;
       end
     1'b1:
       begin
         // Reg r3
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0[2:0] <= b2_r3_f1_reg;
-        rd_dat_d0[31:3] <= 29'b0;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0[2:0] = b2_r3_f1_reg;
+        rd_dat_d0[31:3] = 29'b0;
       end
     default:
-      rd_ack_d0 <= rd_req_int;
+      rd_ack_d0 = rd_req_int;
     endcase
   end
 endmodule

--- a/testfiles/features/blkprefix2.v
+++ b/testfiles/features/blkprefix2.v
@@ -1,0 +1,184 @@
+
+module blkprefix2
+  (
+    input   wire rst_n_i,
+    input   wire clk_i,
+    input   wire wb_cyc_i,
+    input   wire wb_stb_i,
+    input   wire [2:2] wb_adr_i,
+    input   wire [3:0] wb_sel_i,
+    input   wire wb_we_i,
+    input   wire [31:0] wb_dat_i,
+    output  wire wb_ack_o,
+    output  wire wb_err_o,
+    output  wire wb_rty_o,
+    output  wire wb_stall_o,
+    output  reg [31:0] wb_dat_o,
+
+    // REG r2
+    output  wire [2:0] r2_f1_o,
+    output  wire r2_f2_o,
+
+    // REG r3
+    output  wire [2:0] r3_f1_o
+  );
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg [2:0] b1_r2_f1_reg;
+  reg b1_r2_f2_reg;
+  reg r2_wreq;
+  reg r2_wack;
+  reg [2:0] b2_r3_f1_reg;
+  reg r3_wreq;
+  reg r3_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [2:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+
+  // WB decode signals
+  always @(wb_sel_i)
+  ;
+  assign wb_en = wb_cyc_i & wb_stb_i;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb_we_i)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb_we_i)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb_we_i) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb_ack_o = ack_int;
+  assign wb_stall_o = ~ack_int & wb_en;
+  assign wb_rty_o = 1'b0;
+  assign wb_err_o = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        rd_ack_int <= 1'b0;
+        wb_dat_o <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 1'b0;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb_dat_o <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_adr_d0 <= wb_adr_i;
+        wr_dat_d0 <= wb_dat_i;
+      end
+  end
+
+  // Register r2
+  assign r2_f1_o = b1_r2_f1_reg;
+  assign r2_f2_o = b1_r2_f2_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        b1_r2_f1_reg <= 3'b000;
+        b1_r2_f2_reg <= 1'b0;
+        r2_wack <= 1'b0;
+      end
+    else
+      begin
+        if (r2_wreq == 1'b1)
+          begin
+            b1_r2_f1_reg <= wr_dat_d0[2:0];
+            b1_r2_f2_reg <= wr_dat_d0[4];
+          end
+        r2_wack <= r2_wreq;
+      end
+  end
+
+  // Register r3
+  assign r3_f1_o = b2_r3_f1_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        b2_r3_f1_reg <= 3'b000;
+        r3_wack <= 1'b0;
+      end
+    else
+      begin
+        if (r3_wreq == 1'b1)
+          b2_r3_f1_reg <= wr_dat_d0[2:0];
+        r3_wack <= r3_wreq;
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, r2_wack, r3_wack)
+  begin
+    r2_wreq = 1'b0;
+    r3_wreq = 1'b0;
+    case (wr_adr_d0[2:2])
+    1'b0:
+      begin
+        // Reg r2
+        r2_wreq = wr_req_d0;
+        wr_ack_int = r2_wack;
+      end
+    1'b1:
+      begin
+        // Reg r3
+        r3_wreq = wr_req_d0;
+        wr_ack_int = r3_wack;
+      end
+    default:
+      wr_ack_int = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always @(wb_adr_i, rd_req_int, b1_r2_f1_reg, b1_r2_f2_reg, b2_r3_f1_reg)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    case (wb_adr_i[2:2])
+    1'b0:
+      begin
+        // Reg r2
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0[2:0] = b1_r2_f1_reg;
+        rd_dat_d0[3] = 1'b0;
+        rd_dat_d0[4] = b1_r2_f2_reg;
+        rd_dat_d0[31:5] = 27'b0;
+      end
+    1'b1:
+      begin
+        // Reg r3
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0[2:0] = b2_r3_f1_reg;
+        rd_dat_d0[31:3] = 29'b0;
+      end
+    default:
+      rd_ack_d0 = rd_req_int;
+    endcase
+  end
+endmodule

--- a/testfiles/features/blkprefix3.sv
+++ b/testfiles/features/blkprefix3.sv
@@ -52,11 +52,11 @@ module blkprefix3
   reg [31:0] wr_dat_d0;
 
   // WB decode signals
-  always @(wb_sel_i)
+  always_comb
   ;
   assign wb_en = wb_cyc_i & wb_stb_i;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_rip <= 1'b0;
@@ -65,7 +65,7 @@ module blkprefix3
   end
   assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_wip <= 1'b0;
@@ -81,7 +81,7 @@ module blkprefix3
   assign wb_err_o = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -104,7 +104,7 @@ module blkprefix3
   // Register b1_r2
   assign b1_r2_f1_o = b1_r2_f1_reg;
   assign b1_r2_f2_o = b1_r2_f2_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -126,7 +126,7 @@ module blkprefix3
   // Register b1_r3
   assign b1_r3_f1_o = b1_b11_r3_f1_reg;
   assign b1_r3_f2_o = b1_b11_r3_f2_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -147,7 +147,7 @@ module blkprefix3
 
   // Register b2_r3
   assign b2_r3_f1_o = b2_r3_f1_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -163,68 +163,68 @@ module blkprefix3
   end
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0, b1_r2_wack, b1_r3_wack, b2_r3_wack)
+  always_comb
   begin
-    b1_r2_wreq <= 1'b0;
-    b1_r3_wreq <= 1'b0;
-    b2_r3_wreq <= 1'b0;
+    b1_r2_wreq = 1'b0;
+    b1_r3_wreq = 1'b0;
+    b2_r3_wreq = 1'b0;
     case (wr_adr_d0[3:2])
     2'b00:
       begin
         // Reg b1_r2
-        b1_r2_wreq <= wr_req_d0;
-        wr_ack_int <= b1_r2_wack;
+        b1_r2_wreq = wr_req_d0;
+        wr_ack_int = b1_r2_wack;
       end
     2'b01:
       begin
         // Reg b1_r3
-        b1_r3_wreq <= wr_req_d0;
-        wr_ack_int <= b1_r3_wack;
+        b1_r3_wreq = wr_req_d0;
+        wr_ack_int = b1_r3_wack;
       end
     2'b10:
       begin
         // Reg b2_r3
-        b2_r3_wreq <= wr_req_d0;
-        wr_ack_int <= b2_r3_wack;
+        b2_r3_wreq = wr_req_d0;
+        wr_ack_int = b2_r3_wack;
       end
     default:
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     endcase
   end
 
   // Process for read requests.
-  always @(wb_adr_i, rd_req_int, b1_r2_f1_reg, b1_r2_f2_reg, b1_b11_r3_f1_reg, b1_b11_r3_f2_reg, b2_r3_f1_reg)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     case (wb_adr_i[3:2])
     2'b00:
       begin
         // Reg b1_r2
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0[2:0] <= b1_r2_f1_reg;
-        rd_dat_d0[3] <= 1'b0;
-        rd_dat_d0[4] <= b1_r2_f2_reg;
-        rd_dat_d0[31:5] <= 27'b0;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0[2:0] = b1_r2_f1_reg;
+        rd_dat_d0[3] = 1'b0;
+        rd_dat_d0[4] = b1_r2_f2_reg;
+        rd_dat_d0[31:5] = 27'b0;
       end
     2'b01:
       begin
         // Reg b1_r3
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0[2:0] <= b1_b11_r3_f1_reg;
-        rd_dat_d0[3] <= 1'b0;
-        rd_dat_d0[4] <= b1_b11_r3_f2_reg;
-        rd_dat_d0[31:5] <= 27'b0;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0[2:0] = b1_b11_r3_f1_reg;
+        rd_dat_d0[3] = 1'b0;
+        rd_dat_d0[4] = b1_b11_r3_f2_reg;
+        rd_dat_d0[31:5] = 27'b0;
       end
     2'b10:
       begin
         // Reg b2_r3
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0[2:0] <= b2_r3_f1_reg;
-        rd_dat_d0[31:3] <= 29'b0;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0[2:0] = b2_r3_f1_reg;
+        rd_dat_d0[31:3] = 29'b0;
       end
     default:
-      rd_ack_d0 <= rd_req_int;
+      rd_ack_d0 = rd_req_int;
     endcase
   end
 endmodule

--- a/testfiles/features/blkprefix3.v
+++ b/testfiles/features/blkprefix3.v
@@ -1,0 +1,230 @@
+
+module blkprefix3
+  (
+    input   wire rst_n_i,
+    input   wire clk_i,
+    input   wire wb_cyc_i,
+    input   wire wb_stb_i,
+    input   wire [3:2] wb_adr_i,
+    input   wire [3:0] wb_sel_i,
+    input   wire wb_we_i,
+    input   wire [31:0] wb_dat_i,
+    output  wire wb_ack_o,
+    output  wire wb_err_o,
+    output  wire wb_rty_o,
+    output  wire wb_stall_o,
+    output  reg [31:0] wb_dat_o,
+
+    // REG r2
+    output  wire [2:0] b1_r2_f1_o,
+    output  wire b1_r2_f2_o,
+
+    // REG r3
+    output  wire [2:0] b1_r3_f1_o,
+    output  wire b1_r3_f2_o,
+
+    // REG r3
+    output  wire [2:0] b2_r3_f1_o
+  );
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg [2:0] b1_r2_f1_reg;
+  reg b1_r2_f2_reg;
+  reg b1_r2_wreq;
+  reg b1_r2_wack;
+  reg [2:0] b1_b11_r3_f1_reg;
+  reg b1_b11_r3_f2_reg;
+  reg b1_r3_wreq;
+  reg b1_r3_wack;
+  reg [2:0] b2_r3_f1_reg;
+  reg b2_r3_wreq;
+  reg b2_r3_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [3:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+
+  // WB decode signals
+  always @(wb_sel_i)
+  ;
+  assign wb_en = wb_cyc_i & wb_stb_i;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb_we_i)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb_we_i)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb_we_i) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb_ack_o = ack_int;
+  assign wb_stall_o = ~ack_int & wb_en;
+  assign wb_rty_o = 1'b0;
+  assign wb_err_o = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        rd_ack_int <= 1'b0;
+        wb_dat_o <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 2'b00;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb_dat_o <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_adr_d0 <= wb_adr_i;
+        wr_dat_d0 <= wb_dat_i;
+      end
+  end
+
+  // Register b1_r2
+  assign b1_r2_f1_o = b1_r2_f1_reg;
+  assign b1_r2_f2_o = b1_r2_f2_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        b1_r2_f1_reg <= 3'b000;
+        b1_r2_f2_reg <= 1'b0;
+        b1_r2_wack <= 1'b0;
+      end
+    else
+      begin
+        if (b1_r2_wreq == 1'b1)
+          begin
+            b1_r2_f1_reg <= wr_dat_d0[2:0];
+            b1_r2_f2_reg <= wr_dat_d0[4];
+          end
+        b1_r2_wack <= b1_r2_wreq;
+      end
+  end
+
+  // Register b1_r3
+  assign b1_r3_f1_o = b1_b11_r3_f1_reg;
+  assign b1_r3_f2_o = b1_b11_r3_f2_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        b1_b11_r3_f1_reg <= 3'b000;
+        b1_b11_r3_f2_reg <= 1'b0;
+        b1_r3_wack <= 1'b0;
+      end
+    else
+      begin
+        if (b1_r3_wreq == 1'b1)
+          begin
+            b1_b11_r3_f1_reg <= wr_dat_d0[2:0];
+            b1_b11_r3_f2_reg <= wr_dat_d0[4];
+          end
+        b1_r3_wack <= b1_r3_wreq;
+      end
+  end
+
+  // Register b2_r3
+  assign b2_r3_f1_o = b2_r3_f1_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        b2_r3_f1_reg <= 3'b000;
+        b2_r3_wack <= 1'b0;
+      end
+    else
+      begin
+        if (b2_r3_wreq == 1'b1)
+          b2_r3_f1_reg <= wr_dat_d0[2:0];
+        b2_r3_wack <= b2_r3_wreq;
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, b1_r2_wack, b1_r3_wack, b2_r3_wack)
+  begin
+    b1_r2_wreq = 1'b0;
+    b1_r3_wreq = 1'b0;
+    b2_r3_wreq = 1'b0;
+    case (wr_adr_d0[3:2])
+    2'b00:
+      begin
+        // Reg b1_r2
+        b1_r2_wreq = wr_req_d0;
+        wr_ack_int = b1_r2_wack;
+      end
+    2'b01:
+      begin
+        // Reg b1_r3
+        b1_r3_wreq = wr_req_d0;
+        wr_ack_int = b1_r3_wack;
+      end
+    2'b10:
+      begin
+        // Reg b2_r3
+        b2_r3_wreq = wr_req_d0;
+        wr_ack_int = b2_r3_wack;
+      end
+    default:
+      wr_ack_int = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always @(wb_adr_i, rd_req_int, b1_r2_f1_reg, b1_r2_f2_reg, b1_b11_r3_f1_reg, b1_b11_r3_f2_reg, b2_r3_f1_reg)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    case (wb_adr_i[3:2])
+    2'b00:
+      begin
+        // Reg b1_r2
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0[2:0] = b1_r2_f1_reg;
+        rd_dat_d0[3] = 1'b0;
+        rd_dat_d0[4] = b1_r2_f2_reg;
+        rd_dat_d0[31:5] = 27'b0;
+      end
+    2'b01:
+      begin
+        // Reg b1_r3
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0[2:0] = b1_b11_r3_f1_reg;
+        rd_dat_d0[3] = 1'b0;
+        rd_dat_d0[4] = b1_b11_r3_f2_reg;
+        rd_dat_d0[31:5] = 27'b0;
+      end
+    2'b10:
+      begin
+        // Reg b2_r3
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0[2:0] = b2_r3_f1_reg;
+        rd_dat_d0[31:3] = 29'b0;
+      end
+    default:
+      rd_ack_d0 = rd_req_int;
+    endcase
+  end
+endmodule

--- a/testfiles/features/blkprefix4.sv
+++ b/testfiles/features/blkprefix4.sv
@@ -72,11 +72,11 @@ module blkprefix4
   reg [31:0] wr_dat_d0;
 
   // WB decode signals
-  always @(wb_sel_i)
+  always_comb
   ;
   assign wb_en = wb_cyc_i & wb_stb_i;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_rip <= 1'b0;
@@ -85,7 +85,7 @@ module blkprefix4
   end
   assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_wip <= 1'b0;
@@ -101,7 +101,7 @@ module blkprefix4
   assign wb_err_o = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -123,7 +123,7 @@ module blkprefix4
 
   // Register r5
   assign r5_o = r5_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -140,7 +140,7 @@ module blkprefix4
 
   // Register sub1_r1
   assign sub1_r1_o = blk_sub1_r1_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -157,7 +157,7 @@ module blkprefix4
 
   // Register sub1_b1_r2
   assign sub1_b1_r2_o = blk_sub1_b1_r2_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -174,7 +174,7 @@ module blkprefix4
 
   // Register sub1_b2_r3
   assign sub1_b2_r3_o = blk_sub1_b2_r3_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -191,7 +191,7 @@ module blkprefix4
 
   // Register sub2_r1
   assign sub2_r1_o = blk_sub2_r1_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -208,7 +208,7 @@ module blkprefix4
 
   // Register sub2_b1_r2
   assign sub2_b1_r2_o = blk_sub2_b1_r2_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -225,7 +225,7 @@ module blkprefix4
 
   // Register sub2_b2_r3
   assign sub2_b2_r3_o = blk_sub2_b2_r3_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -241,113 +241,113 @@ module blkprefix4
   end
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0, r5_wack, sub1_r1_wack, sub1_b1_r2_wack, sub1_b2_r3_wack, sub2_r1_wack, sub2_b1_r2_wack, sub2_b2_r3_wack)
+  always_comb
   begin
-    r5_wreq <= 1'b0;
-    sub1_r1_wreq <= 1'b0;
-    sub1_b1_r2_wreq <= 1'b0;
-    sub1_b2_r3_wreq <= 1'b0;
-    sub2_r1_wreq <= 1'b0;
-    sub2_b1_r2_wreq <= 1'b0;
-    sub2_b2_r3_wreq <= 1'b0;
+    r5_wreq = 1'b0;
+    sub1_r1_wreq = 1'b0;
+    sub1_b1_r2_wreq = 1'b0;
+    sub1_b2_r3_wreq = 1'b0;
+    sub2_r1_wreq = 1'b0;
+    sub2_b1_r2_wreq = 1'b0;
+    sub2_b2_r3_wreq = 1'b0;
     case (wr_adr_d0[5:2])
     4'b0000:
       begin
         // Reg r5
-        r5_wreq <= wr_req_d0;
-        wr_ack_int <= r5_wack;
+        r5_wreq = wr_req_d0;
+        wr_ack_int = r5_wack;
       end
     4'b1000:
       begin
         // Reg sub1_r1
-        sub1_r1_wreq <= wr_req_d0;
-        wr_ack_int <= sub1_r1_wack;
+        sub1_r1_wreq = wr_req_d0;
+        wr_ack_int = sub1_r1_wack;
       end
     4'b1001:
       begin
         // Reg sub1_b1_r2
-        sub1_b1_r2_wreq <= wr_req_d0;
-        wr_ack_int <= sub1_b1_r2_wack;
+        sub1_b1_r2_wreq = wr_req_d0;
+        wr_ack_int = sub1_b1_r2_wack;
       end
     4'b1010:
       begin
         // Reg sub1_b2_r3
-        sub1_b2_r3_wreq <= wr_req_d0;
-        wr_ack_int <= sub1_b2_r3_wack;
+        sub1_b2_r3_wreq = wr_req_d0;
+        wr_ack_int = sub1_b2_r3_wack;
       end
     4'b1100:
       begin
         // Reg sub2_r1
-        sub2_r1_wreq <= wr_req_d0;
-        wr_ack_int <= sub2_r1_wack;
+        sub2_r1_wreq = wr_req_d0;
+        wr_ack_int = sub2_r1_wack;
       end
     4'b1101:
       begin
         // Reg sub2_b1_r2
-        sub2_b1_r2_wreq <= wr_req_d0;
-        wr_ack_int <= sub2_b1_r2_wack;
+        sub2_b1_r2_wreq = wr_req_d0;
+        wr_ack_int = sub2_b1_r2_wack;
       end
     4'b1110:
       begin
         // Reg sub2_b2_r3
-        sub2_b2_r3_wreq <= wr_req_d0;
-        wr_ack_int <= sub2_b2_r3_wack;
+        sub2_b2_r3_wreq = wr_req_d0;
+        wr_ack_int = sub2_b2_r3_wack;
       end
     default:
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     endcase
   end
 
   // Process for read requests.
-  always @(wb_adr_i, rd_req_int, r5_reg, blk_sub1_r1_reg, blk_sub1_b1_r2_reg, blk_sub1_b2_r3_reg, blk_sub2_r1_reg, blk_sub2_b1_r2_reg, blk_sub2_b2_r3_reg)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     case (wb_adr_i[5:2])
     4'b0000:
       begin
         // Reg r5
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0 <= r5_reg;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = r5_reg;
       end
     4'b1000:
       begin
         // Reg sub1_r1
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0 <= blk_sub1_r1_reg;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = blk_sub1_r1_reg;
       end
     4'b1001:
       begin
         // Reg sub1_b1_r2
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0 <= blk_sub1_b1_r2_reg;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = blk_sub1_b1_r2_reg;
       end
     4'b1010:
       begin
         // Reg sub1_b2_r3
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0 <= blk_sub1_b2_r3_reg;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = blk_sub1_b2_r3_reg;
       end
     4'b1100:
       begin
         // Reg sub2_r1
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0 <= blk_sub2_r1_reg;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = blk_sub2_r1_reg;
       end
     4'b1101:
       begin
         // Reg sub2_b1_r2
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0 <= blk_sub2_b1_r2_reg;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = blk_sub2_b1_r2_reg;
       end
     4'b1110:
       begin
         // Reg sub2_b2_r3
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0 <= blk_sub2_b2_r3_reg;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = blk_sub2_b2_r3_reg;
       end
     default:
-      rd_ack_d0 <= rd_req_int;
+      rd_ack_d0 = rd_req_int;
     endcase
   end
 endmodule

--- a/testfiles/features/blkprefix4.v
+++ b/testfiles/features/blkprefix4.v
@@ -1,0 +1,353 @@
+
+module blkprefix4
+  (
+    input   wire rst_n_i,
+    input   wire clk_i,
+    input   wire wb_cyc_i,
+    input   wire wb_stb_i,
+    input   wire [5:2] wb_adr_i,
+    input   wire [3:0] wb_sel_i,
+    input   wire wb_we_i,
+    input   wire [31:0] wb_dat_i,
+    output  wire wb_ack_o,
+    output  wire wb_err_o,
+    output  wire wb_rty_o,
+    output  wire wb_stall_o,
+    output  reg [31:0] wb_dat_o,
+
+    // REG r5
+    output  wire [31:0] r5_o,
+
+    // REG r1
+    output  wire [31:0] sub1_r1_o,
+
+    // REG r2
+    output  wire [31:0] sub1_b1_r2_o,
+
+    // REG r3
+    output  wire [31:0] sub1_b2_r3_o,
+
+    // REG r1
+    output  wire [31:0] sub2_r1_o,
+
+    // REG r2
+    output  wire [31:0] sub2_b1_r2_o,
+
+    // REG r3
+    output  wire [31:0] sub2_b2_r3_o
+  );
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg [31:0] r5_reg;
+  reg r5_wreq;
+  reg r5_wack;
+  reg [31:0] blk_sub1_r1_reg;
+  reg sub1_r1_wreq;
+  reg sub1_r1_wack;
+  reg [31:0] blk_sub1_b1_r2_reg;
+  reg sub1_b1_r2_wreq;
+  reg sub1_b1_r2_wack;
+  reg [31:0] blk_sub1_b2_r3_reg;
+  reg sub1_b2_r3_wreq;
+  reg sub1_b2_r3_wack;
+  reg [31:0] blk_sub2_r1_reg;
+  reg sub2_r1_wreq;
+  reg sub2_r1_wack;
+  reg [31:0] blk_sub2_b1_r2_reg;
+  reg sub2_b1_r2_wreq;
+  reg sub2_b1_r2_wack;
+  reg [31:0] blk_sub2_b2_r3_reg;
+  reg sub2_b2_r3_wreq;
+  reg sub2_b2_r3_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [5:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+
+  // WB decode signals
+  always @(wb_sel_i)
+  ;
+  assign wb_en = wb_cyc_i & wb_stb_i;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb_we_i)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb_we_i)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb_we_i) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb_ack_o = ack_int;
+  assign wb_stall_o = ~ack_int & wb_en;
+  assign wb_rty_o = 1'b0;
+  assign wb_err_o = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        rd_ack_int <= 1'b0;
+        wb_dat_o <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 4'b0000;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb_dat_o <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_adr_d0 <= wb_adr_i;
+        wr_dat_d0 <= wb_dat_i;
+      end
+  end
+
+  // Register r5
+  assign r5_o = r5_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        r5_reg <= 32'b00000000000000000000000000000000;
+        r5_wack <= 1'b0;
+      end
+    else
+      begin
+        if (r5_wreq == 1'b1)
+          r5_reg <= wr_dat_d0;
+        r5_wack <= r5_wreq;
+      end
+  end
+
+  // Register sub1_r1
+  assign sub1_r1_o = blk_sub1_r1_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        blk_sub1_r1_reg <= 32'b00000000000000000000000000000000;
+        sub1_r1_wack <= 1'b0;
+      end
+    else
+      begin
+        if (sub1_r1_wreq == 1'b1)
+          blk_sub1_r1_reg <= wr_dat_d0;
+        sub1_r1_wack <= sub1_r1_wreq;
+      end
+  end
+
+  // Register sub1_b1_r2
+  assign sub1_b1_r2_o = blk_sub1_b1_r2_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        blk_sub1_b1_r2_reg <= 32'b00000000000000000000000000000000;
+        sub1_b1_r2_wack <= 1'b0;
+      end
+    else
+      begin
+        if (sub1_b1_r2_wreq == 1'b1)
+          blk_sub1_b1_r2_reg <= wr_dat_d0;
+        sub1_b1_r2_wack <= sub1_b1_r2_wreq;
+      end
+  end
+
+  // Register sub1_b2_r3
+  assign sub1_b2_r3_o = blk_sub1_b2_r3_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        blk_sub1_b2_r3_reg <= 32'b00000000000000000000000000000000;
+        sub1_b2_r3_wack <= 1'b0;
+      end
+    else
+      begin
+        if (sub1_b2_r3_wreq == 1'b1)
+          blk_sub1_b2_r3_reg <= wr_dat_d0;
+        sub1_b2_r3_wack <= sub1_b2_r3_wreq;
+      end
+  end
+
+  // Register sub2_r1
+  assign sub2_r1_o = blk_sub2_r1_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        blk_sub2_r1_reg <= 32'b00000000000000000000000000000000;
+        sub2_r1_wack <= 1'b0;
+      end
+    else
+      begin
+        if (sub2_r1_wreq == 1'b1)
+          blk_sub2_r1_reg <= wr_dat_d0;
+        sub2_r1_wack <= sub2_r1_wreq;
+      end
+  end
+
+  // Register sub2_b1_r2
+  assign sub2_b1_r2_o = blk_sub2_b1_r2_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        blk_sub2_b1_r2_reg <= 32'b00000000000000000000000000000000;
+        sub2_b1_r2_wack <= 1'b0;
+      end
+    else
+      begin
+        if (sub2_b1_r2_wreq == 1'b1)
+          blk_sub2_b1_r2_reg <= wr_dat_d0;
+        sub2_b1_r2_wack <= sub2_b1_r2_wreq;
+      end
+  end
+
+  // Register sub2_b2_r3
+  assign sub2_b2_r3_o = blk_sub2_b2_r3_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        blk_sub2_b2_r3_reg <= 32'b00000000000000000000000000000000;
+        sub2_b2_r3_wack <= 1'b0;
+      end
+    else
+      begin
+        if (sub2_b2_r3_wreq == 1'b1)
+          blk_sub2_b2_r3_reg <= wr_dat_d0;
+        sub2_b2_r3_wack <= sub2_b2_r3_wreq;
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, r5_wack, sub1_r1_wack, sub1_b1_r2_wack, sub1_b2_r3_wack, sub2_r1_wack, sub2_b1_r2_wack, sub2_b2_r3_wack)
+  begin
+    r5_wreq = 1'b0;
+    sub1_r1_wreq = 1'b0;
+    sub1_b1_r2_wreq = 1'b0;
+    sub1_b2_r3_wreq = 1'b0;
+    sub2_r1_wreq = 1'b0;
+    sub2_b1_r2_wreq = 1'b0;
+    sub2_b2_r3_wreq = 1'b0;
+    case (wr_adr_d0[5:2])
+    4'b0000:
+      begin
+        // Reg r5
+        r5_wreq = wr_req_d0;
+        wr_ack_int = r5_wack;
+      end
+    4'b1000:
+      begin
+        // Reg sub1_r1
+        sub1_r1_wreq = wr_req_d0;
+        wr_ack_int = sub1_r1_wack;
+      end
+    4'b1001:
+      begin
+        // Reg sub1_b1_r2
+        sub1_b1_r2_wreq = wr_req_d0;
+        wr_ack_int = sub1_b1_r2_wack;
+      end
+    4'b1010:
+      begin
+        // Reg sub1_b2_r3
+        sub1_b2_r3_wreq = wr_req_d0;
+        wr_ack_int = sub1_b2_r3_wack;
+      end
+    4'b1100:
+      begin
+        // Reg sub2_r1
+        sub2_r1_wreq = wr_req_d0;
+        wr_ack_int = sub2_r1_wack;
+      end
+    4'b1101:
+      begin
+        // Reg sub2_b1_r2
+        sub2_b1_r2_wreq = wr_req_d0;
+        wr_ack_int = sub2_b1_r2_wack;
+      end
+    4'b1110:
+      begin
+        // Reg sub2_b2_r3
+        sub2_b2_r3_wreq = wr_req_d0;
+        wr_ack_int = sub2_b2_r3_wack;
+      end
+    default:
+      wr_ack_int = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always @(wb_adr_i, rd_req_int, r5_reg, blk_sub1_r1_reg, blk_sub1_b1_r2_reg, blk_sub1_b2_r3_reg, blk_sub2_r1_reg, blk_sub2_b1_r2_reg, blk_sub2_b2_r3_reg)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    case (wb_adr_i[5:2])
+    4'b0000:
+      begin
+        // Reg r5
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = r5_reg;
+      end
+    4'b1000:
+      begin
+        // Reg sub1_r1
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = blk_sub1_r1_reg;
+      end
+    4'b1001:
+      begin
+        // Reg sub1_b1_r2
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = blk_sub1_b1_r2_reg;
+      end
+    4'b1010:
+      begin
+        // Reg sub1_b2_r3
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = blk_sub1_b2_r3_reg;
+      end
+    4'b1100:
+      begin
+        // Reg sub2_r1
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = blk_sub2_r1_reg;
+      end
+    4'b1101:
+      begin
+        // Reg sub2_b1_r2
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = blk_sub2_b1_r2_reg;
+      end
+    4'b1110:
+      begin
+        // Reg sub2_b2_r3
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = blk_sub2_b2_r3_reg;
+      end
+    default:
+      rd_ack_d0 = rd_req_int;
+    endcase
+  end
+endmodule

--- a/testfiles/features/enums1.sv
+++ b/testfiles/features/enums1.sv
@@ -34,11 +34,11 @@ module enums1
   reg [31:0] wr_dat_d0;
 
   // WB decode signals
-  always @(wb_sel_i)
+  always_comb
   ;
   assign wb_en = wb_cyc_i & wb_stb_i;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_rip <= 1'b0;
@@ -47,7 +47,7 @@ module enums1
   end
   assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_wip <= 1'b0;
@@ -63,7 +63,7 @@ module enums1
   assign wb_err_o = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -83,7 +83,7 @@ module enums1
 
   // Register r1
   assign r1_o = r1_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -99,21 +99,21 @@ module enums1
   end
 
   // Process for write requests.
-  always @(wr_req_d0, r1_wack)
+  always_comb
   begin
-    r1_wreq <= 1'b0;
+    r1_wreq = 1'b0;
     // Reg r1
-    r1_wreq <= wr_req_d0;
-    wr_ack_int <= r1_wack;
+    r1_wreq = wr_req_d0;
+    wr_ack_int = r1_wack;
   end
 
   // Process for read requests.
-  always @(rd_req_int, r1_reg)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     // Reg r1
-    rd_ack_d0 <= rd_req_int;
-    rd_dat_d0 <= r1_reg;
+    rd_ack_d0 = rd_req_int;
+    rd_dat_d0 = r1_reg;
   end
 endmodule

--- a/testfiles/features/enums1.v
+++ b/testfiles/features/enums1.v
@@ -1,0 +1,119 @@
+
+module enums1
+  (
+    input   wire rst_n_i,
+    input   wire clk_i,
+    input   wire wb_cyc_i,
+    input   wire wb_stb_i,
+    input   wire [3:0] wb_sel_i,
+    input   wire wb_we_i,
+    input   wire [31:0] wb_dat_i,
+    output  wire wb_ack_o,
+    output  wire wb_err_o,
+    output  wire wb_rty_o,
+    output  wire wb_stall_o,
+    output  reg [31:0] wb_dat_o,
+
+    // REG r1
+    output  wire [31:0] r1_o
+  );
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg [31:0] r1_reg;
+  reg r1_wreq;
+  reg r1_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [31:0] wr_dat_d0;
+
+  // WB decode signals
+  always @(wb_sel_i)
+  ;
+  assign wb_en = wb_cyc_i & wb_stb_i;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb_we_i)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb_we_i)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb_we_i) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb_ack_o = ack_int;
+  assign wb_stall_o = ~ack_int & wb_en;
+  assign wb_rty_o = 1'b0;
+  assign wb_err_o = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        rd_ack_int <= 1'b0;
+        wb_dat_o <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb_dat_o <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_dat_d0 <= wb_dat_i;
+      end
+  end
+
+  // Register r1
+  assign r1_o = r1_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        r1_reg <= 32'b00000000000000000000000000000000;
+        r1_wack <= 1'b0;
+      end
+    else
+      begin
+        if (r1_wreq == 1'b1)
+          r1_reg <= wr_dat_d0;
+        r1_wack <= r1_wreq;
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_req_d0, r1_wack)
+  begin
+    r1_wreq = 1'b0;
+    // Reg r1
+    r1_wreq = wr_req_d0;
+    wr_ack_int = r1_wack;
+  end
+
+  // Process for read requests.
+  always @(rd_req_int, r1_reg)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    // Reg r1
+    rd_ack_d0 = rd_req_int;
+    rd_dat_d0 = r1_reg;
+  end
+endmodule

--- a/testfiles/features/enums2.sv
+++ b/testfiles/features/enums2.sv
@@ -34,11 +34,11 @@ module enums2
   reg [31:0] wr_dat_d0;
 
   // WB decode signals
-  always @(wb_sel_i)
+  always_comb
   ;
   assign wb_en = wb_cyc_i & wb_stb_i;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_rip <= 1'b0;
@@ -47,7 +47,7 @@ module enums2
   end
   assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_wip <= 1'b0;
@@ -63,7 +63,7 @@ module enums2
   assign wb_err_o = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -83,7 +83,7 @@ module enums2
 
   // Register r1
   assign r1_f1_o = r1_f1_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -99,22 +99,22 @@ module enums2
   end
 
   // Process for write requests.
-  always @(wr_req_d0, r1_wack)
+  always_comb
   begin
-    r1_wreq <= 1'b0;
+    r1_wreq = 1'b0;
     // Reg r1
-    r1_wreq <= wr_req_d0;
-    wr_ack_int <= r1_wack;
+    r1_wreq = wr_req_d0;
+    wr_ack_int = r1_wack;
   end
 
   // Process for read requests.
-  always @(rd_req_int, r1_f1_reg)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     // Reg r1
-    rd_ack_d0 <= rd_req_int;
-    rd_dat_d0[7:0] <= r1_f1_reg;
-    rd_dat_d0[31:8] <= 24'b0;
+    rd_ack_d0 = rd_req_int;
+    rd_dat_d0[7:0] = r1_f1_reg;
+    rd_dat_d0[31:8] = 24'b0;
   end
 endmodule

--- a/testfiles/features/enums2.v
+++ b/testfiles/features/enums2.v
@@ -1,0 +1,120 @@
+
+module enums2
+  (
+    input   wire rst_n_i,
+    input   wire clk_i,
+    input   wire wb_cyc_i,
+    input   wire wb_stb_i,
+    input   wire [3:0] wb_sel_i,
+    input   wire wb_we_i,
+    input   wire [31:0] wb_dat_i,
+    output  wire wb_ack_o,
+    output  wire wb_err_o,
+    output  wire wb_rty_o,
+    output  wire wb_stall_o,
+    output  reg [31:0] wb_dat_o,
+
+    // REG r1
+    output  wire [7:0] r1_f1_o
+  );
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg [7:0] r1_f1_reg;
+  reg r1_wreq;
+  reg r1_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [31:0] wr_dat_d0;
+
+  // WB decode signals
+  always @(wb_sel_i)
+  ;
+  assign wb_en = wb_cyc_i & wb_stb_i;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb_we_i)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb_we_i)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb_we_i) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb_ack_o = ack_int;
+  assign wb_stall_o = ~ack_int & wb_en;
+  assign wb_rty_o = 1'b0;
+  assign wb_err_o = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        rd_ack_int <= 1'b0;
+        wb_dat_o <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb_dat_o <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_dat_d0 <= wb_dat_i;
+      end
+  end
+
+  // Register r1
+  assign r1_f1_o = r1_f1_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        r1_f1_reg <= 8'b00000000;
+        r1_wack <= 1'b0;
+      end
+    else
+      begin
+        if (r1_wreq == 1'b1)
+          r1_f1_reg <= wr_dat_d0[7:0];
+        r1_wack <= r1_wreq;
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_req_d0, r1_wack)
+  begin
+    r1_wreq = 1'b0;
+    // Reg r1
+    r1_wreq = wr_req_d0;
+    wr_ack_int = r1_wack;
+  end
+
+  // Process for read requests.
+  always @(rd_req_int, r1_f1_reg)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    // Reg r1
+    rd_ack_d0 = rd_req_int;
+    rd_dat_d0[7:0] = r1_f1_reg;
+    rd_dat_d0[31:8] = 24'b0;
+  end
+endmodule

--- a/testfiles/features/iogroup1.sv
+++ b/testfiles/features/iogroup1.sv
@@ -76,11 +76,11 @@ module iogroup1
   reg [31:0] wr_dat_d0;
 
   // WB decode signals
-  always @(wb_sel_i)
+  always_comb
   ;
   assign wb_en = wb_cyc_i & wb_stb_i;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_rip <= 1'b0;
@@ -89,7 +89,7 @@ module iogroup1
   end
   assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_wip <= 1'b0;
@@ -105,7 +105,7 @@ module iogroup1
   assign wb_err_o = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -127,7 +127,7 @@ module iogroup1
 
   // Register areg1
   assign ios.areg1 = areg1_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -146,7 +146,7 @@ module iogroup1
 
   // Register areg3
   assign ios.areg3 = areg3_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -167,69 +167,69 @@ module iogroup1
   assign ios.areg4_wr = areg4_wreq;
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0, areg1_wack, areg3_wack, ios.areg4_wack)
+  always_comb
   begin
-    areg1_wreq <= 1'b0;
-    areg3_wreq <= 1'b0;
-    areg4_wreq <= 1'b0;
+    areg1_wreq = 1'b0;
+    areg3_wreq = 1'b0;
+    areg4_wreq = 1'b0;
     case (wr_adr_d0[3:2])
     2'b00:
       begin
         // Reg areg1
-        areg1_wreq <= wr_req_d0;
-        wr_ack_int <= areg1_wack;
+        areg1_wreq = wr_req_d0;
+        wr_ack_int = areg1_wack;
       end
     2'b01:
       // Reg areg2
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     2'b10:
       begin
         // Reg areg3
-        areg3_wreq <= wr_req_d0;
-        wr_ack_int <= areg3_wack;
+        areg3_wreq = wr_req_d0;
+        wr_ack_int = areg3_wack;
       end
     2'b11:
       begin
         // Reg areg4
-        areg4_wreq <= wr_req_d0;
-        wr_ack_int <= ios.areg4_wack;
+        areg4_wreq = wr_req_d0;
+        wr_ack_int = ios.areg4_wack;
       end
     default:
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     endcase
   end
 
   // Process for read requests.
-  always @(wb_adr_i, rd_req_int, areg1_reg, ios.areg2, ios.areg4_rack, ios.areg4i)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
-    ios.areg4_rd <= 1'b0;
+    rd_dat_d0 = {32{1'bx}};
+    ios.areg4_rd = 1'b0;
     case (wb_adr_i[3:2])
     2'b00:
       begin
         // Reg areg1
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0 <= areg1_reg;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = areg1_reg;
       end
     2'b01:
       begin
         // Reg areg2
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0 <= ios.areg2;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = ios.areg2;
       end
     2'b10:
       // Reg areg3
-      rd_ack_d0 <= rd_req_int;
+      rd_ack_d0 = rd_req_int;
     2'b11:
       begin
         // Reg areg4
-        ios.areg4_rd <= rd_req_int;
-        rd_ack_d0 <= ios.areg4_rack;
-        rd_dat_d0 <= ios.areg4i;
+        ios.areg4_rd = rd_req_int;
+        rd_ack_d0 = ios.areg4_rack;
+        rd_dat_d0 = ios.areg4i;
       end
     default:
-      rd_ack_d0 <= rd_req_int;
+      rd_ack_d0 = rd_req_int;
     endcase
   end
 endmodule

--- a/testfiles/features/iogroup1.v
+++ b/testfiles/features/iogroup1.v
@@ -1,0 +1,235 @@
+interface t_ios;
+  logic [31:0] areg1;
+  logic [31:0] areg2;
+  logic [31:0] areg3;
+  logic areg3_wr;
+  logic [31:0] areg4i;
+  logic [31:0] areg4o;
+  logic areg4_wr;
+  logic areg4_rd;
+  logic areg4_wack;
+  logic areg4_rack;
+  modport master(
+    input areg2,
+    input areg4i,
+    input areg4_wack,
+    input areg4_rack,
+    output areg1,
+    output areg3,
+    output areg3_wr,
+    output areg4o,
+    output areg4_wr,
+    output areg4_rd
+  );
+  modport slave(
+    output areg2,
+    output areg4i,
+    output areg4_wack,
+    output areg4_rack,
+    input areg1,
+    input areg3,
+    input areg3_wr,
+    input areg4o,
+    input areg4_wr,
+    input areg4_rd
+  );
+endinterface
+
+
+module iogroup1
+  (
+    input   wire rst_n_i,
+    input   wire clk_i,
+    input   wire wb_cyc_i,
+    input   wire wb_stb_i,
+    input   wire [3:2] wb_adr_i,
+    input   wire [3:0] wb_sel_i,
+    input   wire wb_we_i,
+    input   wire [31:0] wb_dat_i,
+    output  wire wb_ack_o,
+    output  wire wb_err_o,
+    output  wire wb_rty_o,
+    output  wire wb_stall_o,
+    output  reg [31:0] wb_dat_o,
+    // Wires and registers
+    t_ios.master ios
+  );
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg [31:0] areg1_reg;
+  reg areg1_wreq;
+  reg areg1_wack;
+  reg [31:0] areg3_reg;
+  reg areg3_wreq;
+  reg areg3_wack;
+  reg areg4_wreq;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [3:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+
+  // WB decode signals
+  always @(wb_sel_i)
+  ;
+  assign wb_en = wb_cyc_i & wb_stb_i;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb_we_i)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb_we_i)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb_we_i) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb_ack_o = ack_int;
+  assign wb_stall_o = ~ack_int & wb_en;
+  assign wb_rty_o = 1'b0;
+  assign wb_err_o = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        rd_ack_int <= 1'b0;
+        wb_dat_o <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 2'b00;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb_dat_o <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_adr_d0 <= wb_adr_i;
+        wr_dat_d0 <= wb_dat_i;
+      end
+  end
+
+  // Register areg1
+  assign ios.areg1 = areg1_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        areg1_reg <= 32'b00000000000000000000000000000000;
+        areg1_wack <= 1'b0;
+      end
+    else
+      begin
+        if (areg1_wreq == 1'b1)
+          areg1_reg <= wr_dat_d0;
+        areg1_wack <= areg1_wreq;
+      end
+  end
+
+  // Register areg2
+
+  // Register areg3
+  assign ios.areg3 = areg3_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        areg3_reg <= 32'b00000000000000000000000000000000;
+        areg3_wack <= 1'b0;
+      end
+    else
+      begin
+        if (areg3_wreq == 1'b1)
+          areg3_reg <= wr_dat_d0;
+        areg3_wack <= areg3_wreq;
+      end
+  end
+  assign ios.areg3_wr = areg3_wack;
+
+  // Register areg4
+  assign ios.areg4o = wr_dat_d0;
+  assign ios.areg4_wr = areg4_wreq;
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, areg1_wack, areg3_wack, ios.areg4_wack)
+  begin
+    areg1_wreq = 1'b0;
+    areg3_wreq = 1'b0;
+    areg4_wreq = 1'b0;
+    case (wr_adr_d0[3:2])
+    2'b00:
+      begin
+        // Reg areg1
+        areg1_wreq = wr_req_d0;
+        wr_ack_int = areg1_wack;
+      end
+    2'b01:
+      // Reg areg2
+      wr_ack_int = wr_req_d0;
+    2'b10:
+      begin
+        // Reg areg3
+        areg3_wreq = wr_req_d0;
+        wr_ack_int = areg3_wack;
+      end
+    2'b11:
+      begin
+        // Reg areg4
+        areg4_wreq = wr_req_d0;
+        wr_ack_int = ios.areg4_wack;
+      end
+    default:
+      wr_ack_int = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always @(wb_adr_i, rd_req_int, areg1_reg, ios.areg2, ios.areg4_rack, ios.areg4i)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    ios.areg4_rd = 1'b0;
+    case (wb_adr_i[3:2])
+    2'b00:
+      begin
+        // Reg areg1
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = areg1_reg;
+      end
+    2'b01:
+      begin
+        // Reg areg2
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = ios.areg2;
+      end
+    2'b10:
+      // Reg areg3
+      rd_ack_d0 = rd_req_int;
+    2'b11:
+      begin
+        // Reg areg4
+        ios.areg4_rd = rd_req_int;
+        rd_ack_d0 = ios.areg4_rack;
+        rd_dat_d0 = ios.areg4i;
+      end
+    default:
+      rd_ack_d0 = rd_req_int;
+    endcase
+  end
+endmodule

--- a/testfiles/features/iogroup2.sv
+++ b/testfiles/features/iogroup2.sv
@@ -50,11 +50,11 @@ module igroup2
   reg [31:0] wr_dat_d0;
 
   // WB decode signals
-  always @(wb_sel_i)
+  always_comb
   ;
   assign wb_en = wb_cyc_i & wb_stb_i;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_rip <= 1'b0;
@@ -63,7 +63,7 @@ module igroup2
   end
   assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_wip <= 1'b0;
@@ -79,7 +79,7 @@ module igroup2
   assign wb_err_o = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -101,7 +101,7 @@ module igroup2
 
   // Register areg
   assign areg_o = areg_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -118,7 +118,7 @@ module igroup2
 
   // Register blk_breg
   assign blk.breg = blk_breg_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -134,48 +134,48 @@ module igroup2
   end
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0, areg_wack, blk_breg_wack)
+  always_comb
   begin
-    areg_wreq <= 1'b0;
-    blk_breg_wreq <= 1'b0;
+    areg_wreq = 1'b0;
+    blk_breg_wreq = 1'b0;
     case (wr_adr_d0[2:2])
     1'b0:
       begin
         // Reg areg
-        areg_wreq <= wr_req_d0;
-        wr_ack_int <= areg_wack;
+        areg_wreq = wr_req_d0;
+        wr_ack_int = areg_wack;
       end
     1'b1:
       begin
         // Reg blk_breg
-        blk_breg_wreq <= wr_req_d0;
-        wr_ack_int <= blk_breg_wack;
+        blk_breg_wreq = wr_req_d0;
+        wr_ack_int = blk_breg_wack;
       end
     default:
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     endcase
   end
 
   // Process for read requests.
-  always @(wb_adr_i, rd_req_int, areg_reg, blk_breg_reg)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     case (wb_adr_i[2:2])
     1'b0:
       begin
         // Reg areg
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0 <= areg_reg;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = areg_reg;
       end
     1'b1:
       begin
         // Reg blk_breg
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0 <= blk_breg_reg;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = blk_breg_reg;
       end
     default:
-      rd_ack_d0 <= rd_req_int;
+      rd_ack_d0 = rd_req_int;
     endcase
   end
 endmodule

--- a/testfiles/features/iogroup2.v
+++ b/testfiles/features/iogroup2.v
@@ -1,0 +1,181 @@
+interface t_blk;
+  logic [31:0] breg;
+  modport master(
+    output breg
+  );
+  modport slave(
+    input breg
+  );
+endinterface
+
+
+module igroup2
+  (
+    input   wire rst_n_i,
+    input   wire clk_i,
+    input   wire wb_cyc_i,
+    input   wire wb_stb_i,
+    input   wire [2:2] wb_adr_i,
+    input   wire [3:0] wb_sel_i,
+    input   wire wb_we_i,
+    input   wire [31:0] wb_dat_i,
+    output  wire wb_ack_o,
+    output  wire wb_err_o,
+    output  wire wb_rty_o,
+    output  wire wb_stall_o,
+    output  reg [31:0] wb_dat_o,
+
+    // REG areg
+    output  wire [31:0] areg_o,
+    t_blk.master blk
+  );
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg [31:0] areg_reg;
+  reg areg_wreq;
+  reg areg_wack;
+  reg [31:0] blk_breg_reg;
+  reg blk_breg_wreq;
+  reg blk_breg_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [2:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+
+  // WB decode signals
+  always @(wb_sel_i)
+  ;
+  assign wb_en = wb_cyc_i & wb_stb_i;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb_we_i)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb_we_i)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb_we_i) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb_ack_o = ack_int;
+  assign wb_stall_o = ~ack_int & wb_en;
+  assign wb_rty_o = 1'b0;
+  assign wb_err_o = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        rd_ack_int <= 1'b0;
+        wb_dat_o <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 1'b0;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb_dat_o <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_adr_d0 <= wb_adr_i;
+        wr_dat_d0 <= wb_dat_i;
+      end
+  end
+
+  // Register areg
+  assign areg_o = areg_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        areg_reg <= 32'b00000000000000000000000000000000;
+        areg_wack <= 1'b0;
+      end
+    else
+      begin
+        if (areg_wreq == 1'b1)
+          areg_reg <= wr_dat_d0;
+        areg_wack <= areg_wreq;
+      end
+  end
+
+  // Register blk_breg
+  assign blk.breg = blk_breg_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        blk_breg_reg <= 32'b00000000000000000000000000000000;
+        blk_breg_wack <= 1'b0;
+      end
+    else
+      begin
+        if (blk_breg_wreq == 1'b1)
+          blk_breg_reg <= wr_dat_d0;
+        blk_breg_wack <= blk_breg_wreq;
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, areg_wack, blk_breg_wack)
+  begin
+    areg_wreq = 1'b0;
+    blk_breg_wreq = 1'b0;
+    case (wr_adr_d0[2:2])
+    1'b0:
+      begin
+        // Reg areg
+        areg_wreq = wr_req_d0;
+        wr_ack_int = areg_wack;
+      end
+    1'b1:
+      begin
+        // Reg blk_breg
+        blk_breg_wreq = wr_req_d0;
+        wr_ack_int = blk_breg_wack;
+      end
+    default:
+      wr_ack_int = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always @(wb_adr_i, rd_req_int, areg_reg, blk_breg_reg)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    case (wb_adr_i[2:2])
+    1'b0:
+      begin
+        // Reg areg
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = areg_reg;
+      end
+    1'b1:
+      begin
+        // Reg blk_breg
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = blk_breg_reg;
+      end
+    default:
+      rd_ack_d0 = rd_req_int;
+    endcase
+  end
+endmodule

--- a/testfiles/features/mapinfo2.sv
+++ b/testfiles/features/mapinfo2.sv
@@ -32,7 +32,7 @@ module mapinfo2
   assign VMEWrDone = wr_ack_int;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(Clk))
+  always_ff @(posedge(Clk))
   begin
     if (!rst_n)
       begin
@@ -54,7 +54,7 @@ module mapinfo2
 
   // Register test1
   assign test1_o = test1_reg;
-  always @(posedge(Clk))
+  always_ff @(posedge(Clk))
   begin
     if (!rst_n)
       begin
@@ -74,53 +74,53 @@ module mapinfo2
   // Register icode
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0, test1_wack)
+  always_comb
   begin
-    test1_wreq <= 1'b0;
+    test1_wreq = 1'b0;
     case (wr_adr_d0[19:2])
     18'b000000000000000000:
       begin
         // Reg test1
-        test1_wreq <= wr_req_d0;
-        wr_ack_int <= test1_wack;
+        test1_wreq = wr_req_d0;
+        wr_ack_int = test1_wack;
       end
     18'b000000000000000001:
       // Reg mapver
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     18'b000000000000000010:
       // Reg icode
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     default:
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     endcase
   end
 
   // Process for read requests.
-  always @(VMEAddr, VMERdMem, test1_reg)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     case (VMEAddr[19:2])
     18'b000000000000000000:
       begin
         // Reg test1
-        rd_ack_d0 <= VMERdMem;
-        rd_dat_d0 <= test1_reg;
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = test1_reg;
       end
     18'b000000000000000001:
       begin
         // Reg mapver
-        rd_ack_d0 <= VMERdMem;
-        rd_dat_d0 <= 32'b00000000000000010000001000000011;
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = 32'b00000000000000010000001000000011;
       end
     18'b000000000000000010:
       begin
         // Reg icode
-        rd_ack_d0 <= VMERdMem;
-        rd_dat_d0 <= 32'b00000000000000000000000000010001;
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = 32'b00000000000000000000000000010001;
       end
     default:
-      rd_ack_d0 <= VMERdMem;
+      rd_ack_d0 = VMERdMem;
     endcase
   end
 endmodule

--- a/testfiles/features/mapinfo2.v
+++ b/testfiles/features/mapinfo2.v
@@ -1,0 +1,126 @@
+
+module mapinfo2
+  (
+    input   wire Clk,
+    input   wire Rst,
+    input   wire [19:2] VMEAddr,
+    output  reg [31:0] VMERdData,
+    input   wire [31:0] VMEWrData,
+    input   wire VMERdMem,
+    input   wire VMEWrMem,
+    output  wire VMERdDone,
+    output  wire VMEWrDone,
+    output  wire VMERdError,
+    output  wire VMEWrError,
+
+    // REG test1
+    output  wire [31:0] test1_o
+  );
+  wire rst_n;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  reg [31:0] test1_reg;
+  reg test1_wreq;
+  reg test1_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [19:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+  assign rst_n = ~Rst;
+  assign VMERdDone = rd_ack_int;
+  assign VMEWrDone = wr_ack_int;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(Clk))
+  begin
+    if (!rst_n)
+      begin
+        rd_ack_int <= 1'b0;
+        VMERdData <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 18'b000000000000000000;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        VMERdData <= rd_dat_d0;
+        wr_req_d0 <= VMEWrMem;
+        wr_adr_d0 <= VMEAddr;
+        wr_dat_d0 <= VMEWrData;
+      end
+  end
+
+  // Register test1
+  assign test1_o = test1_reg;
+  always @(posedge(Clk))
+  begin
+    if (!rst_n)
+      begin
+        test1_reg <= 32'b00000000000000000000000000000000;
+        test1_wack <= 1'b0;
+      end
+    else
+      begin
+        if (test1_wreq == 1'b1)
+          test1_reg <= wr_dat_d0;
+        test1_wack <= test1_wreq;
+      end
+  end
+
+  // Register mapver
+
+  // Register icode
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, test1_wack)
+  begin
+    test1_wreq = 1'b0;
+    case (wr_adr_d0[19:2])
+    18'b000000000000000000:
+      begin
+        // Reg test1
+        test1_wreq = wr_req_d0;
+        wr_ack_int = test1_wack;
+      end
+    18'b000000000000000001:
+      // Reg mapver
+      wr_ack_int = wr_req_d0;
+    18'b000000000000000010:
+      // Reg icode
+      wr_ack_int = wr_req_d0;
+    default:
+      wr_ack_int = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always @(VMEAddr, VMERdMem, test1_reg)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    case (VMEAddr[19:2])
+    18'b000000000000000000:
+      begin
+        // Reg test1
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = test1_reg;
+      end
+    18'b000000000000000001:
+      begin
+        // Reg mapver
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = 32'b00000000000000010000001000000011;
+      end
+    18'b000000000000000010:
+      begin
+        // Reg icode
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = 32'b00000000000000000000000000010001;
+      end
+    default:
+      rd_ack_d0 = VMERdMem;
+    endcase
+  end
+endmodule

--- a/testfiles/features/mem64ro.sv
+++ b/testfiles/features/mem64ro.sv
@@ -54,16 +54,16 @@ module mem64ro
   reg [3:0] DdrCapturesIndex_1_sel_int;
 
   // WB decode signals
-  always @(wb_sel_i)
+  always_comb
   begin
-    wr_sel[7:0] <= {8{wb_sel_i[0]}};
-    wr_sel[15:8] <= {8{wb_sel_i[1]}};
-    wr_sel[23:16] <= {8{wb_sel_i[2]}};
-    wr_sel[31:24] <= {8{wb_sel_i[3]}};
+    wr_sel[7:0] = {8{wb_sel_i[0]}};
+    wr_sel[15:8] = {8{wb_sel_i[1]}};
+    wr_sel[23:16] = {8{wb_sel_i[2]}};
+    wr_sel[31:24] = {8{wb_sel_i[3]}};
   end
   assign wb_en = wb_cyc_i & wb_stb_i;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_rip <= 1'b0;
@@ -72,7 +72,7 @@ module mem64ro
   end
   assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_wip <= 1'b0;
@@ -88,7 +88,7 @@ module mem64ro
   assign wb_err_o = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -112,7 +112,7 @@ module mem64ro
 
   // Register regA
   assign regA_field0_o = regA_field0_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -152,17 +152,17 @@ module mem64ro
       .wr_b_i(DdrCapturesIndex_DdrCaptures_we_i)
     );
   
-  always @(wr_sel_d0)
+  always_comb
   begin
-    DdrCapturesIndex_0_sel_int <= 4'b0;
+    DdrCapturesIndex_0_sel_int = 4'b0;
     if (~(wr_sel_d0[7:0] == 8'b0))
-      DdrCapturesIndex_0_sel_int[0] <= 1'b1;
+      DdrCapturesIndex_0_sel_int[0] = 1'b1;
     if (~(wr_sel_d0[15:8] == 8'b0))
-      DdrCapturesIndex_0_sel_int[1] <= 1'b1;
+      DdrCapturesIndex_0_sel_int[1] = 1'b1;
     if (~(wr_sel_d0[23:16] == 8'b0))
-      DdrCapturesIndex_0_sel_int[2] <= 1'b1;
+      DdrCapturesIndex_0_sel_int[2] = 1'b1;
     if (~(wr_sel_d0[31:24] == 8'b0))
-      DdrCapturesIndex_0_sel_int[3] <= 1'b1;
+      DdrCapturesIndex_0_sel_int[3] = 1'b1;
   end
   cheby_dpssram #(
       .g_data_width(32),
@@ -188,19 +188,19 @@ module mem64ro
       .wr_b_i(DdrCapturesIndex_DdrCaptures_we_i)
     );
   
-  always @(wr_sel_d0)
+  always_comb
   begin
-    DdrCapturesIndex_1_sel_int <= 4'b0;
+    DdrCapturesIndex_1_sel_int = 4'b0;
     if (~(wr_sel_d0[7:0] == 8'b0))
-      DdrCapturesIndex_1_sel_int[0] <= 1'b1;
+      DdrCapturesIndex_1_sel_int[0] = 1'b1;
     if (~(wr_sel_d0[15:8] == 8'b0))
-      DdrCapturesIndex_1_sel_int[1] <= 1'b1;
+      DdrCapturesIndex_1_sel_int[1] = 1'b1;
     if (~(wr_sel_d0[23:16] == 8'b0))
-      DdrCapturesIndex_1_sel_int[2] <= 1'b1;
+      DdrCapturesIndex_1_sel_int[2] = 1'b1;
     if (~(wr_sel_d0[31:24] == 8'b0))
-      DdrCapturesIndex_1_sel_int[3] <= 1'b1;
+      DdrCapturesIndex_1_sel_int[3] = 1'b1;
   end
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -215,70 +215,70 @@ module mem64ro
   end
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0, regA_wack)
+  always_comb
   begin
-    regA_wreq <= 1'b0;
+    regA_wreq = 1'b0;
     case (wr_adr_d0[9:9])
     1'b0:
       case (wr_adr_d0[8:2])
       7'b0000000:
         begin
           // Reg regA
-          regA_wreq <= wr_req_d0;
-          wr_ack_int <= regA_wack;
+          regA_wreq = wr_req_d0;
+          wr_ack_int = regA_wack;
         end
       default:
-        wr_ack_int <= wr_req_d0;
+        wr_ack_int = wr_req_d0;
       endcase
     1'b1:
       // Memory DdrCapturesIndex
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     default:
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     endcase
   end
 
   // Process for read requests.
-  always @(wb_adr_i, rd_req_int, regA_field0_reg, DdrCapturesIndex_DdrCaptures_int_dato0, DdrCapturesIndex_DdrCaptures_rack0, DdrCapturesIndex_DdrCaptures_int_dato1, DdrCapturesIndex_DdrCaptures_rack1)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
-    DdrCapturesIndex_DdrCaptures_rreq0 <= 1'b0;
-    DdrCapturesIndex_DdrCaptures_rreq1 <= 1'b0;
+    rd_dat_d0 = {32{1'bx}};
+    DdrCapturesIndex_DdrCaptures_rreq0 = 1'b0;
+    DdrCapturesIndex_DdrCaptures_rreq1 = 1'b0;
     case (wb_adr_i[9:9])
     1'b0:
       case (wb_adr_i[8:2])
       7'b0000000:
         begin
           // Reg regA
-          rd_ack_d0 <= rd_req_int;
-          rd_dat_d0[0] <= 1'b0;
-          rd_dat_d0[1] <= regA_field0_reg;
-          rd_dat_d0[31:2] <= 30'b0;
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0[0] = 1'b0;
+          rd_dat_d0[1] = regA_field0_reg;
+          rd_dat_d0[31:2] = 30'b0;
         end
       default:
-        rd_ack_d0 <= rd_req_int;
+        rd_ack_d0 = rd_req_int;
       endcase
     1'b1:
       // Memory DdrCapturesIndex
       case (wb_adr_i[2:2])
       1'b0:
         begin
-          rd_dat_d0 <= DdrCapturesIndex_DdrCaptures_int_dato0;
-          DdrCapturesIndex_DdrCaptures_rreq0 <= rd_req_int;
-          rd_ack_d0 <= DdrCapturesIndex_DdrCaptures_rack0;
+          rd_dat_d0 = DdrCapturesIndex_DdrCaptures_int_dato0;
+          DdrCapturesIndex_DdrCaptures_rreq0 = rd_req_int;
+          rd_ack_d0 = DdrCapturesIndex_DdrCaptures_rack0;
         end
       1'b1:
         begin
-          rd_dat_d0 <= DdrCapturesIndex_DdrCaptures_int_dato1;
-          DdrCapturesIndex_DdrCaptures_rreq1 <= rd_req_int;
-          rd_ack_d0 <= DdrCapturesIndex_DdrCaptures_rack1;
+          rd_dat_d0 = DdrCapturesIndex_DdrCaptures_int_dato1;
+          DdrCapturesIndex_DdrCaptures_rreq1 = rd_req_int;
+          rd_ack_d0 = DdrCapturesIndex_DdrCaptures_rack1;
         end
       default:
         ;
       endcase
     default:
-      rd_ack_d0 <= rd_req_int;
+      rd_ack_d0 = rd_req_int;
     endcase
   end
 endmodule

--- a/testfiles/features/mem64ro.v
+++ b/testfiles/features/mem64ro.v
@@ -1,0 +1,284 @@
+
+module mem64ro
+  (
+    input   wire rst_n_i,
+    input   wire clk_i,
+    input   wire wb_cyc_i,
+    input   wire wb_stb_i,
+    input   wire [9:2] wb_adr_i,
+    input   wire [3:0] wb_sel_i,
+    input   wire wb_we_i,
+    input   wire [31:0] wb_dat_i,
+    output  wire wb_ack_o,
+    output  wire wb_err_o,
+    output  wire wb_rty_o,
+    output  wire wb_stall_o,
+    output  reg [31:0] wb_dat_o,
+
+    // The first register (with some fields)
+    // 1-bit field
+    output  wire regA_field0_o,
+
+    // RAM port for DdrCapturesIndex
+    input   wire [5:0] DdrCapturesIndex_adr_i,
+    input   wire DdrCapturesIndex_DdrCaptures_we_i,
+    input   wire [63:0] DdrCapturesIndex_DdrCaptures_dat_i
+  );
+  reg [31:0] wr_sel;
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg regA_field0_reg;
+  reg regA_wreq;
+  reg regA_wack;
+  wire [31:0] DdrCapturesIndex_DdrCaptures_int_dato0;
+  wire [31:0] DdrCapturesIndex_DdrCaptures_int_dato1;
+  wire [31:0] DdrCapturesIndex_DdrCaptures_ext_dat0;
+  wire [31:0] DdrCapturesIndex_DdrCaptures_ext_dat1;
+  reg DdrCapturesIndex_DdrCaptures_rreq0;
+  reg DdrCapturesIndex_DdrCaptures_rreq1;
+  reg DdrCapturesIndex_DdrCaptures_rack0;
+  reg DdrCapturesIndex_DdrCaptures_rack1;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [9:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+  reg [31:0] wr_sel_d0;
+  reg [3:0] DdrCapturesIndex_0_sel_int;
+  reg [3:0] DdrCapturesIndex_1_sel_int;
+
+  // WB decode signals
+  always @(wb_sel_i)
+  begin
+    wr_sel[7:0] = {8{wb_sel_i[0]}};
+    wr_sel[15:8] = {8{wb_sel_i[1]}};
+    wr_sel[23:16] = {8{wb_sel_i[2]}};
+    wr_sel[31:24] = {8{wb_sel_i[3]}};
+  end
+  assign wb_en = wb_cyc_i & wb_stb_i;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb_we_i)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb_we_i)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb_we_i) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb_ack_o = ack_int;
+  assign wb_stall_o = ~ack_int & wb_en;
+  assign wb_rty_o = 1'b0;
+  assign wb_err_o = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        rd_ack_int <= 1'b0;
+        wb_dat_o <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 8'b00000000;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+        wr_sel_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb_dat_o <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_adr_d0 <= wb_adr_i;
+        wr_dat_d0 <= wb_dat_i;
+        wr_sel_d0 <= wr_sel;
+      end
+  end
+
+  // Register regA
+  assign regA_field0_o = regA_field0_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        regA_field0_reg <= 1'b0;
+        regA_wack <= 1'b0;
+      end
+    else
+      begin
+        if (regA_wreq == 1'b1)
+          regA_field0_reg <= wr_dat_d0[1];
+        regA_wack <= regA_wreq;
+      end
+  end
+
+  // Memory DdrCapturesIndex
+  cheby_dpssram #(
+      .g_data_width(32),
+      .g_size(64),
+      .g_addr_width(6),
+      .g_dual_clock(1'b0),
+      .g_use_bwsel(1'b1)
+    )
+  DdrCapturesIndex_DdrCaptures_raminst0 (
+      .clk_a_i(clk_i),
+      .clk_b_i(clk_i),
+      .addr_a_i(wb_adr_i[8:3]),
+      .bwsel_a_i(DdrCapturesIndex_0_sel_int),
+      .data_a_i({32{1'bx}}),
+      .data_a_o(DdrCapturesIndex_DdrCaptures_int_dato0),
+      .rd_a_i(DdrCapturesIndex_DdrCaptures_rreq0),
+      .wr_a_i(1'b0),
+      .addr_b_i(DdrCapturesIndex_adr_i),
+      .bwsel_b_i({4{1'b1}}),
+      .data_b_i(DdrCapturesIndex_DdrCaptures_dat_i[63:32]),
+      .data_b_o(DdrCapturesIndex_DdrCaptures_ext_dat0),
+      .rd_b_i(1'b0),
+      .wr_b_i(DdrCapturesIndex_DdrCaptures_we_i)
+    );
+  
+  always @(wr_sel_d0)
+  begin
+    DdrCapturesIndex_0_sel_int = 4'b0;
+    if (~(wr_sel_d0[7:0] == 8'b0))
+      DdrCapturesIndex_0_sel_int[0] = 1'b1;
+    if (~(wr_sel_d0[15:8] == 8'b0))
+      DdrCapturesIndex_0_sel_int[1] = 1'b1;
+    if (~(wr_sel_d0[23:16] == 8'b0))
+      DdrCapturesIndex_0_sel_int[2] = 1'b1;
+    if (~(wr_sel_d0[31:24] == 8'b0))
+      DdrCapturesIndex_0_sel_int[3] = 1'b1;
+  end
+  cheby_dpssram #(
+      .g_data_width(32),
+      .g_size(64),
+      .g_addr_width(6),
+      .g_dual_clock(1'b0),
+      .g_use_bwsel(1'b1)
+    )
+  DdrCapturesIndex_DdrCaptures_raminst1 (
+      .clk_a_i(clk_i),
+      .clk_b_i(clk_i),
+      .addr_a_i(wb_adr_i[8:3]),
+      .bwsel_a_i(DdrCapturesIndex_1_sel_int),
+      .data_a_i({32{1'bx}}),
+      .data_a_o(DdrCapturesIndex_DdrCaptures_int_dato1),
+      .rd_a_i(DdrCapturesIndex_DdrCaptures_rreq1),
+      .wr_a_i(1'b0),
+      .addr_b_i(DdrCapturesIndex_adr_i),
+      .bwsel_b_i({4{1'b1}}),
+      .data_b_i(DdrCapturesIndex_DdrCaptures_dat_i[31:0]),
+      .data_b_o(DdrCapturesIndex_DdrCaptures_ext_dat1),
+      .rd_b_i(1'b0),
+      .wr_b_i(DdrCapturesIndex_DdrCaptures_we_i)
+    );
+  
+  always @(wr_sel_d0)
+  begin
+    DdrCapturesIndex_1_sel_int = 4'b0;
+    if (~(wr_sel_d0[7:0] == 8'b0))
+      DdrCapturesIndex_1_sel_int[0] = 1'b1;
+    if (~(wr_sel_d0[15:8] == 8'b0))
+      DdrCapturesIndex_1_sel_int[1] = 1'b1;
+    if (~(wr_sel_d0[23:16] == 8'b0))
+      DdrCapturesIndex_1_sel_int[2] = 1'b1;
+    if (~(wr_sel_d0[31:24] == 8'b0))
+      DdrCapturesIndex_1_sel_int[3] = 1'b1;
+  end
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        DdrCapturesIndex_DdrCaptures_rack0 <= 1'b0;
+        DdrCapturesIndex_DdrCaptures_rack1 <= 1'b0;
+      end
+    else
+      begin
+        DdrCapturesIndex_DdrCaptures_rack0 <= DdrCapturesIndex_DdrCaptures_rreq0;
+        DdrCapturesIndex_DdrCaptures_rack1 <= DdrCapturesIndex_DdrCaptures_rreq1;
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, regA_wack)
+  begin
+    regA_wreq = 1'b0;
+    case (wr_adr_d0[9:9])
+    1'b0:
+      case (wr_adr_d0[8:2])
+      7'b0000000:
+        begin
+          // Reg regA
+          regA_wreq = wr_req_d0;
+          wr_ack_int = regA_wack;
+        end
+      default:
+        wr_ack_int = wr_req_d0;
+      endcase
+    1'b1:
+      // Memory DdrCapturesIndex
+      wr_ack_int = wr_req_d0;
+    default:
+      wr_ack_int = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always @(wb_adr_i, rd_req_int, regA_field0_reg, DdrCapturesIndex_DdrCaptures_int_dato0, DdrCapturesIndex_DdrCaptures_rack0, DdrCapturesIndex_DdrCaptures_int_dato1, DdrCapturesIndex_DdrCaptures_rack1)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    DdrCapturesIndex_DdrCaptures_rreq0 = 1'b0;
+    DdrCapturesIndex_DdrCaptures_rreq1 = 1'b0;
+    case (wb_adr_i[9:9])
+    1'b0:
+      case (wb_adr_i[8:2])
+      7'b0000000:
+        begin
+          // Reg regA
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0[0] = 1'b0;
+          rd_dat_d0[1] = regA_field0_reg;
+          rd_dat_d0[31:2] = 30'b0;
+        end
+      default:
+        rd_ack_d0 = rd_req_int;
+      endcase
+    1'b1:
+      // Memory DdrCapturesIndex
+      case (wb_adr_i[2:2])
+      1'b0:
+        begin
+          rd_dat_d0 = DdrCapturesIndex_DdrCaptures_int_dato0;
+          DdrCapturesIndex_DdrCaptures_rreq0 = rd_req_int;
+          rd_ack_d0 = DdrCapturesIndex_DdrCaptures_rack0;
+        end
+      1'b1:
+        begin
+          rd_dat_d0 = DdrCapturesIndex_DdrCaptures_int_dato1;
+          DdrCapturesIndex_DdrCaptures_rreq1 = rd_req_int;
+          rd_ack_d0 = DdrCapturesIndex_DdrCaptures_rack1;
+        end
+      default:
+        ;
+      endcase
+    default:
+      rd_ack_d0 = rd_req_int;
+    endcase
+  end
+endmodule

--- a/testfiles/features/mem64rodual.sv
+++ b/testfiles/features/mem64rodual.sv
@@ -46,16 +46,16 @@ module mem64rodual
   reg [3:0] DdrCapturesIndex_1_sel_int;
 
   // WB decode signals
-  always @(wb_sel_i)
+  always_comb
   begin
-    wr_sel[7:0] <= {8{wb_sel_i[0]}};
-    wr_sel[15:8] <= {8{wb_sel_i[1]}};
-    wr_sel[23:16] <= {8{wb_sel_i[2]}};
-    wr_sel[31:24] <= {8{wb_sel_i[3]}};
+    wr_sel[7:0] = {8{wb_sel_i[0]}};
+    wr_sel[15:8] = {8{wb_sel_i[1]}};
+    wr_sel[23:16] = {8{wb_sel_i[2]}};
+    wr_sel[31:24] = {8{wb_sel_i[3]}};
   end
   assign wb_en = wb_cyc_i & wb_stb_i;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_rip <= 1'b0;
@@ -64,7 +64,7 @@ module mem64rodual
   end
   assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_wip <= 1'b0;
@@ -80,7 +80,7 @@ module mem64rodual
   assign wb_err_o = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -123,17 +123,17 @@ module mem64rodual
       .wr_b_i(DdrCapturesIndex_DdrCaptures_we_i)
     );
   
-  always @(wr_sel_d0)
+  always_comb
   begin
-    DdrCapturesIndex_0_sel_int <= 4'b0;
+    DdrCapturesIndex_0_sel_int = 4'b0;
     if (~(wr_sel_d0[7:0] == 8'b0))
-      DdrCapturesIndex_0_sel_int[0] <= 1'b1;
+      DdrCapturesIndex_0_sel_int[0] = 1'b1;
     if (~(wr_sel_d0[15:8] == 8'b0))
-      DdrCapturesIndex_0_sel_int[1] <= 1'b1;
+      DdrCapturesIndex_0_sel_int[1] = 1'b1;
     if (~(wr_sel_d0[23:16] == 8'b0))
-      DdrCapturesIndex_0_sel_int[2] <= 1'b1;
+      DdrCapturesIndex_0_sel_int[2] = 1'b1;
     if (~(wr_sel_d0[31:24] == 8'b0))
-      DdrCapturesIndex_0_sel_int[3] <= 1'b1;
+      DdrCapturesIndex_0_sel_int[3] = 1'b1;
   end
   cheby_dpssram #(
       .g_data_width(32),
@@ -159,19 +159,19 @@ module mem64rodual
       .wr_b_i(DdrCapturesIndex_DdrCaptures_we_i)
     );
   
-  always @(wr_sel_d0)
+  always_comb
   begin
-    DdrCapturesIndex_1_sel_int <= 4'b0;
+    DdrCapturesIndex_1_sel_int = 4'b0;
     if (~(wr_sel_d0[7:0] == 8'b0))
-      DdrCapturesIndex_1_sel_int[0] <= 1'b1;
+      DdrCapturesIndex_1_sel_int[0] = 1'b1;
     if (~(wr_sel_d0[15:8] == 8'b0))
-      DdrCapturesIndex_1_sel_int[1] <= 1'b1;
+      DdrCapturesIndex_1_sel_int[1] = 1'b1;
     if (~(wr_sel_d0[23:16] == 8'b0))
-      DdrCapturesIndex_1_sel_int[2] <= 1'b1;
+      DdrCapturesIndex_1_sel_int[2] = 1'b1;
     if (~(wr_sel_d0[31:24] == 8'b0))
-      DdrCapturesIndex_1_sel_int[3] <= 1'b1;
+      DdrCapturesIndex_1_sel_int[3] = 1'b1;
   end
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -186,30 +186,30 @@ module mem64rodual
   end
 
   // Process for write requests.
-  always @(wr_req_d0)
+  always_comb
   // Memory DdrCapturesIndex
-  wr_ack_int <= wr_req_d0;
+  wr_ack_int = wr_req_d0;
 
   // Process for read requests.
-  always @(wb_adr_i, DdrCapturesIndex_DdrCaptures_int_dato0, rd_req_int, DdrCapturesIndex_DdrCaptures_rack0, DdrCapturesIndex_DdrCaptures_int_dato1, DdrCapturesIndex_DdrCaptures_rack1)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
-    DdrCapturesIndex_DdrCaptures_rreq0 <= 1'b0;
-    DdrCapturesIndex_DdrCaptures_rreq1 <= 1'b0;
+    rd_dat_d0 = {32{1'bx}};
+    DdrCapturesIndex_DdrCaptures_rreq0 = 1'b0;
+    DdrCapturesIndex_DdrCaptures_rreq1 = 1'b0;
     // Memory DdrCapturesIndex
     case (wb_adr_i[2:2])
     1'b0:
       begin
-        rd_dat_d0 <= DdrCapturesIndex_DdrCaptures_int_dato0;
-        DdrCapturesIndex_DdrCaptures_rreq0 <= rd_req_int;
-        rd_ack_d0 <= DdrCapturesIndex_DdrCaptures_rack0;
+        rd_dat_d0 = DdrCapturesIndex_DdrCaptures_int_dato0;
+        DdrCapturesIndex_DdrCaptures_rreq0 = rd_req_int;
+        rd_ack_d0 = DdrCapturesIndex_DdrCaptures_rack0;
       end
     1'b1:
       begin
-        rd_dat_d0 <= DdrCapturesIndex_DdrCaptures_int_dato1;
-        DdrCapturesIndex_DdrCaptures_rreq1 <= rd_req_int;
-        rd_ack_d0 <= DdrCapturesIndex_DdrCaptures_rack1;
+        rd_dat_d0 = DdrCapturesIndex_DdrCaptures_int_dato1;
+        DdrCapturesIndex_DdrCaptures_rreq1 = rd_req_int;
+        rd_ack_d0 = DdrCapturesIndex_DdrCaptures_rack1;
       end
     default:
       ;

--- a/testfiles/features/mem64rodual.v
+++ b/testfiles/features/mem64rodual.v
@@ -1,0 +1,218 @@
+
+module mem64rodual
+  (
+    input   wire rst_n_i,
+    input   wire clk_i,
+    input   wire wb_cyc_i,
+    input   wire wb_stb_i,
+    input   wire [8:2] wb_adr_i,
+    input   wire [3:0] wb_sel_i,
+    input   wire wb_we_i,
+    input   wire [31:0] wb_dat_i,
+    output  wire wb_ack_o,
+    output  wire wb_err_o,
+    output  wire wb_rty_o,
+    output  wire wb_stall_o,
+    output  reg [31:0] wb_dat_o,
+
+    // RAM port for DdrCapturesIndex
+    input   wire [5:0] DdrCapturesIndex_adr_i,
+    input   wire DdrCapturesIndex_clk_i,
+    input   wire DdrCapturesIndex_DdrCaptures_we_i,
+    input   wire [63:0] DdrCapturesIndex_DdrCaptures_dat_i
+  );
+  reg [31:0] wr_sel;
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  wire [31:0] DdrCapturesIndex_DdrCaptures_int_dato0;
+  wire [31:0] DdrCapturesIndex_DdrCaptures_int_dato1;
+  wire [31:0] DdrCapturesIndex_DdrCaptures_ext_dat0;
+  wire [31:0] DdrCapturesIndex_DdrCaptures_ext_dat1;
+  reg DdrCapturesIndex_DdrCaptures_rreq0;
+  reg DdrCapturesIndex_DdrCaptures_rreq1;
+  reg DdrCapturesIndex_DdrCaptures_rack0;
+  reg DdrCapturesIndex_DdrCaptures_rack1;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [31:0] wr_sel_d0;
+  reg [3:0] DdrCapturesIndex_0_sel_int;
+  reg [3:0] DdrCapturesIndex_1_sel_int;
+
+  // WB decode signals
+  always @(wb_sel_i)
+  begin
+    wr_sel[7:0] = {8{wb_sel_i[0]}};
+    wr_sel[15:8] = {8{wb_sel_i[1]}};
+    wr_sel[23:16] = {8{wb_sel_i[2]}};
+    wr_sel[31:24] = {8{wb_sel_i[3]}};
+  end
+  assign wb_en = wb_cyc_i & wb_stb_i;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb_we_i)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb_we_i)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb_we_i) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb_ack_o = ack_int;
+  assign wb_stall_o = ~ack_int & wb_en;
+  assign wb_rty_o = 1'b0;
+  assign wb_err_o = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        rd_ack_int <= 1'b0;
+        wb_dat_o <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_sel_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb_dat_o <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_sel_d0 <= wr_sel;
+      end
+  end
+
+  // Memory DdrCapturesIndex
+  cheby_dpssram #(
+      .g_data_width(32),
+      .g_size(64),
+      .g_addr_width(6),
+      .g_dual_clock(1'b1),
+      .g_use_bwsel(1'b1)
+    )
+  DdrCapturesIndex_DdrCaptures_raminst0 (
+      .clk_a_i(clk_i),
+      .clk_b_i(DdrCapturesIndex_clk_i),
+      .addr_a_i(wb_adr_i[8:3]),
+      .bwsel_a_i(DdrCapturesIndex_0_sel_int),
+      .data_a_i({32{1'bx}}),
+      .data_a_o(DdrCapturesIndex_DdrCaptures_int_dato0),
+      .rd_a_i(DdrCapturesIndex_DdrCaptures_rreq0),
+      .wr_a_i(1'b0),
+      .addr_b_i(DdrCapturesIndex_adr_i),
+      .bwsel_b_i({4{1'b1}}),
+      .data_b_i(DdrCapturesIndex_DdrCaptures_dat_i[63:32]),
+      .data_b_o(DdrCapturesIndex_DdrCaptures_ext_dat0),
+      .rd_b_i(1'b0),
+      .wr_b_i(DdrCapturesIndex_DdrCaptures_we_i)
+    );
+  
+  always @(wr_sel_d0)
+  begin
+    DdrCapturesIndex_0_sel_int = 4'b0;
+    if (~(wr_sel_d0[7:0] == 8'b0))
+      DdrCapturesIndex_0_sel_int[0] = 1'b1;
+    if (~(wr_sel_d0[15:8] == 8'b0))
+      DdrCapturesIndex_0_sel_int[1] = 1'b1;
+    if (~(wr_sel_d0[23:16] == 8'b0))
+      DdrCapturesIndex_0_sel_int[2] = 1'b1;
+    if (~(wr_sel_d0[31:24] == 8'b0))
+      DdrCapturesIndex_0_sel_int[3] = 1'b1;
+  end
+  cheby_dpssram #(
+      .g_data_width(32),
+      .g_size(64),
+      .g_addr_width(6),
+      .g_dual_clock(1'b1),
+      .g_use_bwsel(1'b1)
+    )
+  DdrCapturesIndex_DdrCaptures_raminst1 (
+      .clk_a_i(clk_i),
+      .clk_b_i(DdrCapturesIndex_clk_i),
+      .addr_a_i(wb_adr_i[8:3]),
+      .bwsel_a_i(DdrCapturesIndex_1_sel_int),
+      .data_a_i({32{1'bx}}),
+      .data_a_o(DdrCapturesIndex_DdrCaptures_int_dato1),
+      .rd_a_i(DdrCapturesIndex_DdrCaptures_rreq1),
+      .wr_a_i(1'b0),
+      .addr_b_i(DdrCapturesIndex_adr_i),
+      .bwsel_b_i({4{1'b1}}),
+      .data_b_i(DdrCapturesIndex_DdrCaptures_dat_i[31:0]),
+      .data_b_o(DdrCapturesIndex_DdrCaptures_ext_dat1),
+      .rd_b_i(1'b0),
+      .wr_b_i(DdrCapturesIndex_DdrCaptures_we_i)
+    );
+  
+  always @(wr_sel_d0)
+  begin
+    DdrCapturesIndex_1_sel_int = 4'b0;
+    if (~(wr_sel_d0[7:0] == 8'b0))
+      DdrCapturesIndex_1_sel_int[0] = 1'b1;
+    if (~(wr_sel_d0[15:8] == 8'b0))
+      DdrCapturesIndex_1_sel_int[1] = 1'b1;
+    if (~(wr_sel_d0[23:16] == 8'b0))
+      DdrCapturesIndex_1_sel_int[2] = 1'b1;
+    if (~(wr_sel_d0[31:24] == 8'b0))
+      DdrCapturesIndex_1_sel_int[3] = 1'b1;
+  end
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        DdrCapturesIndex_DdrCaptures_rack0 <= 1'b0;
+        DdrCapturesIndex_DdrCaptures_rack1 <= 1'b0;
+      end
+    else
+      begin
+        DdrCapturesIndex_DdrCaptures_rack0 <= DdrCapturesIndex_DdrCaptures_rreq0;
+        DdrCapturesIndex_DdrCaptures_rack1 <= DdrCapturesIndex_DdrCaptures_rreq1;
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_req_d0)
+  // Memory DdrCapturesIndex
+  wr_ack_int = wr_req_d0;
+
+  // Process for read requests.
+  always @(wb_adr_i, DdrCapturesIndex_DdrCaptures_int_dato0, rd_req_int, DdrCapturesIndex_DdrCaptures_rack0, DdrCapturesIndex_DdrCaptures_int_dato1, DdrCapturesIndex_DdrCaptures_rack1)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    DdrCapturesIndex_DdrCaptures_rreq0 = 1'b0;
+    DdrCapturesIndex_DdrCaptures_rreq1 = 1'b0;
+    // Memory DdrCapturesIndex
+    case (wb_adr_i[2:2])
+    1'b0:
+      begin
+        rd_dat_d0 = DdrCapturesIndex_DdrCaptures_int_dato0;
+        DdrCapturesIndex_DdrCaptures_rreq0 = rd_req_int;
+        rd_ack_d0 = DdrCapturesIndex_DdrCaptures_rack0;
+      end
+    1'b1:
+      begin
+        rd_dat_d0 = DdrCapturesIndex_DdrCaptures_int_dato1;
+        DdrCapturesIndex_DdrCaptures_rreq1 = rd_req_int;
+        rd_ack_d0 = DdrCapturesIndex_DdrCaptures_rack1;
+      end
+    default:
+      ;
+    endcase
+  end
+endmodule

--- a/testfiles/features/no_port.sv
+++ b/testfiles/features/no_port.sv
@@ -37,7 +37,7 @@ module no_port
   assign wr_req = (psel & pwrite) & ~penable;
   assign wr_addr = paddr;
   assign wr_data = pwdata;
-  always @(pstrb)
+  always_comb
   ;
 
   // Read Channel
@@ -48,7 +48,7 @@ module no_port
   assign pslverr = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(pclk))
+  always_ff @(posedge(pclk))
   begin
     if (!presetn)
       begin
@@ -69,7 +69,7 @@ module no_port
   end
 
   // Register reg0
-  always @(posedge(pclk))
+  always_ff @(posedge(pclk))
   begin
     if (!presetn)
       begin
@@ -85,7 +85,7 @@ module no_port
   end
 
   // Register reg1
-  always @(posedge(pclk))
+  always_ff @(posedge(pclk))
   begin
     if (!presetn)
       begin
@@ -101,48 +101,48 @@ module no_port
   end
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0, reg0_wack, reg1_wack)
+  always_comb
   begin
-    reg0_wreq <= 1'b0;
-    reg1_wreq <= 1'b0;
+    reg0_wreq = 1'b0;
+    reg1_wreq = 1'b0;
     case (wr_adr_d0[2:2])
     1'b0:
       begin
         // Reg reg0
-        reg0_wreq <= wr_req_d0;
-        wr_ack <= reg0_wack;
+        reg0_wreq = wr_req_d0;
+        wr_ack = reg0_wack;
       end
     1'b1:
       begin
         // Reg reg1
-        reg1_wreq <= wr_req_d0;
-        wr_ack <= reg1_wack;
+        reg1_wreq = wr_req_d0;
+        wr_ack = reg1_wack;
       end
     default:
-      wr_ack <= wr_req_d0;
+      wr_ack = wr_req_d0;
     endcase
   end
 
   // Process for read requests.
-  always @(rd_addr, rd_req, reg0_reg, reg1_reg)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     case (rd_addr[2:2])
     1'b0:
       begin
         // Reg reg0
-        rd_ack_d0 <= rd_req;
-        rd_dat_d0 <= reg0_reg;
+        rd_ack_d0 = rd_req;
+        rd_dat_d0 = reg0_reg;
       end
     1'b1:
       begin
         // Reg reg1
-        rd_ack_d0 <= rd_req;
-        rd_dat_d0 <= reg1_reg;
+        rd_ack_d0 = rd_req;
+        rd_dat_d0 = reg1_reg;
       end
     default:
-      rd_ack_d0 <= rd_req;
+      rd_ack_d0 = rd_req;
     endcase
   end
 endmodule

--- a/testfiles/features/no_port.v
+++ b/testfiles/features/no_port.v
@@ -1,0 +1,148 @@
+
+module no_port
+  (
+    input   wire pclk,
+    input   wire presetn,
+    input   wire [2:2] paddr,
+    input   wire psel,
+    input   wire pwrite,
+    input   wire penable,
+    output  wire pready,
+    input   wire [31:0] pwdata,
+    input   wire [3:0] pstrb,
+    output  wire [31:0] prdata,
+    output  wire pslverr
+  );
+  wire wr_req;
+  wire [2:2] wr_addr;
+  wire [31:0] wr_data;
+  wire rd_req;
+  wire [2:2] rd_addr;
+  reg [31:0] rd_data;
+  reg wr_ack;
+  reg rd_ack;
+  reg [31:0] reg0_reg;
+  reg reg0_wreq;
+  reg reg0_wack;
+  reg [31:0] reg1_reg;
+  reg reg1_wreq;
+  reg reg1_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [2:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+
+  // Write Channel
+  assign wr_req = (psel & pwrite) & ~penable;
+  assign wr_addr = paddr;
+  assign wr_data = pwdata;
+  always @(pstrb)
+  ;
+
+  // Read Channel
+  assign rd_req = (psel & ~pwrite) & ~penable;
+  assign rd_addr = paddr;
+  assign prdata = rd_data;
+  assign pready = wr_ack | rd_ack;
+  assign pslverr = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(pclk))
+  begin
+    if (!presetn)
+      begin
+        rd_ack <= 1'b0;
+        rd_data <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 1'b0;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack <= rd_ack_d0;
+        rd_data <= rd_dat_d0;
+        wr_req_d0 <= wr_req;
+        wr_adr_d0 <= wr_addr;
+        wr_dat_d0 <= wr_data;
+      end
+  end
+
+  // Register reg0
+  always @(posedge(pclk))
+  begin
+    if (!presetn)
+      begin
+        reg0_reg <= 32'b00000000000000000000000000000000;
+        reg0_wack <= 1'b0;
+      end
+    else
+      begin
+        if (reg0_wreq == 1'b1)
+          reg0_reg <= wr_dat_d0;
+        reg0_wack <= reg0_wreq;
+      end
+  end
+
+  // Register reg1
+  always @(posedge(pclk))
+  begin
+    if (!presetn)
+      begin
+        reg1_reg <= 32'b00000000000000000000000000000000;
+        reg1_wack <= 1'b0;
+      end
+    else
+      begin
+        if (reg1_wreq == 1'b1)
+          reg1_reg <= wr_dat_d0;
+        reg1_wack <= reg1_wreq;
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, reg0_wack, reg1_wack)
+  begin
+    reg0_wreq = 1'b0;
+    reg1_wreq = 1'b0;
+    case (wr_adr_d0[2:2])
+    1'b0:
+      begin
+        // Reg reg0
+        reg0_wreq = wr_req_d0;
+        wr_ack = reg0_wack;
+      end
+    1'b1:
+      begin
+        // Reg reg1
+        reg1_wreq = wr_req_d0;
+        wr_ack = reg1_wack;
+      end
+    default:
+      wr_ack = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always @(rd_addr, rd_req, reg0_reg, reg1_reg)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    case (rd_addr[2:2])
+    1'b0:
+      begin
+        // Reg reg0
+        rd_ack_d0 = rd_req;
+        rd_dat_d0 = reg0_reg;
+      end
+    1'b1:
+      begin
+        // Reg reg1
+        rd_ack_d0 = rd_req;
+        rd_dat_d0 = reg1_reg;
+      end
+    default:
+      rd_ack_d0 = rd_req;
+    endcase
+  end
+endmodule

--- a/testfiles/features/orclrout_rw.sv
+++ b/testfiles/features/orclrout_rw.sv
@@ -35,11 +35,11 @@ module orclrout
   reg [31:0] wr_dat_d0;
 
   // WB decode signals
-  always @(wb_sel_i)
+  always_comb
   ;
   assign wb_en = wb_cyc_i & wb_stb_i;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_rip <= 1'b0;
@@ -48,7 +48,7 @@ module orclrout
   end
   assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_wip <= 1'b0;
@@ -64,7 +64,7 @@ module orclrout
   assign wb_err_o = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -84,7 +84,7 @@ module orclrout
 
   // Register breg
   assign breg_o = breg_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -102,21 +102,21 @@ module orclrout
   end
 
   // Process for write requests.
-  always @(wr_req_d0, breg_wack)
+  always_comb
   begin
-    breg_wreq <= 1'b0;
+    breg_wreq = 1'b0;
     // Reg breg
-    breg_wreq <= wr_req_d0;
-    wr_ack_int <= breg_wack;
+    breg_wreq = wr_req_d0;
+    wr_ack_int = breg_wack;
   end
 
   // Process for read requests.
-  always @(rd_req_int, breg_reg)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     // Reg breg
-    rd_ack_d0 <= rd_req_int;
-    rd_dat_d0 <= breg_reg;
+    rd_ack_d0 = rd_req_int;
+    rd_dat_d0 = breg_reg;
   end
 endmodule

--- a/testfiles/features/orclrout_rw.v
+++ b/testfiles/features/orclrout_rw.v
@@ -1,0 +1,122 @@
+
+module orclrout
+  (
+    input   wire rst_n_i,
+    input   wire clk_i,
+    input   wire wb_cyc_i,
+    input   wire wb_stb_i,
+    input   wire [3:0] wb_sel_i,
+    input   wire wb_we_i,
+    input   wire [31:0] wb_dat_i,
+    output  wire wb_ack_o,
+    output  wire wb_err_o,
+    output  wire wb_rty_o,
+    output  wire wb_stall_o,
+    output  reg [31:0] wb_dat_o,
+
+    // REG breg
+    input   wire [31:0] breg_i,
+    output  wire [31:0] breg_o
+  );
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg [31:0] breg_reg;
+  reg breg_wreq;
+  reg breg_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [31:0] wr_dat_d0;
+
+  // WB decode signals
+  always @(wb_sel_i)
+  ;
+  assign wb_en = wb_cyc_i & wb_stb_i;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb_we_i)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb_we_i)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb_we_i) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb_ack_o = ack_int;
+  assign wb_stall_o = ~ack_int & wb_en;
+  assign wb_rty_o = 1'b0;
+  assign wb_err_o = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        rd_ack_int <= 1'b0;
+        wb_dat_o <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb_dat_o <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_dat_d0 <= wb_dat_i;
+      end
+  end
+
+  // Register breg
+  assign breg_o = breg_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        breg_reg <= 32'b00000000000000000000000000000000;
+        breg_wack <= 1'b0;
+      end
+    else
+      begin
+        if (breg_wreq == 1'b1)
+          breg_reg <= breg_i | (breg_reg & ~wr_dat_d0);
+        else
+          breg_reg <= breg_i | breg_reg;
+        breg_wack <= breg_wreq;
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_req_d0, breg_wack)
+  begin
+    breg_wreq = 1'b0;
+    // Reg breg
+    breg_wreq = wr_req_d0;
+    wr_ack_int = breg_wack;
+  end
+
+  // Process for read requests.
+  always @(rd_req_int, breg_reg)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    // Reg breg
+    rd_ack_d0 = rd_req_int;
+    rd_dat_d0 = breg_reg;
+  end
+endmodule

--- a/testfiles/features/reg-strobe.sv
+++ b/testfiles/features/reg-strobe.sv
@@ -36,11 +36,11 @@ module reg_strobe
   reg [31:0] wr_dat_d0;
 
   // WB decode signals
-  always @(wb_sel_i)
+  always_comb
   ;
   assign wb_en = wb_cyc_i & wb_stb_i;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_rip <= 1'b0;
@@ -49,7 +49,7 @@ module reg_strobe
   end
   assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_wip <= 1'b0;
@@ -65,7 +65,7 @@ module reg_strobe
   assign wb_err_o = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -85,7 +85,7 @@ module reg_strobe
 
   // Register regA
   assign regA_field0_o = regA_field0_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -102,23 +102,23 @@ module reg_strobe
   assign regA_wr_o = regA_wack;
 
   // Process for write requests.
-  always @(wr_req_d0, regA_wack)
+  always_comb
   begin
-    regA_wreq <= 1'b0;
+    regA_wreq = 1'b0;
     // Reg regA
-    regA_wreq <= wr_req_d0;
-    wr_ack_int <= regA_wack;
+    regA_wreq = wr_req_d0;
+    wr_ack_int = regA_wack;
   end
 
   // Process for read requests.
-  always @(rd_req_int, regA_field0_reg)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     // Reg regA
-    rd_ack_d0 <= rd_req_int;
-    rd_dat_d0[0] <= 1'b0;
-    rd_dat_d0[1] <= regA_field0_reg;
-    rd_dat_d0[31:2] <= 30'b0;
+    rd_ack_d0 = rd_req_int;
+    rd_dat_d0[0] = 1'b0;
+    rd_dat_d0[1] = regA_field0_reg;
+    rd_dat_d0[31:2] = 30'b0;
   end
 endmodule

--- a/testfiles/features/reg-strobe.v
+++ b/testfiles/features/reg-strobe.v
@@ -1,0 +1,124 @@
+
+module reg_strobe
+  (
+    input   wire rst_n_i,
+    input   wire clk_i,
+    input   wire wb_cyc_i,
+    input   wire wb_stb_i,
+    input   wire [3:0] wb_sel_i,
+    input   wire wb_we_i,
+    input   wire [31:0] wb_dat_i,
+    output  wire wb_ack_o,
+    output  wire wb_err_o,
+    output  wire wb_rty_o,
+    output  wire wb_stall_o,
+    output  reg [31:0] wb_dat_o,
+
+    // The first register (with some fields)
+    // 1-bit field
+    output  wire regA_field0_o,
+    output  wire regA_wr_o
+  );
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg regA_field0_reg;
+  reg regA_wreq;
+  reg regA_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [31:0] wr_dat_d0;
+
+  // WB decode signals
+  always @(wb_sel_i)
+  ;
+  assign wb_en = wb_cyc_i & wb_stb_i;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb_we_i)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb_we_i)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb_we_i) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb_ack_o = ack_int;
+  assign wb_stall_o = ~ack_int & wb_en;
+  assign wb_rty_o = 1'b0;
+  assign wb_err_o = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        rd_ack_int <= 1'b0;
+        wb_dat_o <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb_dat_o <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_dat_d0 <= wb_dat_i;
+      end
+  end
+
+  // Register regA
+  assign regA_field0_o = regA_field0_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        regA_field0_reg <= 1'b0;
+        regA_wack <= 1'b0;
+      end
+    else
+      begin
+        if (regA_wreq == 1'b1)
+          regA_field0_reg <= wr_dat_d0[1];
+        regA_wack <= regA_wreq;
+      end
+  end
+  assign regA_wr_o = regA_wack;
+
+  // Process for write requests.
+  always @(wr_req_d0, regA_wack)
+  begin
+    regA_wreq = 1'b0;
+    // Reg regA
+    regA_wreq = wr_req_d0;
+    wr_ack_int = regA_wack;
+  end
+
+  // Process for read requests.
+  always @(rd_req_int, regA_field0_reg)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    // Reg regA
+    rd_ack_d0 = rd_req_int;
+    rd_dat_d0[0] = 1'b0;
+    rd_dat_d0[1] = regA_field0_reg;
+    rd_dat_d0[31:2] = 30'b0;
+  end
+endmodule

--- a/testfiles/features/reg128.sv
+++ b/testfiles/features/reg128.sv
@@ -36,11 +36,11 @@ module reg128
   reg [31:0] wr_dat_d0;
 
   // WB decode signals
-  always @(wb_sel_i)
+  always_comb
   ;
   assign wb_en = wb_cyc_i & wb_stb_i;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_rip <= 1'b0;
@@ -49,7 +49,7 @@ module reg128
   end
   assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_wip <= 1'b0;
@@ -65,7 +65,7 @@ module reg128
   assign wb_err_o = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -87,7 +87,7 @@ module reg128
 
   // Register areg
   assign areg_o = areg_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -109,71 +109,71 @@ module reg128
   end
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0, areg_wack)
+  always_comb
   begin
-    areg_wreq <= 4'b0;
+    areg_wreq = 4'b0;
     case (wr_adr_d0[3:2])
     2'b00:
       begin
         // Reg areg
-        areg_wreq[3] <= wr_req_d0;
-        wr_ack_int <= areg_wack[3];
+        areg_wreq[3] = wr_req_d0;
+        wr_ack_int = areg_wack[3];
       end
     2'b01:
       begin
         // Reg areg
-        areg_wreq[2] <= wr_req_d0;
-        wr_ack_int <= areg_wack[2];
+        areg_wreq[2] = wr_req_d0;
+        wr_ack_int = areg_wack[2];
       end
     2'b10:
       begin
         // Reg areg
-        areg_wreq[1] <= wr_req_d0;
-        wr_ack_int <= areg_wack[1];
+        areg_wreq[1] = wr_req_d0;
+        wr_ack_int = areg_wack[1];
       end
     2'b11:
       begin
         // Reg areg
-        areg_wreq[0] <= wr_req_d0;
-        wr_ack_int <= areg_wack[0];
+        areg_wreq[0] = wr_req_d0;
+        wr_ack_int = areg_wack[0];
       end
     default:
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     endcase
   end
 
   // Process for read requests.
-  always @(wb_adr_i, rd_req_int, areg_reg)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     case (wb_adr_i[3:2])
     2'b00:
       begin
         // Reg areg
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0 <= areg_reg[127:96];
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = areg_reg[127:96];
       end
     2'b01:
       begin
         // Reg areg
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0 <= areg_reg[95:64];
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = areg_reg[95:64];
       end
     2'b10:
       begin
         // Reg areg
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0 <= areg_reg[63:32];
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = areg_reg[63:32];
       end
     2'b11:
       begin
         // Reg areg
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0 <= areg_reg[31:0];
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = areg_reg[31:0];
       end
     default:
-      rd_ack_d0 <= rd_req_int;
+      rd_ack_d0 = rd_req_int;
     endcase
   end
 endmodule

--- a/testfiles/features/reg128.v
+++ b/testfiles/features/reg128.v
@@ -1,0 +1,179 @@
+
+module reg128
+  (
+    input   wire rst_n_i,
+    input   wire clk_i,
+    input   wire wb_cyc_i,
+    input   wire wb_stb_i,
+    input   wire [3:2] wb_adr_i,
+    input   wire [3:0] wb_sel_i,
+    input   wire wb_we_i,
+    input   wire [31:0] wb_dat_i,
+    output  wire wb_ack_o,
+    output  wire wb_err_o,
+    output  wire wb_rty_o,
+    output  wire wb_stall_o,
+    output  reg [31:0] wb_dat_o,
+
+    // REG areg
+    output  wire [127:0] areg_o
+  );
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg [127:0] areg_reg;
+  reg [3:0] areg_wreq;
+  reg [3:0] areg_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [3:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+
+  // WB decode signals
+  always @(wb_sel_i)
+  ;
+  assign wb_en = wb_cyc_i & wb_stb_i;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb_we_i)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb_we_i)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb_we_i) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb_ack_o = ack_int;
+  assign wb_stall_o = ~ack_int & wb_en;
+  assign wb_rty_o = 1'b0;
+  assign wb_err_o = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        rd_ack_int <= 1'b0;
+        wb_dat_o <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 2'b00;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb_dat_o <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_adr_d0 <= wb_adr_i;
+        wr_dat_d0 <= wb_dat_i;
+      end
+  end
+
+  // Register areg
+  assign areg_o = areg_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        areg_reg <= 128'b00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000;
+        areg_wack <= 4'b0;
+      end
+    else
+      begin
+        if (areg_wreq[0] == 1'b1)
+          areg_reg[31:0] <= wr_dat_d0;
+        if (areg_wreq[1] == 1'b1)
+          areg_reg[63:32] <= wr_dat_d0;
+        if (areg_wreq[2] == 1'b1)
+          areg_reg[95:64] <= wr_dat_d0;
+        if (areg_wreq[3] == 1'b1)
+          areg_reg[127:96] <= wr_dat_d0;
+        areg_wack <= areg_wreq;
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, areg_wack)
+  begin
+    areg_wreq = 4'b0;
+    case (wr_adr_d0[3:2])
+    2'b00:
+      begin
+        // Reg areg
+        areg_wreq[3] = wr_req_d0;
+        wr_ack_int = areg_wack[3];
+      end
+    2'b01:
+      begin
+        // Reg areg
+        areg_wreq[2] = wr_req_d0;
+        wr_ack_int = areg_wack[2];
+      end
+    2'b10:
+      begin
+        // Reg areg
+        areg_wreq[1] = wr_req_d0;
+        wr_ack_int = areg_wack[1];
+      end
+    2'b11:
+      begin
+        // Reg areg
+        areg_wreq[0] = wr_req_d0;
+        wr_ack_int = areg_wack[0];
+      end
+    default:
+      wr_ack_int = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always @(wb_adr_i, rd_req_int, areg_reg)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    case (wb_adr_i[3:2])
+    2'b00:
+      begin
+        // Reg areg
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = areg_reg[127:96];
+      end
+    2'b01:
+      begin
+        // Reg areg
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = areg_reg[95:64];
+      end
+    2'b10:
+      begin
+        // Reg areg
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = areg_reg[63:32];
+      end
+    2'b11:
+      begin
+        // Reg areg
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = areg_reg[31:0];
+      end
+    default:
+      rd_ack_d0 = rd_req_int;
+    endcase
+  end
+endmodule

--- a/testfiles/features/regprefix1.sv
+++ b/testfiles/features/regprefix1.sv
@@ -52,11 +52,11 @@ module regprefix1
   reg [31:0] wr_dat_d0;
 
   // WB decode signals
-  always @(wb_sel_i)
+  always_comb
   ;
   assign wb_en = wb_cyc_i & wb_stb_i;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_rip <= 1'b0;
@@ -65,7 +65,7 @@ module regprefix1
   end
   assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_wip <= 1'b0;
@@ -81,7 +81,7 @@ module regprefix1
   assign wb_err_o = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -104,7 +104,7 @@ module regprefix1
   // Register r1
   assign f1_o = f1_reg;
   assign f2_o = f2_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -126,7 +126,7 @@ module regprefix1
   // Register r2
   assign f3_o = f3_reg;
   assign f4_o = f4_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -147,7 +147,7 @@ module regprefix1
 
   // Register r3
   assign r3_o = r3_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -163,67 +163,67 @@ module regprefix1
   end
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0, r1_wack, r2_wack, r3_wack)
+  always_comb
   begin
-    r1_wreq <= 1'b0;
-    r2_wreq <= 1'b0;
-    r3_wreq <= 1'b0;
+    r1_wreq = 1'b0;
+    r2_wreq = 1'b0;
+    r3_wreq = 1'b0;
     case (wr_adr_d0[3:2])
     2'b00:
       begin
         // Reg r1
-        r1_wreq <= wr_req_d0;
-        wr_ack_int <= r1_wack;
+        r1_wreq = wr_req_d0;
+        wr_ack_int = r1_wack;
       end
     2'b01:
       begin
         // Reg r2
-        r2_wreq <= wr_req_d0;
-        wr_ack_int <= r2_wack;
+        r2_wreq = wr_req_d0;
+        wr_ack_int = r2_wack;
       end
     2'b10:
       begin
         // Reg r3
-        r3_wreq <= wr_req_d0;
-        wr_ack_int <= r3_wack;
+        r3_wreq = wr_req_d0;
+        wr_ack_int = r3_wack;
       end
     default:
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     endcase
   end
 
   // Process for read requests.
-  always @(wb_adr_i, rd_req_int, f1_reg, f2_reg, f3_reg, f4_reg, r3_reg)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     case (wb_adr_i[3:2])
     2'b00:
       begin
         // Reg r1
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0[2:0] <= f1_reg;
-        rd_dat_d0[3] <= 1'b0;
-        rd_dat_d0[4] <= f2_reg;
-        rd_dat_d0[31:5] <= 27'b0;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0[2:0] = f1_reg;
+        rd_dat_d0[3] = 1'b0;
+        rd_dat_d0[4] = f2_reg;
+        rd_dat_d0[31:5] = 27'b0;
       end
     2'b01:
       begin
         // Reg r2
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0[2:0] <= f3_reg;
-        rd_dat_d0[3] <= 1'b0;
-        rd_dat_d0[4] <= f4_reg;
-        rd_dat_d0[31:5] <= 27'b0;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0[2:0] = f3_reg;
+        rd_dat_d0[3] = 1'b0;
+        rd_dat_d0[4] = f4_reg;
+        rd_dat_d0[31:5] = 27'b0;
       end
     2'b10:
       begin
         // Reg r3
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0 <= r3_reg;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = r3_reg;
       end
     default:
-      rd_ack_d0 <= rd_req_int;
+      rd_ack_d0 = rd_req_int;
     endcase
   end
 endmodule

--- a/testfiles/features/regprefix1.v
+++ b/testfiles/features/regprefix1.v
@@ -1,0 +1,229 @@
+
+module regprefix1
+  (
+    input   wire rst_n_i,
+    input   wire clk_i,
+    input   wire wb_cyc_i,
+    input   wire wb_stb_i,
+    input   wire [3:2] wb_adr_i,
+    input   wire [3:0] wb_sel_i,
+    input   wire wb_we_i,
+    input   wire [31:0] wb_dat_i,
+    output  wire wb_ack_o,
+    output  wire wb_err_o,
+    output  wire wb_rty_o,
+    output  wire wb_stall_o,
+    output  reg [31:0] wb_dat_o,
+
+    // REG r1
+    output  wire [2:0] f1_o,
+    output  wire f2_o,
+
+    // REG r2
+    output  wire [2:0] f3_o,
+    output  wire f4_o,
+
+    // REG r3
+    output  wire [31:0] r3_o
+  );
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg [2:0] f1_reg;
+  reg f2_reg;
+  reg r1_wreq;
+  reg r1_wack;
+  reg [2:0] f3_reg;
+  reg f4_reg;
+  reg r2_wreq;
+  reg r2_wack;
+  reg [31:0] r3_reg;
+  reg r3_wreq;
+  reg r3_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [3:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+
+  // WB decode signals
+  always @(wb_sel_i)
+  ;
+  assign wb_en = wb_cyc_i & wb_stb_i;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb_we_i)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb_we_i)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb_we_i) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb_ack_o = ack_int;
+  assign wb_stall_o = ~ack_int & wb_en;
+  assign wb_rty_o = 1'b0;
+  assign wb_err_o = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        rd_ack_int <= 1'b0;
+        wb_dat_o <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 2'b00;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb_dat_o <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_adr_d0 <= wb_adr_i;
+        wr_dat_d0 <= wb_dat_i;
+      end
+  end
+
+  // Register r1
+  assign f1_o = f1_reg;
+  assign f2_o = f2_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        f1_reg <= 3'b000;
+        f2_reg <= 1'b0;
+        r1_wack <= 1'b0;
+      end
+    else
+      begin
+        if (r1_wreq == 1'b1)
+          begin
+            f1_reg <= wr_dat_d0[2:0];
+            f2_reg <= wr_dat_d0[4];
+          end
+        r1_wack <= r1_wreq;
+      end
+  end
+
+  // Register r2
+  assign f3_o = f3_reg;
+  assign f4_o = f4_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        f3_reg <= 3'b000;
+        f4_reg <= 1'b0;
+        r2_wack <= 1'b0;
+      end
+    else
+      begin
+        if (r2_wreq == 1'b1)
+          begin
+            f3_reg <= wr_dat_d0[2:0];
+            f4_reg <= wr_dat_d0[4];
+          end
+        r2_wack <= r2_wreq;
+      end
+  end
+
+  // Register r3
+  assign r3_o = r3_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        r3_reg <= 32'b00000000000000000000000000000000;
+        r3_wack <= 1'b0;
+      end
+    else
+      begin
+        if (r3_wreq == 1'b1)
+          r3_reg <= wr_dat_d0;
+        r3_wack <= r3_wreq;
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, r1_wack, r2_wack, r3_wack)
+  begin
+    r1_wreq = 1'b0;
+    r2_wreq = 1'b0;
+    r3_wreq = 1'b0;
+    case (wr_adr_d0[3:2])
+    2'b00:
+      begin
+        // Reg r1
+        r1_wreq = wr_req_d0;
+        wr_ack_int = r1_wack;
+      end
+    2'b01:
+      begin
+        // Reg r2
+        r2_wreq = wr_req_d0;
+        wr_ack_int = r2_wack;
+      end
+    2'b10:
+      begin
+        // Reg r3
+        r3_wreq = wr_req_d0;
+        wr_ack_int = r3_wack;
+      end
+    default:
+      wr_ack_int = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always @(wb_adr_i, rd_req_int, f1_reg, f2_reg, f3_reg, f4_reg, r3_reg)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    case (wb_adr_i[3:2])
+    2'b00:
+      begin
+        // Reg r1
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0[2:0] = f1_reg;
+        rd_dat_d0[3] = 1'b0;
+        rd_dat_d0[4] = f2_reg;
+        rd_dat_d0[31:5] = 27'b0;
+      end
+    2'b01:
+      begin
+        // Reg r2
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0[2:0] = f3_reg;
+        rd_dat_d0[3] = 1'b0;
+        rd_dat_d0[4] = f4_reg;
+        rd_dat_d0[31:5] = 27'b0;
+      end
+    2'b10:
+      begin
+        // Reg r3
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = r3_reg;
+      end
+    default:
+      rd_ack_d0 = rd_req_int;
+    endcase
+  end
+endmodule

--- a/testfiles/features/regprefix2.sv
+++ b/testfiles/features/regprefix2.sv
@@ -52,11 +52,11 @@ module regprefix2
   reg [31:0] wr_dat_d0;
 
   // WB decode signals
-  always @(wb_sel_i)
+  always_comb
   ;
   assign wb_en = wb_cyc_i & wb_stb_i;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_rip <= 1'b0;
@@ -65,7 +65,7 @@ module regprefix2
   end
   assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_wip <= 1'b0;
@@ -81,7 +81,7 @@ module regprefix2
   assign wb_err_o = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -104,7 +104,7 @@ module regprefix2
   // Register r1
   assign f1_o = f1_reg;
   assign f2_o = f2_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -126,7 +126,7 @@ module regprefix2
   // Register r2
   assign f3_o = f3_reg;
   assign f4_o = f4_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -147,7 +147,7 @@ module regprefix2
 
   // Register r3
   assign r3_o = r3_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -163,67 +163,67 @@ module regprefix2
   end
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0, r1_wack, r2_wack, r3_wack)
+  always_comb
   begin
-    r1_wreq <= 1'b0;
-    r2_wreq <= 1'b0;
-    r3_wreq <= 1'b0;
+    r1_wreq = 1'b0;
+    r2_wreq = 1'b0;
+    r3_wreq = 1'b0;
     case (wr_adr_d0[3:2])
     2'b00:
       begin
         // Reg r1
-        r1_wreq <= wr_req_d0;
-        wr_ack_int <= r1_wack;
+        r1_wreq = wr_req_d0;
+        wr_ack_int = r1_wack;
       end
     2'b01:
       begin
         // Reg r2
-        r2_wreq <= wr_req_d0;
-        wr_ack_int <= r2_wack;
+        r2_wreq = wr_req_d0;
+        wr_ack_int = r2_wack;
       end
     2'b10:
       begin
         // Reg r3
-        r3_wreq <= wr_req_d0;
-        wr_ack_int <= r3_wack;
+        r3_wreq = wr_req_d0;
+        wr_ack_int = r3_wack;
       end
     default:
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     endcase
   end
 
   // Process for read requests.
-  always @(wb_adr_i, rd_req_int, f1_reg, f2_reg, f3_reg, f4_reg, r3_reg)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     case (wb_adr_i[3:2])
     2'b00:
       begin
         // Reg r1
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0[2:0] <= f1_reg;
-        rd_dat_d0[3] <= 1'b0;
-        rd_dat_d0[4] <= f2_reg;
-        rd_dat_d0[31:5] <= 27'b0;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0[2:0] = f1_reg;
+        rd_dat_d0[3] = 1'b0;
+        rd_dat_d0[4] = f2_reg;
+        rd_dat_d0[31:5] = 27'b0;
       end
     2'b01:
       begin
         // Reg r2
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0[2:0] <= f3_reg;
-        rd_dat_d0[3] <= 1'b0;
-        rd_dat_d0[4] <= f4_reg;
-        rd_dat_d0[31:5] <= 27'b0;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0[2:0] = f3_reg;
+        rd_dat_d0[3] = 1'b0;
+        rd_dat_d0[4] = f4_reg;
+        rd_dat_d0[31:5] = 27'b0;
       end
     2'b10:
       begin
         // Reg r3
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0 <= r3_reg;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = r3_reg;
       end
     default:
-      rd_ack_d0 <= rd_req_int;
+      rd_ack_d0 = rd_req_int;
     endcase
   end
 endmodule

--- a/testfiles/features/regprefix2.v
+++ b/testfiles/features/regprefix2.v
@@ -1,0 +1,229 @@
+
+module regprefix2
+  (
+    input   wire rst_n_i,
+    input   wire clk_i,
+    input   wire wb_cyc_i,
+    input   wire wb_stb_i,
+    input   wire [3:2] wb_adr_i,
+    input   wire [3:0] wb_sel_i,
+    input   wire wb_we_i,
+    input   wire [31:0] wb_dat_i,
+    output  wire wb_ack_o,
+    output  wire wb_err_o,
+    output  wire wb_rty_o,
+    output  wire wb_stall_o,
+    output  reg [31:0] wb_dat_o,
+
+    // REG r1
+    output  wire [2:0] f1_o,
+    output  wire f2_o,
+
+    // REG r2
+    output  wire [2:0] f3_o,
+    output  wire f4_o,
+
+    // REG r3
+    output  wire [31:0] r3_o
+  );
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg [2:0] f1_reg;
+  reg f2_reg;
+  reg r1_wreq;
+  reg r1_wack;
+  reg [2:0] f3_reg;
+  reg f4_reg;
+  reg r2_wreq;
+  reg r2_wack;
+  reg [31:0] r3_reg;
+  reg r3_wreq;
+  reg r3_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [3:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+
+  // WB decode signals
+  always @(wb_sel_i)
+  ;
+  assign wb_en = wb_cyc_i & wb_stb_i;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb_we_i)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb_we_i)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb_we_i) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb_ack_o = ack_int;
+  assign wb_stall_o = ~ack_int & wb_en;
+  assign wb_rty_o = 1'b0;
+  assign wb_err_o = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        rd_ack_int <= 1'b0;
+        wb_dat_o <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 2'b00;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb_dat_o <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_adr_d0 <= wb_adr_i;
+        wr_dat_d0 <= wb_dat_i;
+      end
+  end
+
+  // Register r1
+  assign f1_o = f1_reg;
+  assign f2_o = f2_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        f1_reg <= 3'b000;
+        f2_reg <= 1'b0;
+        r1_wack <= 1'b0;
+      end
+    else
+      begin
+        if (r1_wreq == 1'b1)
+          begin
+            f1_reg <= wr_dat_d0[2:0];
+            f2_reg <= wr_dat_d0[4];
+          end
+        r1_wack <= r1_wreq;
+      end
+  end
+
+  // Register r2
+  assign f3_o = f3_reg;
+  assign f4_o = f4_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        f3_reg <= 3'b000;
+        f4_reg <= 1'b0;
+        r2_wack <= 1'b0;
+      end
+    else
+      begin
+        if (r2_wreq == 1'b1)
+          begin
+            f3_reg <= wr_dat_d0[2:0];
+            f4_reg <= wr_dat_d0[4];
+          end
+        r2_wack <= r2_wreq;
+      end
+  end
+
+  // Register r3
+  assign r3_o = r3_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        r3_reg <= 32'b00000000000000000000000000000000;
+        r3_wack <= 1'b0;
+      end
+    else
+      begin
+        if (r3_wreq == 1'b1)
+          r3_reg <= wr_dat_d0;
+        r3_wack <= r3_wreq;
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, r1_wack, r2_wack, r3_wack)
+  begin
+    r1_wreq = 1'b0;
+    r2_wreq = 1'b0;
+    r3_wreq = 1'b0;
+    case (wr_adr_d0[3:2])
+    2'b00:
+      begin
+        // Reg r1
+        r1_wreq = wr_req_d0;
+        wr_ack_int = r1_wack;
+      end
+    2'b01:
+      begin
+        // Reg r2
+        r2_wreq = wr_req_d0;
+        wr_ack_int = r2_wack;
+      end
+    2'b10:
+      begin
+        // Reg r3
+        r3_wreq = wr_req_d0;
+        wr_ack_int = r3_wack;
+      end
+    default:
+      wr_ack_int = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always @(wb_adr_i, rd_req_int, f1_reg, f2_reg, f3_reg, f4_reg, r3_reg)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    case (wb_adr_i[3:2])
+    2'b00:
+      begin
+        // Reg r1
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0[2:0] = f1_reg;
+        rd_dat_d0[3] = 1'b0;
+        rd_dat_d0[4] = f2_reg;
+        rd_dat_d0[31:5] = 27'b0;
+      end
+    2'b01:
+      begin
+        // Reg r2
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0[2:0] = f3_reg;
+        rd_dat_d0[3] = 1'b0;
+        rd_dat_d0[4] = f4_reg;
+        rd_dat_d0[31:5] = 27'b0;
+      end
+    2'b10:
+      begin
+        // Reg r3
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = r3_reg;
+      end
+    default:
+      rd_ack_d0 = rd_req_int;
+    endcase
+  end
+endmodule

--- a/testfiles/features/regprefix3.sv
+++ b/testfiles/features/regprefix3.sv
@@ -48,11 +48,11 @@ module regprefix3
   reg [31:0] wr_dat_d0;
 
   // WB decode signals
-  always @(wb_sel_i)
+  always_comb
   ;
   assign wb_en = wb_cyc_i & wb_stb_i;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_rip <= 1'b0;
@@ -61,7 +61,7 @@ module regprefix3
   end
   assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_wip <= 1'b0;
@@ -77,7 +77,7 @@ module regprefix3
   assign wb_err_o = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -99,7 +99,7 @@ module regprefix3
 
   // Register blk1_r1
   assign blk1_r1_o = blk1_r1_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -116,7 +116,7 @@ module regprefix3
 
   // Register blk1_r2
   assign blk1_r2_o = blk1_r2_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -133,7 +133,7 @@ module regprefix3
 
   // Register r3
   assign r3_o = r3_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -149,61 +149,61 @@ module regprefix3
   end
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0, blk1_r1_wack, blk1_r2_wack, r3_wack)
+  always_comb
   begin
-    blk1_r1_wreq <= 1'b0;
-    blk1_r2_wreq <= 1'b0;
-    r3_wreq <= 1'b0;
+    blk1_r1_wreq = 1'b0;
+    blk1_r2_wreq = 1'b0;
+    r3_wreq = 1'b0;
     case (wr_adr_d0[5:2])
     4'b0000:
       begin
         // Reg blk1_r1
-        blk1_r1_wreq <= wr_req_d0;
-        wr_ack_int <= blk1_r1_wack;
+        blk1_r1_wreq = wr_req_d0;
+        wr_ack_int = blk1_r1_wack;
       end
     4'b0001:
       begin
         // Reg blk1_r2
-        blk1_r2_wreq <= wr_req_d0;
-        wr_ack_int <= blk1_r2_wack;
+        blk1_r2_wreq = wr_req_d0;
+        wr_ack_int = blk1_r2_wack;
       end
     4'b1000:
       begin
         // Reg r3
-        r3_wreq <= wr_req_d0;
-        wr_ack_int <= r3_wack;
+        r3_wreq = wr_req_d0;
+        wr_ack_int = r3_wack;
       end
     default:
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     endcase
   end
 
   // Process for read requests.
-  always @(wb_adr_i, rd_req_int, blk1_r1_reg, blk1_r2_reg, r3_reg)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     case (wb_adr_i[5:2])
     4'b0000:
       begin
         // Reg blk1_r1
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0 <= blk1_r1_reg;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = blk1_r1_reg;
       end
     4'b0001:
       begin
         // Reg blk1_r2
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0 <= blk1_r2_reg;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = blk1_r2_reg;
       end
     4'b1000:
       begin
         // Reg r3
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0 <= r3_reg;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = r3_reg;
       end
     default:
-      rd_ack_d0 <= rd_req_int;
+      rd_ack_d0 = rd_req_int;
     endcase
   end
 endmodule

--- a/testfiles/features/regprefix3.v
+++ b/testfiles/features/regprefix3.v
@@ -1,0 +1,209 @@
+
+module regprefix3
+  (
+    input   wire rst_n_i,
+    input   wire clk_i,
+    input   wire wb_cyc_i,
+    input   wire wb_stb_i,
+    input   wire [5:2] wb_adr_i,
+    input   wire [3:0] wb_sel_i,
+    input   wire wb_we_i,
+    input   wire [31:0] wb_dat_i,
+    output  wire wb_ack_o,
+    output  wire wb_err_o,
+    output  wire wb_rty_o,
+    output  wire wb_stall_o,
+    output  reg [31:0] wb_dat_o,
+
+    // REG r1
+    output  wire [31:0] blk1_r1_o,
+
+    // REG r2
+    output  wire [31:0] blk1_r2_o,
+
+    // REG r3
+    output  wire [31:0] r3_o
+  );
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg [31:0] blk1_r1_reg;
+  reg blk1_r1_wreq;
+  reg blk1_r1_wack;
+  reg [31:0] blk1_r2_reg;
+  reg blk1_r2_wreq;
+  reg blk1_r2_wack;
+  reg [31:0] r3_reg;
+  reg r3_wreq;
+  reg r3_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [5:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+
+  // WB decode signals
+  always @(wb_sel_i)
+  ;
+  assign wb_en = wb_cyc_i & wb_stb_i;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb_we_i)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb_we_i)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb_we_i) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb_ack_o = ack_int;
+  assign wb_stall_o = ~ack_int & wb_en;
+  assign wb_rty_o = 1'b0;
+  assign wb_err_o = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        rd_ack_int <= 1'b0;
+        wb_dat_o <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 4'b0000;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb_dat_o <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_adr_d0 <= wb_adr_i;
+        wr_dat_d0 <= wb_dat_i;
+      end
+  end
+
+  // Register blk1_r1
+  assign blk1_r1_o = blk1_r1_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        blk1_r1_reg <= 32'b00000000000000000000000000000000;
+        blk1_r1_wack <= 1'b0;
+      end
+    else
+      begin
+        if (blk1_r1_wreq == 1'b1)
+          blk1_r1_reg <= wr_dat_d0;
+        blk1_r1_wack <= blk1_r1_wreq;
+      end
+  end
+
+  // Register blk1_r2
+  assign blk1_r2_o = blk1_r2_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        blk1_r2_reg <= 32'b00000000000000000000000000000000;
+        blk1_r2_wack <= 1'b0;
+      end
+    else
+      begin
+        if (blk1_r2_wreq == 1'b1)
+          blk1_r2_reg <= wr_dat_d0;
+        blk1_r2_wack <= blk1_r2_wreq;
+      end
+  end
+
+  // Register r3
+  assign r3_o = r3_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        r3_reg <= 32'b00000000000000000000000000000000;
+        r3_wack <= 1'b0;
+      end
+    else
+      begin
+        if (r3_wreq == 1'b1)
+          r3_reg <= wr_dat_d0;
+        r3_wack <= r3_wreq;
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, blk1_r1_wack, blk1_r2_wack, r3_wack)
+  begin
+    blk1_r1_wreq = 1'b0;
+    blk1_r2_wreq = 1'b0;
+    r3_wreq = 1'b0;
+    case (wr_adr_d0[5:2])
+    4'b0000:
+      begin
+        // Reg blk1_r1
+        blk1_r1_wreq = wr_req_d0;
+        wr_ack_int = blk1_r1_wack;
+      end
+    4'b0001:
+      begin
+        // Reg blk1_r2
+        blk1_r2_wreq = wr_req_d0;
+        wr_ack_int = blk1_r2_wack;
+      end
+    4'b1000:
+      begin
+        // Reg r3
+        r3_wreq = wr_req_d0;
+        wr_ack_int = r3_wack;
+      end
+    default:
+      wr_ack_int = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always @(wb_adr_i, rd_req_int, blk1_r1_reg, blk1_r2_reg, r3_reg)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    case (wb_adr_i[5:2])
+    4'b0000:
+      begin
+        // Reg blk1_r1
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = blk1_r1_reg;
+      end
+    4'b0001:
+      begin
+        // Reg blk1_r2
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = blk1_r2_reg;
+      end
+    4'b1000:
+      begin
+        // Reg r3
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = r3_reg;
+      end
+    default:
+      rd_ack_d0 = rd_req_int;
+    endcase
+  end
+endmodule

--- a/testfiles/features/repeat-iogroup1.sv
+++ b/testfiles/features/repeat-iogroup1.sv
@@ -49,11 +49,11 @@ module repeat_iogroup1
   reg [31:0] wr_dat_d0;
 
   // WB decode signals
-  always @(wb_sel_i)
+  always_comb
   ;
   assign wb_en = wb_cyc_i & wb_stb_i;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_rip <= 1'b0;
@@ -62,7 +62,7 @@ module repeat_iogroup1
   end
   assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_wip <= 1'b0;
@@ -78,7 +78,7 @@ module repeat_iogroup1
   assign wb_err_o = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -100,7 +100,7 @@ module repeat_iogroup1
 
   // Register arr1_0_areg1
   assign itf[0].areg1 = arr1_0_areg1_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -117,7 +117,7 @@ module repeat_iogroup1
 
   // Register arr1_1_areg1
   assign itf[1].areg1 = arr1_1_areg1_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -133,48 +133,48 @@ module repeat_iogroup1
   end
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0, arr1_0_areg1_wack, arr1_1_areg1_wack)
+  always_comb
   begin
-    arr1_0_areg1_wreq <= 1'b0;
-    arr1_1_areg1_wreq <= 1'b0;
+    arr1_0_areg1_wreq = 1'b0;
+    arr1_1_areg1_wreq = 1'b0;
     case (wr_adr_d0[2:2])
     1'b0:
       begin
         // Reg arr1_0_areg1
-        arr1_0_areg1_wreq <= wr_req_d0;
-        wr_ack_int <= arr1_0_areg1_wack;
+        arr1_0_areg1_wreq = wr_req_d0;
+        wr_ack_int = arr1_0_areg1_wack;
       end
     1'b1:
       begin
         // Reg arr1_1_areg1
-        arr1_1_areg1_wreq <= wr_req_d0;
-        wr_ack_int <= arr1_1_areg1_wack;
+        arr1_1_areg1_wreq = wr_req_d0;
+        wr_ack_int = arr1_1_areg1_wack;
       end
     default:
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     endcase
   end
 
   // Process for read requests.
-  always @(wb_adr_i, rd_req_int, arr1_0_areg1_reg, arr1_1_areg1_reg)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     case (wb_adr_i[2:2])
     1'b0:
       begin
         // Reg arr1_0_areg1
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0 <= arr1_0_areg1_reg;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = arr1_0_areg1_reg;
       end
     1'b1:
       begin
         // Reg arr1_1_areg1
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0 <= arr1_1_areg1_reg;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = arr1_1_areg1_reg;
       end
     default:
-      rd_ack_d0 <= rd_req_int;
+      rd_ack_d0 = rd_req_int;
     endcase
   end
 endmodule

--- a/testfiles/features/repeat-iogroup1.v
+++ b/testfiles/features/repeat-iogroup1.v
@@ -1,0 +1,180 @@
+interface t_itf;
+  logic [31:0] areg1;
+  modport master(
+    output areg1
+  );
+  modport slave(
+    input areg1
+  );
+endinterface
+
+
+module repeat_iogroup1
+  (
+    input   wire rst_n_i,
+    input   wire clk_i,
+    input   wire wb_cyc_i,
+    input   wire wb_stb_i,
+    input   wire [2:2] wb_adr_i,
+    input   wire [3:0] wb_sel_i,
+    input   wire wb_we_i,
+    input   wire [31:0] wb_dat_i,
+    output  wire wb_ack_o,
+    output  wire wb_err_o,
+    output  wire wb_rty_o,
+    output  wire wb_stall_o,
+    output  reg [31:0] wb_dat_o,
+
+    // REPEAT arr1
+    t_itf.master itf[2]
+  );
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg [31:0] arr1_0_areg1_reg;
+  reg arr1_0_areg1_wreq;
+  reg arr1_0_areg1_wack;
+  reg [31:0] arr1_1_areg1_reg;
+  reg arr1_1_areg1_wreq;
+  reg arr1_1_areg1_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [2:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+
+  // WB decode signals
+  always @(wb_sel_i)
+  ;
+  assign wb_en = wb_cyc_i & wb_stb_i;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb_we_i)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb_we_i)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb_we_i) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb_ack_o = ack_int;
+  assign wb_stall_o = ~ack_int & wb_en;
+  assign wb_rty_o = 1'b0;
+  assign wb_err_o = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        rd_ack_int <= 1'b0;
+        wb_dat_o <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 1'b0;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb_dat_o <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_adr_d0 <= wb_adr_i;
+        wr_dat_d0 <= wb_dat_i;
+      end
+  end
+
+  // Register arr1_0_areg1
+  assign itf[0].areg1 = arr1_0_areg1_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        arr1_0_areg1_reg <= 32'b00000000000000000000000000000000;
+        arr1_0_areg1_wack <= 1'b0;
+      end
+    else
+      begin
+        if (arr1_0_areg1_wreq == 1'b1)
+          arr1_0_areg1_reg <= wr_dat_d0;
+        arr1_0_areg1_wack <= arr1_0_areg1_wreq;
+      end
+  end
+
+  // Register arr1_1_areg1
+  assign itf[1].areg1 = arr1_1_areg1_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        arr1_1_areg1_reg <= 32'b00000000000000000000000000000000;
+        arr1_1_areg1_wack <= 1'b0;
+      end
+    else
+      begin
+        if (arr1_1_areg1_wreq == 1'b1)
+          arr1_1_areg1_reg <= wr_dat_d0;
+        arr1_1_areg1_wack <= arr1_1_areg1_wreq;
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, arr1_0_areg1_wack, arr1_1_areg1_wack)
+  begin
+    arr1_0_areg1_wreq = 1'b0;
+    arr1_1_areg1_wreq = 1'b0;
+    case (wr_adr_d0[2:2])
+    1'b0:
+      begin
+        // Reg arr1_0_areg1
+        arr1_0_areg1_wreq = wr_req_d0;
+        wr_ack_int = arr1_0_areg1_wack;
+      end
+    1'b1:
+      begin
+        // Reg arr1_1_areg1
+        arr1_1_areg1_wreq = wr_req_d0;
+        wr_ack_int = arr1_1_areg1_wack;
+      end
+    default:
+      wr_ack_int = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always @(wb_adr_i, rd_req_int, arr1_0_areg1_reg, arr1_1_areg1_reg)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    case (wb_adr_i[2:2])
+    1'b0:
+      begin
+        // Reg arr1_0_areg1
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = arr1_0_areg1_reg;
+      end
+    1'b1:
+      begin
+        // Reg arr1_1_areg1
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = arr1_1_areg1_reg;
+      end
+    default:
+      rd_ack_d0 = rd_req_int;
+    endcase
+  end
+endmodule

--- a/testfiles/features/repeat-iogroup2.sv
+++ b/testfiles/features/repeat-iogroup2.sv
@@ -46,11 +46,11 @@ module repeat_iogroup1
   reg [31:0] wr_dat_d0;
 
   // WB decode signals
-  always @(wb_sel_i)
+  always_comb
   ;
   assign wb_en = wb_cyc_i & wb_stb_i;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_rip <= 1'b0;
@@ -59,7 +59,7 @@ module repeat_iogroup1
   end
   assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_wip <= 1'b0;
@@ -75,7 +75,7 @@ module repeat_iogroup1
   assign wb_err_o = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -102,38 +102,38 @@ module repeat_iogroup1
   assign itf[1].areg1o = wr_dat_d0;
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0)
+  always_comb
   case (wr_adr_d0[2:2])
   1'b0:
     // Reg arr1_0_areg1
-    wr_ack_int <= wr_req_d0;
+    wr_ack_int = wr_req_d0;
   1'b1:
     // Reg arr1_1_areg1
-    wr_ack_int <= wr_req_d0;
+    wr_ack_int = wr_req_d0;
   default:
-    wr_ack_int <= wr_req_d0;
+    wr_ack_int = wr_req_d0;
   endcase
 
   // Process for read requests.
-  always @(wb_adr_i, rd_req_int, itf[0].areg1i, itf[1].areg1i)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     case (wb_adr_i[2:2])
     1'b0:
       begin
         // Reg arr1_0_areg1
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0 <= itf[0].areg1i;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = itf[0].areg1i;
       end
     1'b1:
       begin
         // Reg arr1_1_areg1
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0 <= itf[1].areg1i;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = itf[1].areg1i;
       end
     default:
-      rd_ack_d0 <= rd_req_int;
+      rd_ack_d0 = rd_req_int;
     endcase
   end
 endmodule

--- a/testfiles/features/repeat-iogroup2.v
+++ b/testfiles/features/repeat-iogroup2.v
@@ -1,0 +1,139 @@
+interface t_itf;
+  logic [31:0] areg1i;
+  logic [31:0] areg1o;
+  modport master(
+    input areg1i,
+    output areg1o
+  );
+  modport slave(
+    output areg1i,
+    input areg1o
+  );
+endinterface
+
+
+module repeat_iogroup1
+  (
+    input   wire rst_n_i,
+    input   wire clk_i,
+    input   wire wb_cyc_i,
+    input   wire wb_stb_i,
+    input   wire [2:2] wb_adr_i,
+    input   wire [3:0] wb_sel_i,
+    input   wire wb_we_i,
+    input   wire [31:0] wb_dat_i,
+    output  wire wb_ack_o,
+    output  wire wb_err_o,
+    output  wire wb_rty_o,
+    output  wire wb_stall_o,
+    output  reg [31:0] wb_dat_o,
+
+    // REPEAT arr1
+    t_itf.master itf[2]
+  );
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [2:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+
+  // WB decode signals
+  always @(wb_sel_i)
+  ;
+  assign wb_en = wb_cyc_i & wb_stb_i;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb_we_i)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb_we_i)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb_we_i) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb_ack_o = ack_int;
+  assign wb_stall_o = ~ack_int & wb_en;
+  assign wb_rty_o = 1'b0;
+  assign wb_err_o = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        rd_ack_int <= 1'b0;
+        wb_dat_o <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 1'b0;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb_dat_o <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_adr_d0 <= wb_adr_i;
+        wr_dat_d0 <= wb_dat_i;
+      end
+  end
+
+  // Register arr1_0_areg1
+  assign itf[0].areg1o = wr_dat_d0;
+
+  // Register arr1_1_areg1
+  assign itf[1].areg1o = wr_dat_d0;
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0)
+  case (wr_adr_d0[2:2])
+  1'b0:
+    // Reg arr1_0_areg1
+    wr_ack_int = wr_req_d0;
+  1'b1:
+    // Reg arr1_1_areg1
+    wr_ack_int = wr_req_d0;
+  default:
+    wr_ack_int = wr_req_d0;
+  endcase
+
+  // Process for read requests.
+  always @(wb_adr_i, rd_req_int, itf[0].areg1i, itf[1].areg1i)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    case (wb_adr_i[2:2])
+    1'b0:
+      begin
+        // Reg arr1_0_areg1
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = itf[0].areg1i;
+      end
+    1'b1:
+      begin
+        // Reg arr1_1_areg1
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = itf[1].areg1i;
+      end
+    default:
+      rd_ack_d0 = rd_req_int;
+    endcase
+  end
+endmodule

--- a/testfiles/features/repeat-iogroup3.sv
+++ b/testfiles/features/repeat-iogroup3.sv
@@ -46,11 +46,11 @@ module repeat_iogroup3
   reg [31:0] wr_dat_d0;
 
   // WB decode signals
-  always @(wb_sel_i)
+  always_comb
   ;
   assign wb_en = wb_cyc_i & wb_stb_i;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_rip <= 1'b0;
@@ -59,7 +59,7 @@ module repeat_iogroup3
   end
   assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_wip <= 1'b0;
@@ -75,7 +75,7 @@ module repeat_iogroup3
   assign wb_err_o = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -102,38 +102,38 @@ module repeat_iogroup3
   assign itf[1].areg1o = wr_dat_d0;
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0)
+  always_comb
   case (wr_adr_d0[2:2])
   1'b0:
     // Reg areg10
-    wr_ack_int <= wr_req_d0;
+    wr_ack_int = wr_req_d0;
   1'b1:
     // Reg areg11
-    wr_ack_int <= wr_req_d0;
+    wr_ack_int = wr_req_d0;
   default:
-    wr_ack_int <= wr_req_d0;
+    wr_ack_int = wr_req_d0;
   endcase
 
   // Process for read requests.
-  always @(wb_adr_i, rd_req_int, itf[0].areg1i, itf[1].areg1i)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     case (wb_adr_i[2:2])
     1'b0:
       begin
         // Reg areg10
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0 <= itf[0].areg1i;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = itf[0].areg1i;
       end
     1'b1:
       begin
         // Reg areg11
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0 <= itf[1].areg1i;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = itf[1].areg1i;
       end
     default:
-      rd_ack_d0 <= rd_req_int;
+      rd_ack_d0 = rd_req_int;
     endcase
   end
 endmodule

--- a/testfiles/features/repeat-iogroup3.v
+++ b/testfiles/features/repeat-iogroup3.v
@@ -1,0 +1,139 @@
+interface t_itf;
+  logic [31:0] areg1i;
+  logic [31:0] areg1o;
+  modport master(
+    input areg1i,
+    output areg1o
+  );
+  modport slave(
+    output areg1i,
+    input areg1o
+  );
+endinterface
+
+
+module repeat_iogroup3
+  (
+    input   wire rst_n_i,
+    input   wire clk_i,
+    input   wire wb_cyc_i,
+    input   wire wb_stb_i,
+    input   wire [2:2] wb_adr_i,
+    input   wire [3:0] wb_sel_i,
+    input   wire wb_we_i,
+    input   wire [31:0] wb_dat_i,
+    output  wire wb_ack_o,
+    output  wire wb_err_o,
+    output  wire wb_rty_o,
+    output  wire wb_stall_o,
+    output  reg [31:0] wb_dat_o,
+
+    // REPEAT arr1
+    t_itf.master itf[2]
+  );
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [2:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+
+  // WB decode signals
+  always @(wb_sel_i)
+  ;
+  assign wb_en = wb_cyc_i & wb_stb_i;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb_we_i)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb_we_i)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb_we_i) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb_ack_o = ack_int;
+  assign wb_stall_o = ~ack_int & wb_en;
+  assign wb_rty_o = 1'b0;
+  assign wb_err_o = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        rd_ack_int <= 1'b0;
+        wb_dat_o <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 1'b0;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb_dat_o <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_adr_d0 <= wb_adr_i;
+        wr_dat_d0 <= wb_dat_i;
+      end
+  end
+
+  // Register areg10
+  assign itf[0].areg1o = wr_dat_d0;
+
+  // Register areg11
+  assign itf[1].areg1o = wr_dat_d0;
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0)
+  case (wr_adr_d0[2:2])
+  1'b0:
+    // Reg areg10
+    wr_ack_int = wr_req_d0;
+  1'b1:
+    // Reg areg11
+    wr_ack_int = wr_req_d0;
+  default:
+    wr_ack_int = wr_req_d0;
+  endcase
+
+  // Process for read requests.
+  always @(wb_adr_i, rd_req_int, itf[0].areg1i, itf[1].areg1i)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    case (wb_adr_i[2:2])
+    1'b0:
+      begin
+        // Reg areg10
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = itf[0].areg1i;
+      end
+    1'b1:
+      begin
+        // Reg areg11
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = itf[1].areg1i;
+      end
+    default:
+      rd_ack_d0 = rd_req_int;
+    endcase
+  end
+endmodule

--- a/testfiles/features/repeat-iogroup4.sv
+++ b/testfiles/features/repeat-iogroup4.sv
@@ -52,11 +52,11 @@ module repeat_iogroup4
   reg [31:0] wr_dat_d0;
 
   // WB decode signals
-  always @(wb_sel_i)
+  always_comb
   ;
   assign wb_en = wb_cyc_i & wb_stb_i;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_rip <= 1'b0;
@@ -65,7 +65,7 @@ module repeat_iogroup4
   end
   assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_wip <= 1'b0;
@@ -81,7 +81,7 @@ module repeat_iogroup4
   assign wb_err_o = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -103,7 +103,7 @@ module repeat_iogroup4
 
   // Register areg0
   assign itf[0].areg = arr1_0_areg_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -121,46 +121,46 @@ module repeat_iogroup4
   // Register regf0
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0, areg0_wack)
+  always_comb
   begin
-    areg0_wreq <= 1'b0;
+    areg0_wreq = 1'b0;
     case (wr_adr_d0[2:2])
     1'b0:
       begin
         // Reg areg0
-        areg0_wreq <= wr_req_d0;
-        wr_ack_int <= areg0_wack;
+        areg0_wreq = wr_req_d0;
+        wr_ack_int = areg0_wack;
       end
     1'b1:
       // Reg regf0
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     default:
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     endcase
   end
 
   // Process for read requests.
-  always @(wb_adr_i, rd_req_int, arr1_0_areg_reg, itf[0].regf_f0, itf[0].regf_f1)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     case (wb_adr_i[2:2])
     1'b0:
       begin
         // Reg areg0
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0 <= arr1_0_areg_reg;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = arr1_0_areg_reg;
       end
     1'b1:
       begin
         // Reg regf0
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0[0] <= itf[0].regf_f0;
-        rd_dat_d0[1] <= itf[0].regf_f1;
-        rd_dat_d0[31:2] <= 30'b0;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0[0] = itf[0].regf_f0;
+        rd_dat_d0[1] = itf[0].regf_f1;
+        rd_dat_d0[31:2] = 30'b0;
       end
     default:
-      rd_ack_d0 <= rd_req_int;
+      rd_ack_d0 = rd_req_int;
     endcase
   end
 endmodule

--- a/testfiles/features/repeat-iogroup4.v
+++ b/testfiles/features/repeat-iogroup4.v
@@ -1,0 +1,166 @@
+interface t_itf;
+  logic [31:0] areg;
+  logic regf_f0;
+  logic regf_f1;
+  modport master(
+    input regf_f0,
+    input regf_f1,
+    output areg
+  );
+  modport slave(
+    output regf_f0,
+    output regf_f1,
+    input areg
+  );
+endinterface
+
+
+module repeat_iogroup4
+  (
+    input   wire rst_n_i,
+    input   wire clk_i,
+    input   wire wb_cyc_i,
+    input   wire wb_stb_i,
+    input   wire [2:2] wb_adr_i,
+    input   wire [3:0] wb_sel_i,
+    input   wire wb_we_i,
+    input   wire [31:0] wb_dat_i,
+    output  wire wb_ack_o,
+    output  wire wb_err_o,
+    output  wire wb_rty_o,
+    output  wire wb_stall_o,
+    output  reg [31:0] wb_dat_o,
+
+    // the array of registers
+    t_itf.master itf[1]
+  );
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg [31:0] arr1_0_areg_reg;
+  reg areg0_wreq;
+  reg areg0_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [2:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+
+  // WB decode signals
+  always @(wb_sel_i)
+  ;
+  assign wb_en = wb_cyc_i & wb_stb_i;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb_we_i)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb_we_i)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb_we_i) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb_ack_o = ack_int;
+  assign wb_stall_o = ~ack_int & wb_en;
+  assign wb_rty_o = 1'b0;
+  assign wb_err_o = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        rd_ack_int <= 1'b0;
+        wb_dat_o <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 1'b0;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb_dat_o <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_adr_d0 <= wb_adr_i;
+        wr_dat_d0 <= wb_dat_i;
+      end
+  end
+
+  // Register areg0
+  assign itf[0].areg = arr1_0_areg_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        arr1_0_areg_reg <= 32'b00000000000000000000000000000000;
+        areg0_wack <= 1'b0;
+      end
+    else
+      begin
+        if (areg0_wreq == 1'b1)
+          arr1_0_areg_reg <= wr_dat_d0;
+        areg0_wack <= areg0_wreq;
+      end
+  end
+
+  // Register regf0
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, areg0_wack)
+  begin
+    areg0_wreq = 1'b0;
+    case (wr_adr_d0[2:2])
+    1'b0:
+      begin
+        // Reg areg0
+        areg0_wreq = wr_req_d0;
+        wr_ack_int = areg0_wack;
+      end
+    1'b1:
+      // Reg regf0
+      wr_ack_int = wr_req_d0;
+    default:
+      wr_ack_int = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always @(wb_adr_i, rd_req_int, arr1_0_areg_reg, itf[0].regf_f0, itf[0].regf_f1)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    case (wb_adr_i[2:2])
+    1'b0:
+      begin
+        // Reg areg0
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = arr1_0_areg_reg;
+      end
+    1'b1:
+      begin
+        // Reg regf0
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0[0] = itf[0].regf_f0;
+        rd_dat_d0[1] = itf[0].regf_f1;
+        rd_dat_d0[31:2] = 30'b0;
+      end
+    default:
+      rd_ack_d0 = rd_req_int;
+    endcase
+  end
+endmodule

--- a/testfiles/features/semver1.sv
+++ b/testfiles/features/semver1.sv
@@ -34,11 +34,11 @@ module semver1
   reg [31:0] wr_dat_d0;
 
   // WB decode signals
-  always @(wb_sel_i)
+  always_comb
   ;
   assign wb_en = wb_cyc_i & wb_stb_i;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_rip <= 1'b0;
@@ -47,7 +47,7 @@ module semver1
   end
   assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_wip <= 1'b0;
@@ -63,7 +63,7 @@ module semver1
   assign wb_err_o = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -83,7 +83,7 @@ module semver1
 
   // Register r1
   assign r1_o = r1_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -99,21 +99,21 @@ module semver1
   end
 
   // Process for write requests.
-  always @(wr_req_d0, r1_wack)
+  always_comb
   begin
-    r1_wreq <= 1'b0;
+    r1_wreq = 1'b0;
     // Reg r1
-    r1_wreq <= wr_req_d0;
-    wr_ack_int <= r1_wack;
+    r1_wreq = wr_req_d0;
+    wr_ack_int = r1_wack;
   end
 
   // Process for read requests.
-  always @(rd_req_int, r1_reg)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     // Reg r1
-    rd_ack_d0 <= rd_req_int;
-    rd_dat_d0 <= r1_reg;
+    rd_ack_d0 = rd_req_int;
+    rd_dat_d0 = r1_reg;
   end
 endmodule

--- a/testfiles/features/semver1.v
+++ b/testfiles/features/semver1.v
@@ -1,0 +1,119 @@
+
+module semver1
+  (
+    input   wire rst_n_i,
+    input   wire clk_i,
+    input   wire wb_cyc_i,
+    input   wire wb_stb_i,
+    input   wire [3:0] wb_sel_i,
+    input   wire wb_we_i,
+    input   wire [31:0] wb_dat_i,
+    output  wire wb_ack_o,
+    output  wire wb_err_o,
+    output  wire wb_rty_o,
+    output  wire wb_stall_o,
+    output  reg [31:0] wb_dat_o,
+
+    // REG r1
+    output  wire [31:0] r1_o
+  );
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg [31:0] r1_reg;
+  reg r1_wreq;
+  reg r1_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [31:0] wr_dat_d0;
+
+  // WB decode signals
+  always @(wb_sel_i)
+  ;
+  assign wb_en = wb_cyc_i & wb_stb_i;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb_we_i)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb_we_i)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb_we_i) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb_ack_o = ack_int;
+  assign wb_stall_o = ~ack_int & wb_en;
+  assign wb_rty_o = 1'b0;
+  assign wb_err_o = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        rd_ack_int <= 1'b0;
+        wb_dat_o <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb_dat_o <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_dat_d0 <= wb_dat_i;
+      end
+  end
+
+  // Register r1
+  assign r1_o = r1_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        r1_reg <= 32'b00000000000000000000000000000000;
+        r1_wack <= 1'b0;
+      end
+    else
+      begin
+        if (r1_wreq == 1'b1)
+          r1_reg <= wr_dat_d0;
+        r1_wack <= r1_wreq;
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_req_d0, r1_wack)
+  begin
+    r1_wreq = 1'b0;
+    // Reg r1
+    r1_wreq = wr_req_d0;
+    wr_ack_int = r1_wack;
+  end
+
+  // Process for read requests.
+  always @(rd_req_int, r1_reg)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    // Reg r1
+    rd_ack_d0 = rd_req_int;
+    rd_dat_d0 = r1_reg;
+  end
+endmodule

--- a/testfiles/features/semver2.sv
+++ b/testfiles/features/semver2.sv
@@ -36,11 +36,11 @@ module semver2
   reg [31:0] wr_dat_d0;
 
   // WB decode signals
-  always @(wb_sel_i)
+  always_comb
   ;
   assign wb_en = wb_cyc_i & wb_stb_i;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_rip <= 1'b0;
@@ -49,7 +49,7 @@ module semver2
   end
   assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_wip <= 1'b0;
@@ -65,7 +65,7 @@ module semver2
   assign wb_err_o = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -87,7 +87,7 @@ module semver2
 
   // Register r1
   assign r1_o = r1_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -105,44 +105,44 @@ module semver2
   // Register v
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0, r1_wack)
+  always_comb
   begin
-    r1_wreq <= 1'b0;
+    r1_wreq = 1'b0;
     case (wr_adr_d0[2:2])
     1'b0:
       begin
         // Reg r1
-        r1_wreq <= wr_req_d0;
-        wr_ack_int <= r1_wack;
+        r1_wreq = wr_req_d0;
+        wr_ack_int = r1_wack;
       end
     1'b1:
       // Reg v
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     default:
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     endcase
   end
 
   // Process for read requests.
-  always @(wb_adr_i, rd_req_int, r1_reg)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     case (wb_adr_i[2:2])
     1'b0:
       begin
         // Reg r1
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0 <= r1_reg;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = r1_reg;
       end
     1'b1:
       begin
         // Reg v
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0 <= 32'b00000000000000010000001000000011;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = 32'b00000000000000010000001000000011;
       end
     default:
-      rd_ack_d0 <= rd_req_int;
+      rd_ack_d0 = rd_req_int;
     endcase
   end
 endmodule

--- a/testfiles/features/semver2.v
+++ b/testfiles/features/semver2.v
@@ -1,0 +1,148 @@
+
+module semver2
+  (
+    input   wire rst_n_i,
+    input   wire clk_i,
+    input   wire wb_cyc_i,
+    input   wire wb_stb_i,
+    input   wire [2:2] wb_adr_i,
+    input   wire [3:0] wb_sel_i,
+    input   wire wb_we_i,
+    input   wire [31:0] wb_dat_i,
+    output  wire wb_ack_o,
+    output  wire wb_err_o,
+    output  wire wb_rty_o,
+    output  wire wb_stall_o,
+    output  reg [31:0] wb_dat_o,
+
+    // REG r1
+    output  wire [31:0] r1_o
+  );
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg [31:0] r1_reg;
+  reg r1_wreq;
+  reg r1_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [2:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+
+  // WB decode signals
+  always @(wb_sel_i)
+  ;
+  assign wb_en = wb_cyc_i & wb_stb_i;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb_we_i)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb_we_i)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb_we_i) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb_ack_o = ack_int;
+  assign wb_stall_o = ~ack_int & wb_en;
+  assign wb_rty_o = 1'b0;
+  assign wb_err_o = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        rd_ack_int <= 1'b0;
+        wb_dat_o <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 1'b0;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb_dat_o <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_adr_d0 <= wb_adr_i;
+        wr_dat_d0 <= wb_dat_i;
+      end
+  end
+
+  // Register r1
+  assign r1_o = r1_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        r1_reg <= 32'b00000000000000000000000000000000;
+        r1_wack <= 1'b0;
+      end
+    else
+      begin
+        if (r1_wreq == 1'b1)
+          r1_reg <= wr_dat_d0;
+        r1_wack <= r1_wreq;
+      end
+  end
+
+  // Register v
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, r1_wack)
+  begin
+    r1_wreq = 1'b0;
+    case (wr_adr_d0[2:2])
+    1'b0:
+      begin
+        // Reg r1
+        r1_wreq = wr_req_d0;
+        wr_ack_int = r1_wack;
+      end
+    1'b1:
+      // Reg v
+      wr_ack_int = wr_req_d0;
+    default:
+      wr_ack_int = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always @(wb_adr_i, rd_req_int, r1_reg)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    case (wb_adr_i[2:2])
+    1'b0:
+      begin
+        // Reg r1
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = r1_reg;
+      end
+    1'b1:
+      begin
+        // Reg v
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = 32'b00000000000000010000001000000011;
+      end
+    default:
+      rd_ack_d0 = rd_req_int;
+    endcase
+  end
+endmodule

--- a/testfiles/features/wires1.sv
+++ b/testfiles/features/wires1.sv
@@ -52,11 +52,11 @@ module wires1
   reg [31:0] wr_dat_d0;
 
   // WB decode signals
-  always @(wb_sel_i)
+  always_comb
   ;
   assign wb_en = wb_cyc_i & wb_stb_i;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_rip <= 1'b0;
@@ -65,7 +65,7 @@ module wires1
   end
   assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_wip <= 1'b0;
@@ -81,7 +81,7 @@ module wires1
   assign wb_err_o = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -103,7 +103,7 @@ module wires1
 
   // Register strobe
   assign strobe_o = strobe_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -127,63 +127,63 @@ module wires1
   assign acks_wr_o = acks_wreq;
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0, strobe_wack, acks_wack_i)
+  always_comb
   begin
-    strobe_wreq <= 1'b0;
-    acks_wreq <= 1'b0;
+    strobe_wreq = 1'b0;
+    acks_wreq = 1'b0;
     case (wr_adr_d0[3:2])
     2'b00:
       begin
         // Reg strobe
-        strobe_wreq <= wr_req_d0;
-        wr_ack_int <= strobe_wack;
+        strobe_wreq = wr_req_d0;
+        wr_ack_int = strobe_wack;
       end
     2'b01:
       // Reg wires
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     2'b10:
       begin
         // Reg acks
-        acks_wreq <= wr_req_d0;
-        wr_ack_int <= acks_wack_i;
+        acks_wreq = wr_req_d0;
+        wr_ack_int = acks_wack_i;
       end
     default:
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     endcase
   end
 
   // Process for read requests.
-  always @(wb_adr_i, rd_req_int, strobe_reg, wires_i, acks_rack_i, acks_i)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
-    strobe_rd_o <= 1'b0;
-    wires_rd_o <= 1'b0;
-    acks_rd_o <= 1'b0;
+    rd_dat_d0 = {32{1'bx}};
+    strobe_rd_o = 1'b0;
+    wires_rd_o = 1'b0;
+    acks_rd_o = 1'b0;
     case (wb_adr_i[3:2])
     2'b00:
       begin
         // Reg strobe
-        strobe_rd_o <= rd_req_int;
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0 <= strobe_reg;
+        strobe_rd_o = rd_req_int;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = strobe_reg;
       end
     2'b01:
       begin
         // Reg wires
-        wires_rd_o <= rd_req_int;
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0 <= wires_i;
+        wires_rd_o = rd_req_int;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = wires_i;
       end
     2'b10:
       begin
         // Reg acks
-        acks_rd_o <= rd_req_int;
-        rd_ack_d0 <= acks_rack_i;
-        rd_dat_d0 <= acks_i;
+        acks_rd_o = rd_req_int;
+        rd_ack_d0 = acks_rack_i;
+        rd_dat_d0 = acks_i;
       end
     default:
-      rd_ack_d0 <= rd_req_int;
+      rd_ack_d0 = rd_req_int;
     endcase
   end
 endmodule

--- a/testfiles/features/wires1.v
+++ b/testfiles/features/wires1.v
@@ -1,0 +1,189 @@
+
+module wires1
+  (
+    input   wire rst_n_i,
+    input   wire clk_i,
+    input   wire wb_cyc_i,
+    input   wire wb_stb_i,
+    input   wire [3:2] wb_adr_i,
+    input   wire [3:0] wb_sel_i,
+    input   wire wb_we_i,
+    input   wire [31:0] wb_dat_i,
+    output  wire wb_ack_o,
+    output  wire wb_err_o,
+    output  wire wb_rty_o,
+    output  wire wb_stall_o,
+    output  reg [31:0] wb_dat_o,
+
+    // REG strobe
+    output  wire [31:0] strobe_o,
+    output  wire strobe_wr_o,
+    output  reg strobe_rd_o,
+
+    // REG wires
+    input   wire [31:0] wires_i,
+    output  wire [31:0] wires_o,
+    output  reg wires_rd_o,
+
+    // REG acks
+    input   wire [31:0] acks_i,
+    output  wire [31:0] acks_o,
+    output  wire acks_wr_o,
+    output  reg acks_rd_o,
+    input   wire acks_wack_i,
+    input   wire acks_rack_i
+  );
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg [31:0] strobe_reg;
+  reg strobe_wreq;
+  reg strobe_wack;
+  reg acks_wreq;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [3:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+
+  // WB decode signals
+  always @(wb_sel_i)
+  ;
+  assign wb_en = wb_cyc_i & wb_stb_i;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb_we_i)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb_we_i)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb_we_i) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb_ack_o = ack_int;
+  assign wb_stall_o = ~ack_int & wb_en;
+  assign wb_rty_o = 1'b0;
+  assign wb_err_o = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        rd_ack_int <= 1'b0;
+        wb_dat_o <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 2'b00;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb_dat_o <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_adr_d0 <= wb_adr_i;
+        wr_dat_d0 <= wb_dat_i;
+      end
+  end
+
+  // Register strobe
+  assign strobe_o = strobe_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        strobe_reg <= 32'b00000000000000000000000000000000;
+        strobe_wack <= 1'b0;
+      end
+    else
+      begin
+        if (strobe_wreq == 1'b1)
+          strobe_reg <= wr_dat_d0;
+        strobe_wack <= strobe_wreq;
+      end
+  end
+  assign strobe_wr_o = strobe_wack;
+
+  // Register wires
+  assign wires_o = wr_dat_d0;
+
+  // Register acks
+  assign acks_o = wr_dat_d0;
+  assign acks_wr_o = acks_wreq;
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, strobe_wack, acks_wack_i)
+  begin
+    strobe_wreq = 1'b0;
+    acks_wreq = 1'b0;
+    case (wr_adr_d0[3:2])
+    2'b00:
+      begin
+        // Reg strobe
+        strobe_wreq = wr_req_d0;
+        wr_ack_int = strobe_wack;
+      end
+    2'b01:
+      // Reg wires
+      wr_ack_int = wr_req_d0;
+    2'b10:
+      begin
+        // Reg acks
+        acks_wreq = wr_req_d0;
+        wr_ack_int = acks_wack_i;
+      end
+    default:
+      wr_ack_int = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always @(wb_adr_i, rd_req_int, strobe_reg, wires_i, acks_rack_i, acks_i)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    strobe_rd_o = 1'b0;
+    wires_rd_o = 1'b0;
+    acks_rd_o = 1'b0;
+    case (wb_adr_i[3:2])
+    2'b00:
+      begin
+        // Reg strobe
+        strobe_rd_o = rd_req_int;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = strobe_reg;
+      end
+    2'b01:
+      begin
+        // Reg wires
+        wires_rd_o = rd_req_int;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = wires_i;
+      end
+    2'b10:
+      begin
+        // Reg acks
+        acks_rd_o = rd_req_int;
+        rd_ack_d0 = acks_rack_i;
+        rd_dat_d0 = acks_i;
+      end
+    default:
+      rd_ack_d0 = rd_req_int;
+    endcase
+  end
+endmodule

--- a/testfiles/features/xilinx_attrs.sv
+++ b/testfiles/features/xilinx_attrs.sv
@@ -74,7 +74,7 @@ module xilinx_attrs
   assign awready = ~axi_awset;
   assign wready = ~axi_wset;
   assign bvalid = axi_wdone;
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -117,7 +117,7 @@ module xilinx_attrs
   // AR and R channels
   assign arready = ~axi_arset;
   assign rvalid = axi_rdone;
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -150,7 +150,7 @@ module xilinx_attrs
   assign rresp = 2'b00;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -178,24 +178,24 @@ module xilinx_attrs
   assign subm_awprot_o = 3'b000;
   assign subm_wvalid_o = subm_w_val;
   assign subm_wdata_o = wr_dat_d0;
-  always @(wr_sel_d0)
+  always_comb
   begin
-    subm_wstrb_o <= 4'b0;
+    subm_wstrb_o = 4'b0;
     if (~(wr_sel_d0[7:0] == 8'b0))
-      subm_wstrb_o[0] <= 1'b1;
+      subm_wstrb_o[0] = 1'b1;
     if (~(wr_sel_d0[15:8] == 8'b0))
-      subm_wstrb_o[1] <= 1'b1;
+      subm_wstrb_o[1] = 1'b1;
     if (~(wr_sel_d0[23:16] == 8'b0))
-      subm_wstrb_o[2] <= 1'b1;
+      subm_wstrb_o[2] = 1'b1;
     if (~(wr_sel_d0[31:24] == 8'b0))
-      subm_wstrb_o[3] <= 1'b1;
+      subm_wstrb_o[3] = 1'b1;
   end
   assign subm_bready_o = 1'b1;
   assign subm_arvalid_o = subm_ar_val;
   assign subm_araddr_o = rd_addr[2:2];
   assign subm_arprot_o = 3'b000;
   assign subm_rready_o = 1'b1;
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -212,23 +212,23 @@ module xilinx_attrs
   end
 
   // Process for write requests.
-  always @(wr_req_d0, subm_bvalid_i)
+  always_comb
   begin
-    subm_wr <= 1'b0;
+    subm_wr = 1'b0;
     // Submap subm
-    subm_wr <= wr_req_d0;
-    wr_ack <= subm_bvalid_i;
+    subm_wr = wr_req_d0;
+    wr_ack = subm_bvalid_i;
   end
 
   // Process for read requests.
-  always @(rd_req, subm_rdata_i, subm_rvalid_i)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
-    subm_rd <= 1'b0;
+    rd_dat_d0 = {32{1'bx}};
+    subm_rd = 1'b0;
     // Submap subm
-    subm_rd <= rd_req;
-    rd_dat_d0 <= subm_rdata_i;
-    rd_ack_d0 <= subm_rvalid_i;
+    subm_rd = rd_req;
+    rd_dat_d0 = subm_rdata_i;
+    rd_ack_d0 = subm_rvalid_i;
   end
 endmodule

--- a/testfiles/features/xilinx_attrs.v
+++ b/testfiles/features/xilinx_attrs.v
@@ -1,0 +1,234 @@
+
+module xilinx_attrs
+  (
+    input   wire aclk,
+    input   wire areset_n,
+    input   wire awvalid,
+    output  wire awready,
+    input   wire [2:2] awaddr,
+    input   wire [2:0] awprot,
+    input   wire wvalid,
+    output  wire wready,
+    input   wire [31:0] wdata,
+    input   wire [3:0] wstrb,
+    output  wire bvalid,
+    input   wire bready,
+    output  wire [1:0] bresp,
+    input   wire arvalid,
+    output  wire arready,
+    input   wire [2:2] araddr,
+    input   wire [2:0] arprot,
+    output  wire rvalid,
+    input   wire rready,
+    output  reg [31:0] rdata,
+    output  wire [1:0] rresp,
+
+    // AXI-4 lite bus subm
+    output  wire subm_awvalid_o,
+    input   wire subm_awready_i,
+    output  wire [2:2] subm_awaddr_o,
+    output  wire [2:0] subm_awprot_o,
+    output  wire subm_wvalid_o,
+    input   wire subm_wready_i,
+    output  wire [31:0] subm_wdata_o,
+    output  reg [3:0] subm_wstrb_o,
+    input   wire subm_bvalid_i,
+    output  wire subm_bready_o,
+    input   wire [1:0] subm_bresp_i,
+    output  wire subm_arvalid_o,
+    input   wire subm_arready_i,
+    output  wire [2:2] subm_araddr_o,
+    output  wire [2:0] subm_arprot_o,
+    input   wire subm_rvalid_i,
+    output  wire subm_rready_o,
+    input   wire [31:0] subm_rdata_i,
+    input   wire [1:0] subm_rresp_i
+  );
+  reg wr_req;
+  reg wr_ack;
+  reg [2:2] wr_addr;
+  reg [31:0] wr_data;
+  reg [31:0] wr_sel;
+  reg axi_awset;
+  reg axi_wset;
+  reg axi_wdone;
+  reg rd_req;
+  reg rd_ack;
+  reg [2:2] rd_addr;
+  reg [31:0] rd_data;
+  reg axi_arset;
+  reg axi_rdone;
+  reg subm_aw_val;
+  reg subm_w_val;
+  reg subm_ar_val;
+  reg subm_rd;
+  reg subm_wr;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [2:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+  reg [31:0] wr_sel_d0;
+
+  // AW, W and B channels
+  assign awready = ~axi_awset;
+  assign wready = ~axi_wset;
+  assign bvalid = axi_wdone;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        wr_req <= 1'b0;
+        axi_awset <= 1'b0;
+        axi_wset <= 1'b0;
+        axi_wdone <= 1'b0;
+      end
+    else
+      begin
+        wr_req <= 1'b0;
+        if (awvalid == 1'b1 & axi_awset == 1'b0)
+          begin
+            wr_addr <= awaddr;
+            axi_awset <= 1'b1;
+            wr_req <= axi_wset;
+          end
+        if (wvalid == 1'b1 & axi_wset == 1'b0)
+          begin
+            wr_data <= wdata;
+            wr_sel[7:0] <= {8{wstrb[0]}};
+            wr_sel[15:8] <= {8{wstrb[1]}};
+            wr_sel[23:16] <= {8{wstrb[2]}};
+            wr_sel[31:24] <= {8{wstrb[3]}};
+            axi_wset <= 1'b1;
+            wr_req <= axi_awset | awvalid;
+          end
+        if ((axi_wdone & bready) == 1'b1)
+          begin
+            axi_wset <= 1'b0;
+            axi_awset <= 1'b0;
+            axi_wdone <= 1'b0;
+          end
+        if (wr_ack == 1'b1)
+          axi_wdone <= 1'b1;
+      end
+  end
+  assign bresp = 2'b00;
+
+  // AR and R channels
+  assign arready = ~axi_arset;
+  assign rvalid = axi_rdone;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        rd_req <= 1'b0;
+        axi_arset <= 1'b0;
+        axi_rdone <= 1'b0;
+        rdata <= 32'b0;
+      end
+    else
+      begin
+        rd_req <= 1'b0;
+        if (arvalid == 1'b1 & axi_arset == 1'b0)
+          begin
+            rd_addr <= araddr;
+            axi_arset <= 1'b1;
+            rd_req <= 1'b1;
+          end
+        if ((axi_rdone & rready) == 1'b1)
+          begin
+            axi_arset <= 1'b0;
+            axi_rdone <= 1'b0;
+          end
+        if (rd_ack == 1'b1)
+          begin
+            axi_rdone <= 1'b1;
+            rdata <= rd_data;
+          end
+      end
+  end
+  assign rresp = 2'b00;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        rd_ack <= 1'b0;
+        rd_data <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 1'b0;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+        wr_sel_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack <= rd_ack_d0;
+        rd_data <= rd_dat_d0;
+        wr_req_d0 <= wr_req;
+        wr_adr_d0 <= wr_addr;
+        wr_dat_d0 <= wr_data;
+        wr_sel_d0 <= wr_sel;
+      end
+  end
+
+  // Interface subm
+  assign subm_awvalid_o = subm_aw_val;
+  assign subm_awaddr_o = wr_adr_d0[2:2];
+  assign subm_awprot_o = 3'b000;
+  assign subm_wvalid_o = subm_w_val;
+  assign subm_wdata_o = wr_dat_d0;
+  always @(wr_sel_d0)
+  begin
+    subm_wstrb_o = 4'b0;
+    if (~(wr_sel_d0[7:0] == 8'b0))
+      subm_wstrb_o[0] = 1'b1;
+    if (~(wr_sel_d0[15:8] == 8'b0))
+      subm_wstrb_o[1] = 1'b1;
+    if (~(wr_sel_d0[23:16] == 8'b0))
+      subm_wstrb_o[2] = 1'b1;
+    if (~(wr_sel_d0[31:24] == 8'b0))
+      subm_wstrb_o[3] = 1'b1;
+  end
+  assign subm_bready_o = 1'b1;
+  assign subm_arvalid_o = subm_ar_val;
+  assign subm_araddr_o = rd_addr[2:2];
+  assign subm_arprot_o = 3'b000;
+  assign subm_rready_o = 1'b1;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        subm_aw_val <= 1'b0;
+        subm_w_val <= 1'b0;
+        subm_ar_val <= 1'b0;
+      end
+    else
+      begin
+        subm_aw_val <= subm_wr | (subm_aw_val & ~subm_awready_i);
+        subm_w_val <= subm_wr | (subm_w_val & ~subm_wready_i);
+        subm_ar_val <= subm_rd | (subm_ar_val & ~subm_arready_i);
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_req_d0, subm_bvalid_i)
+  begin
+    subm_wr = 1'b0;
+    // Submap subm
+    subm_wr = wr_req_d0;
+    wr_ack = subm_bvalid_i;
+  end
+
+  // Process for read requests.
+  always @(rd_req, subm_rdata_i, subm_rvalid_i)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    subm_rd = 1'b0;
+    // Submap subm
+    subm_rd = rd_req;
+    rd_dat_d0 = subm_rdata_i;
+    rd_ack_d0 = subm_rvalid_i;
+  end
+endmodule

--- a/testfiles/features/xilinx_attrs_cern.sv
+++ b/testfiles/features/xilinx_attrs_cern.sv
@@ -35,7 +35,7 @@ module xilinx_attrs
   assign VMEWrDone = wr_ack_int;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(Clk))
+  always_ff @(posedge(Clk))
   begin
     if (!rst_n)
       begin
@@ -57,7 +57,7 @@ module xilinx_attrs
 
   // Interface subm
   assign subm_VMEWrData_o = wr_dat_d0;
-  always @(posedge(Clk))
+  always_ff @(posedge(Clk))
   begin
     if (!rst_n)
       subm_wt <= 1'b0;
@@ -65,30 +65,30 @@ module xilinx_attrs
       subm_wt <= (subm_wt | subm_ws) & ~subm_VMEWrDone_i;
   end
   assign subm_VMEWrMem_o = subm_ws;
-  always @(VMEAddr, wr_adr_d0, subm_wt, subm_ws)
+  always_comb
   if ((subm_ws | subm_wt) == 1'b1)
-    subm_VMEAddr_o <= wr_adr_d0[2:2];
+    subm_VMEAddr_o = wr_adr_d0[2:2];
   else
-    subm_VMEAddr_o <= VMEAddr[2:2];
+    subm_VMEAddr_o = VMEAddr[2:2];
 
   // Process for write requests.
-  always @(wr_req_d0, subm_VMEWrDone_i)
+  always_comb
   begin
-    subm_ws <= 1'b0;
+    subm_ws = 1'b0;
     // Submap subm
-    subm_ws <= wr_req_d0;
-    wr_ack_int <= subm_VMEWrDone_i;
+    subm_ws = wr_req_d0;
+    wr_ack_int = subm_VMEWrDone_i;
   end
 
   // Process for read requests.
-  always @(VMERdMem, subm_VMERdData_i, subm_VMERdDone_i)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
-    subm_VMERdMem_o <= 1'b0;
+    rd_dat_d0 = {32{1'bx}};
+    subm_VMERdMem_o = 1'b0;
     // Submap subm
-    subm_VMERdMem_o <= VMERdMem;
-    rd_dat_d0 <= subm_VMERdData_i;
-    rd_ack_d0 <= subm_VMERdDone_i;
+    subm_VMERdMem_o = VMERdMem;
+    rd_dat_d0 = subm_VMERdData_i;
+    rd_ack_d0 = subm_VMERdDone_i;
   end
 endmodule

--- a/testfiles/features/xilinx_attrs_cern.v
+++ b/testfiles/features/xilinx_attrs_cern.v
@@ -1,0 +1,94 @@
+
+module xilinx_attrs
+  (
+    input   wire Clk,
+    input   wire Rst,
+    input   wire [2:2] VMEAddr,
+    output  reg [31:0] VMERdData,
+    input   wire [31:0] VMEWrData,
+    input   wire VMERdMem,
+    input   wire VMEWrMem,
+    output  wire VMERdDone,
+    output  wire VMEWrDone,
+
+    // CERN-BE bus subm
+    output  reg [2:2] subm_VMEAddr_o,
+    input   wire [31:0] subm_VMERdData_i,
+    output  wire [31:0] subm_VMEWrData_o,
+    output  reg subm_VMERdMem_o,
+    output  wire subm_VMEWrMem_o,
+    input   wire subm_VMERdDone_i,
+    input   wire subm_VMEWrDone_i
+  );
+  wire rst_n;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [2:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+  reg subm_ws;
+  reg subm_wt;
+  assign rst_n = ~Rst;
+  assign VMERdDone = rd_ack_int;
+  assign VMEWrDone = wr_ack_int;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(Clk))
+  begin
+    if (!rst_n)
+      begin
+        rd_ack_int <= 1'b0;
+        VMERdData <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 1'b0;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        VMERdData <= rd_dat_d0;
+        wr_req_d0 <= VMEWrMem;
+        wr_adr_d0 <= VMEAddr;
+        wr_dat_d0 <= VMEWrData;
+      end
+  end
+
+  // Interface subm
+  assign subm_VMEWrData_o = wr_dat_d0;
+  always @(posedge(Clk))
+  begin
+    if (!rst_n)
+      subm_wt <= 1'b0;
+    else
+      subm_wt <= (subm_wt | subm_ws) & ~subm_VMEWrDone_i;
+  end
+  assign subm_VMEWrMem_o = subm_ws;
+  always @(VMEAddr, wr_adr_d0, subm_wt, subm_ws)
+  if ((subm_ws | subm_wt) == 1'b1)
+    subm_VMEAddr_o = wr_adr_d0[2:2];
+  else
+    subm_VMEAddr_o = VMEAddr[2:2];
+
+  // Process for write requests.
+  always @(wr_req_d0, subm_VMEWrDone_i)
+  begin
+    subm_ws = 1'b0;
+    // Submap subm
+    subm_ws = wr_req_d0;
+    wr_ack_int = subm_VMEWrDone_i;
+  end
+
+  // Process for read requests.
+  always @(VMERdMem, subm_VMERdData_i, subm_VMERdDone_i)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    subm_VMERdMem_o = 1'b0;
+    // Submap subm
+    subm_VMERdMem_o = VMERdMem;
+    rd_dat_d0 = subm_VMERdData_i;
+    rd_ack_d0 = subm_VMERdDone_i;
+  end
+endmodule

--- a/testfiles/fmc-adc01/fmc_adc_alt_trigin.sv
+++ b/testfiles/fmc-adc01/fmc_adc_alt_trigin.sv
@@ -32,12 +32,12 @@ module alt_trigin
   reg [31:0] wr_dat_d0;
 
   // WB decode signals
-  always @(wb.sel)
+  always_comb
   ;
   assign adr_int = wb.adr[4:2];
   assign wb_en = wb.cyc & wb.stb;
 
-  always @(posedge(wb.clk))
+  always_ff @(posedge(wb.clk))
   begin
     if (!wb.rst_n)
       wb_rip <= 1'b0;
@@ -46,7 +46,7 @@ module alt_trigin
   end
   assign rd_req_int = (wb_en & ~wb.we) & ~wb_rip;
 
-  always @(posedge(wb.clk))
+  always_ff @(posedge(wb.clk))
   begin
     if (!wb.rst_n)
       wb_wip <= 1'b0;
@@ -62,7 +62,7 @@ module alt_trigin
   assign wb.err = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(wb.clk))
+  always_ff @(posedge(wb.clk))
   begin
     if (!wb.rst_n)
       begin
@@ -91,94 +91,94 @@ module alt_trigin
   // Register cycles
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0)
+  always_comb
   begin
-    ctrl_wreq <= 1'b0;
+    ctrl_wreq = 1'b0;
     case (wr_adr_d0[4:3])
     2'b00:
       case (wr_adr_d0[2:2])
       1'b0:
         begin
           // Reg ctrl
-          ctrl_wreq <= wr_req_d0;
-          wr_ack_int <= wr_req_d0;
+          ctrl_wreq = wr_req_d0;
+          wr_ack_int = wr_req_d0;
         end
       default:
-        wr_ack_int <= wr_req_d0;
+        wr_ack_int = wr_req_d0;
       endcase
     2'b01:
       case (wr_adr_d0[2:2])
       1'b0:
         // Reg seconds
-        wr_ack_int <= wr_req_d0;
+        wr_ack_int = wr_req_d0;
       1'b1:
         // Reg seconds
-        wr_ack_int <= wr_req_d0;
+        wr_ack_int = wr_req_d0;
       default:
-        wr_ack_int <= wr_req_d0;
+        wr_ack_int = wr_req_d0;
       endcase
     2'b10:
       case (wr_adr_d0[2:2])
       1'b0:
         // Reg cycles
-        wr_ack_int <= wr_req_d0;
+        wr_ack_int = wr_req_d0;
       default:
-        wr_ack_int <= wr_req_d0;
+        wr_ack_int = wr_req_d0;
       endcase
     default:
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     endcase
   end
 
   // Process for read requests.
-  always @(adr_int, rd_req_int, ctrl_enable_i, seconds_i, cycles_i)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     case (adr_int[4:3])
     2'b00:
       case (adr_int[2:2])
       1'b0:
         begin
           // Reg ctrl
-          rd_ack_d0 <= rd_req_int;
-          rd_dat_d0[0] <= 1'b0;
-          rd_dat_d0[1] <= ctrl_enable_i;
-          rd_dat_d0[31:2] <= 30'b0;
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0[0] = 1'b0;
+          rd_dat_d0[1] = ctrl_enable_i;
+          rd_dat_d0[31:2] = 30'b0;
         end
       default:
-        rd_ack_d0 <= rd_req_int;
+        rd_ack_d0 = rd_req_int;
       endcase
     2'b01:
       case (adr_int[2:2])
       1'b0:
         begin
           // Reg seconds
-          rd_ack_d0 <= rd_req_int;
-          rd_dat_d0 <= seconds_i[63:32];
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0 = seconds_i[63:32];
         end
       1'b1:
         begin
           // Reg seconds
-          rd_ack_d0 <= rd_req_int;
-          rd_dat_d0 <= seconds_i[31:0];
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0 = seconds_i[31:0];
         end
       default:
-        rd_ack_d0 <= rd_req_int;
+        rd_ack_d0 = rd_req_int;
       endcase
     2'b10:
       case (adr_int[2:2])
       1'b0:
         begin
           // Reg cycles
-          rd_ack_d0 <= rd_req_int;
-          rd_dat_d0 <= cycles_i;
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0 = cycles_i;
         end
       default:
-        rd_ack_d0 <= rd_req_int;
+        rd_ack_d0 = rd_req_int;
       endcase
     default:
-      rd_ack_d0 <= rd_req_int;
+      rd_ack_d0 = rd_req_int;
     endcase
   end
 endmodule

--- a/testfiles/fmc-adc01/fmc_adc_alt_trigin.v
+++ b/testfiles/fmc-adc01/fmc_adc_alt_trigin.v
@@ -1,0 +1,184 @@
+
+module alt_trigin
+  (
+    t_wishbone.slave wb,
+
+    // Control register
+    // Enable trigger, cleared when triggered
+    input   wire ctrl_enable_i,
+    output  wire ctrl_enable_o,
+    output  wire ctrl_wr_o,
+
+    // Time (seconds) to trigger
+    input   wire [63:0] seconds_i,
+
+    // Time (cycles) to trigger
+    input   wire [31:0] cycles_i
+  );
+  wire [4:2] adr_int;
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg ctrl_wreq;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [4:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+
+  // WB decode signals
+  always @(wb.sel)
+  ;
+  assign adr_int = wb.adr[4:2];
+  assign wb_en = wb.cyc & wb.stb;
+
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb.we)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb.we) & ~wb_rip;
+
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb.we)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb.we) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb.ack = ack_int;
+  assign wb.stall = ~ack_int & wb_en;
+  assign wb.rty = 1'b0;
+  assign wb.err = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      begin
+        rd_ack_int <= 1'b0;
+        wb.dati <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 3'b000;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb.dati <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_adr_d0 <= adr_int;
+        wr_dat_d0 <= wb.dato;
+      end
+  end
+
+  // Register ctrl
+  assign ctrl_enable_o = wr_dat_d0[1];
+  assign ctrl_wr_o = ctrl_wreq;
+
+  // Register seconds
+
+  // Register cycles
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0)
+  begin
+    ctrl_wreq = 1'b0;
+    case (wr_adr_d0[4:3])
+    2'b00:
+      case (wr_adr_d0[2:2])
+      1'b0:
+        begin
+          // Reg ctrl
+          ctrl_wreq = wr_req_d0;
+          wr_ack_int = wr_req_d0;
+        end
+      default:
+        wr_ack_int = wr_req_d0;
+      endcase
+    2'b01:
+      case (wr_adr_d0[2:2])
+      1'b0:
+        // Reg seconds
+        wr_ack_int = wr_req_d0;
+      1'b1:
+        // Reg seconds
+        wr_ack_int = wr_req_d0;
+      default:
+        wr_ack_int = wr_req_d0;
+      endcase
+    2'b10:
+      case (wr_adr_d0[2:2])
+      1'b0:
+        // Reg cycles
+        wr_ack_int = wr_req_d0;
+      default:
+        wr_ack_int = wr_req_d0;
+      endcase
+    default:
+      wr_ack_int = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always @(adr_int, rd_req_int, ctrl_enable_i, seconds_i, cycles_i)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    case (adr_int[4:3])
+    2'b00:
+      case (adr_int[2:2])
+      1'b0:
+        begin
+          // Reg ctrl
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0[0] = 1'b0;
+          rd_dat_d0[1] = ctrl_enable_i;
+          rd_dat_d0[31:2] = 30'b0;
+        end
+      default:
+        rd_ack_d0 = rd_req_int;
+      endcase
+    2'b01:
+      case (adr_int[2:2])
+      1'b0:
+        begin
+          // Reg seconds
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0 = seconds_i[63:32];
+        end
+      1'b1:
+        begin
+          // Reg seconds
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0 = seconds_i[31:0];
+        end
+      default:
+        rd_ack_d0 = rd_req_int;
+      endcase
+    2'b10:
+      case (adr_int[2:2])
+      1'b0:
+        begin
+          // Reg cycles
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0 = cycles_i;
+        end
+      default:
+        rd_ack_d0 = rd_req_int;
+      endcase
+    default:
+      rd_ack_d0 = rd_req_int;
+    endcase
+  end
+endmodule

--- a/testfiles/fmc-adc01/fmc_adc_alt_trigout.sv
+++ b/testfiles/fmc-adc01/fmc_adc_alt_trigout.sv
@@ -67,12 +67,12 @@ module alt_trigout
   reg [31:0] wr_dat_d0;
 
   // WB decode signals
-  always @(wb.sel)
+  always_comb
   ;
   assign adr_int = wb.adr[4:2];
   assign wb_en = wb.cyc & wb.stb;
 
-  always @(posedge(wb.clk))
+  always_ff @(posedge(wb.clk))
   begin
     if (!wb.rst_n)
       wb_rip <= 1'b0;
@@ -81,7 +81,7 @@ module alt_trigout
   end
   assign rd_req_int = (wb_en & ~wb.we) & ~wb_rip;
 
-  always @(posedge(wb.clk))
+  always_ff @(posedge(wb.clk))
   begin
     if (!wb.rst_n)
       wb_wip <= 1'b0;
@@ -97,7 +97,7 @@ module alt_trigout
   assign wb.err = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(wb.clk))
+  always_ff @(posedge(wb.clk))
   begin
     if (!wb.rst_n)
       begin
@@ -125,7 +125,7 @@ module alt_trigout
   assign ch3_enable_o = ch3_enable_reg;
   assign ch4_enable_o = ch4_enable_reg;
   assign ext_enable_o = ext_enable_reg;
-  always @(posedge(wb.clk))
+  always_ff @(posedge(wb.clk))
   begin
     if (!wb.rst_n)
       begin
@@ -155,123 +155,123 @@ module alt_trigout
   // Register ts_cycles
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0, ctrl_wack)
+  always_comb
   begin
-    ctrl_wreq <= 1'b0;
+    ctrl_wreq = 1'b0;
     case (wr_adr_d0[4:3])
     2'b00:
       case (wr_adr_d0[2:2])
       1'b0:
         // Reg status
-        wr_ack_int <= wr_req_d0;
+        wr_ack_int = wr_req_d0;
       1'b1:
         begin
           // Reg ctrl
-          ctrl_wreq <= wr_req_d0;
-          wr_ack_int <= ctrl_wack;
+          ctrl_wreq = wr_req_d0;
+          wr_ack_int = ctrl_wack;
         end
       default:
-        wr_ack_int <= wr_req_d0;
+        wr_ack_int = wr_req_d0;
       endcase
     2'b01:
       case (wr_adr_d0[2:2])
       1'b0:
         // Reg ts_mask_sec
-        wr_ack_int <= wr_req_d0;
+        wr_ack_int = wr_req_d0;
       1'b1:
         // Reg ts_mask_sec
-        wr_ack_int <= wr_req_d0;
+        wr_ack_int = wr_req_d0;
       default:
-        wr_ack_int <= wr_req_d0;
+        wr_ack_int = wr_req_d0;
       endcase
     2'b10:
       case (wr_adr_d0[2:2])
       1'b0:
         // Reg ts_cycles
-        wr_ack_int <= wr_req_d0;
+        wr_ack_int = wr_req_d0;
       default:
-        wr_ack_int <= wr_req_d0;
+        wr_ack_int = wr_req_d0;
       endcase
     default:
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     endcase
   end
 
   // Process for read requests.
-  always @(adr_int, rd_req_int, wr_enable_i, wr_link_i, wr_valid_i, ts_present_i, ch1_enable_reg, ch2_enable_reg, ch3_enable_reg, ch4_enable_reg, ext_enable_reg, ts_sec_i, ch1_mask_i, ch2_mask_i, ch3_mask_i, ch4_mask_i, ext_mask_i, cycles_i)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
-    ts_cycles_rd_o <= 1'b0;
+    rd_dat_d0 = {32{1'bx}};
+    ts_cycles_rd_o = 1'b0;
     case (adr_int[4:3])
     2'b00:
       case (adr_int[2:2])
       1'b0:
         begin
           // Reg status
-          rd_ack_d0 <= rd_req_int;
-          rd_dat_d0[0] <= wr_enable_i;
-          rd_dat_d0[1] <= wr_link_i;
-          rd_dat_d0[2] <= wr_valid_i;
-          rd_dat_d0[7:3] <= 5'b0;
-          rd_dat_d0[8] <= ts_present_i;
-          rd_dat_d0[31:9] <= 23'b0;
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0[0] = wr_enable_i;
+          rd_dat_d0[1] = wr_link_i;
+          rd_dat_d0[2] = wr_valid_i;
+          rd_dat_d0[7:3] = 5'b0;
+          rd_dat_d0[8] = ts_present_i;
+          rd_dat_d0[31:9] = 23'b0;
         end
       1'b1:
         begin
           // Reg ctrl
-          rd_ack_d0 <= rd_req_int;
-          rd_dat_d0[0] <= ch1_enable_reg;
-          rd_dat_d0[1] <= ch2_enable_reg;
-          rd_dat_d0[2] <= ch3_enable_reg;
-          rd_dat_d0[3] <= ch4_enable_reg;
-          rd_dat_d0[7:4] <= 4'b0;
-          rd_dat_d0[8] <= ext_enable_reg;
-          rd_dat_d0[31:9] <= 23'b0;
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0[0] = ch1_enable_reg;
+          rd_dat_d0[1] = ch2_enable_reg;
+          rd_dat_d0[2] = ch3_enable_reg;
+          rd_dat_d0[3] = ch4_enable_reg;
+          rd_dat_d0[7:4] = 4'b0;
+          rd_dat_d0[8] = ext_enable_reg;
+          rd_dat_d0[31:9] = 23'b0;
         end
       default:
-        rd_ack_d0 <= rd_req_int;
+        rd_ack_d0 = rd_req_int;
       endcase
     2'b01:
       case (adr_int[2:2])
       1'b0:
         begin
           // Reg ts_mask_sec
-          rd_ack_d0 <= rd_req_int;
-          rd_dat_d0[7:0] <= ts_sec_i[39:32];
-          rd_dat_d0[15:8] <= 8'b0;
-          rd_dat_d0[16] <= ch1_mask_i;
-          rd_dat_d0[17] <= ch2_mask_i;
-          rd_dat_d0[18] <= ch3_mask_i;
-          rd_dat_d0[19] <= ch4_mask_i;
-          rd_dat_d0[23:20] <= 4'b0;
-          rd_dat_d0[24] <= ext_mask_i;
-          rd_dat_d0[31:25] <= 7'b0;
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0[7:0] = ts_sec_i[39:32];
+          rd_dat_d0[15:8] = 8'b0;
+          rd_dat_d0[16] = ch1_mask_i;
+          rd_dat_d0[17] = ch2_mask_i;
+          rd_dat_d0[18] = ch3_mask_i;
+          rd_dat_d0[19] = ch4_mask_i;
+          rd_dat_d0[23:20] = 4'b0;
+          rd_dat_d0[24] = ext_mask_i;
+          rd_dat_d0[31:25] = 7'b0;
         end
       1'b1:
         begin
           // Reg ts_mask_sec
-          rd_ack_d0 <= rd_req_int;
-          rd_dat_d0 <= ts_sec_i[31:0];
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0 = ts_sec_i[31:0];
         end
       default:
-        rd_ack_d0 <= rd_req_int;
+        rd_ack_d0 = rd_req_int;
       endcase
     2'b10:
       case (adr_int[2:2])
       1'b0:
         begin
           // Reg ts_cycles
-          ts_cycles_rd_o <= rd_req_int;
-          rd_ack_d0 <= rd_req_int;
-          rd_dat_d0[27:0] <= cycles_i;
-          rd_dat_d0[31:28] <= 4'b0;
+          ts_cycles_rd_o = rd_req_int;
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0[27:0] = cycles_i;
+          rd_dat_d0[31:28] = 4'b0;
         end
       default:
-        rd_ack_d0 <= rd_req_int;
+        rd_ack_d0 = rd_req_int;
       endcase
     default:
-      rd_ack_d0 <= rd_req_int;
+      rd_ack_d0 = rd_req_int;
     endcase
   end
 endmodule

--- a/testfiles/fmc-adc01/fmc_adc_alt_trigout.v
+++ b/testfiles/fmc-adc01/fmc_adc_alt_trigout.v
@@ -1,0 +1,277 @@
+
+module alt_trigout
+  (
+    t_wishbone.slave wb,
+
+    // Status register
+    // Set when WR is enabled
+    input   wire wr_enable_i,
+    // WR link status
+    input   wire wr_link_i,
+    // Set when WR time is valid
+    input   wire wr_valid_i,
+    // Set when the timestamp fifo is not empty
+    input   wire ts_present_i,
+
+    // Control register
+    // Enable channel 1 trigger
+    output  wire ch1_enable_o,
+    // Enable channel 2 trigger
+    output  wire ch2_enable_o,
+    // Enable channel 3 trigger
+    output  wire ch3_enable_o,
+    // Enable channel 4 trigger
+    output  wire ch4_enable_o,
+    // Enable external trigger
+    output  wire ext_enable_o,
+
+    // Time (seconds) of the last event
+    // Seconds part of the timestamp
+    input   wire [39:0] ts_sec_i,
+    // Set if channel 1 triggered
+    input   wire ch1_mask_i,
+    // Set if channel 2 triggered
+    input   wire ch2_mask_i,
+    // Set if channel 3 triggered
+    input   wire ch3_mask_i,
+    // Set if channel 4 triggered
+    input   wire ch4_mask_i,
+    // Set if external trigger
+    input   wire ext_mask_i,
+
+    // Reading this register discard the entry
+    // Cycles
+    input   wire [27:0] cycles_i,
+    output  reg ts_cycles_rd_o
+  );
+  wire [4:2] adr_int;
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg ch1_enable_reg;
+  reg ch2_enable_reg;
+  reg ch3_enable_reg;
+  reg ch4_enable_reg;
+  reg ext_enable_reg;
+  reg ctrl_wreq;
+  reg ctrl_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [4:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+
+  // WB decode signals
+  always @(wb.sel)
+  ;
+  assign adr_int = wb.adr[4:2];
+  assign wb_en = wb.cyc & wb.stb;
+
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb.we)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb.we) & ~wb_rip;
+
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb.we)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb.we) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb.ack = ack_int;
+  assign wb.stall = ~ack_int & wb_en;
+  assign wb.rty = 1'b0;
+  assign wb.err = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      begin
+        rd_ack_int <= 1'b0;
+        wb.dati <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 3'b000;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb.dati <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_adr_d0 <= adr_int;
+        wr_dat_d0 <= wb.dato;
+      end
+  end
+
+  // Register status
+
+  // Register ctrl
+  assign ch1_enable_o = ch1_enable_reg;
+  assign ch2_enable_o = ch2_enable_reg;
+  assign ch3_enable_o = ch3_enable_reg;
+  assign ch4_enable_o = ch4_enable_reg;
+  assign ext_enable_o = ext_enable_reg;
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      begin
+        ch1_enable_reg <= 1'b0;
+        ch2_enable_reg <= 1'b0;
+        ch3_enable_reg <= 1'b0;
+        ch4_enable_reg <= 1'b0;
+        ext_enable_reg <= 1'b0;
+        ctrl_wack <= 1'b0;
+      end
+    else
+      begin
+        if (ctrl_wreq == 1'b1)
+          begin
+            ch1_enable_reg <= wr_dat_d0[0];
+            ch2_enable_reg <= wr_dat_d0[1];
+            ch3_enable_reg <= wr_dat_d0[2];
+            ch4_enable_reg <= wr_dat_d0[3];
+            ext_enable_reg <= wr_dat_d0[8];
+          end
+        ctrl_wack <= ctrl_wreq;
+      end
+  end
+
+  // Register ts_mask_sec
+
+  // Register ts_cycles
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, ctrl_wack)
+  begin
+    ctrl_wreq = 1'b0;
+    case (wr_adr_d0[4:3])
+    2'b00:
+      case (wr_adr_d0[2:2])
+      1'b0:
+        // Reg status
+        wr_ack_int = wr_req_d0;
+      1'b1:
+        begin
+          // Reg ctrl
+          ctrl_wreq = wr_req_d0;
+          wr_ack_int = ctrl_wack;
+        end
+      default:
+        wr_ack_int = wr_req_d0;
+      endcase
+    2'b01:
+      case (wr_adr_d0[2:2])
+      1'b0:
+        // Reg ts_mask_sec
+        wr_ack_int = wr_req_d0;
+      1'b1:
+        // Reg ts_mask_sec
+        wr_ack_int = wr_req_d0;
+      default:
+        wr_ack_int = wr_req_d0;
+      endcase
+    2'b10:
+      case (wr_adr_d0[2:2])
+      1'b0:
+        // Reg ts_cycles
+        wr_ack_int = wr_req_d0;
+      default:
+        wr_ack_int = wr_req_d0;
+      endcase
+    default:
+      wr_ack_int = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always @(adr_int, rd_req_int, wr_enable_i, wr_link_i, wr_valid_i, ts_present_i, ch1_enable_reg, ch2_enable_reg, ch3_enable_reg, ch4_enable_reg, ext_enable_reg, ts_sec_i, ch1_mask_i, ch2_mask_i, ch3_mask_i, ch4_mask_i, ext_mask_i, cycles_i)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    ts_cycles_rd_o = 1'b0;
+    case (adr_int[4:3])
+    2'b00:
+      case (adr_int[2:2])
+      1'b0:
+        begin
+          // Reg status
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0[0] = wr_enable_i;
+          rd_dat_d0[1] = wr_link_i;
+          rd_dat_d0[2] = wr_valid_i;
+          rd_dat_d0[7:3] = 5'b0;
+          rd_dat_d0[8] = ts_present_i;
+          rd_dat_d0[31:9] = 23'b0;
+        end
+      1'b1:
+        begin
+          // Reg ctrl
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0[0] = ch1_enable_reg;
+          rd_dat_d0[1] = ch2_enable_reg;
+          rd_dat_d0[2] = ch3_enable_reg;
+          rd_dat_d0[3] = ch4_enable_reg;
+          rd_dat_d0[7:4] = 4'b0;
+          rd_dat_d0[8] = ext_enable_reg;
+          rd_dat_d0[31:9] = 23'b0;
+        end
+      default:
+        rd_ack_d0 = rd_req_int;
+      endcase
+    2'b01:
+      case (adr_int[2:2])
+      1'b0:
+        begin
+          // Reg ts_mask_sec
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0[7:0] = ts_sec_i[39:32];
+          rd_dat_d0[15:8] = 8'b0;
+          rd_dat_d0[16] = ch1_mask_i;
+          rd_dat_d0[17] = ch2_mask_i;
+          rd_dat_d0[18] = ch3_mask_i;
+          rd_dat_d0[19] = ch4_mask_i;
+          rd_dat_d0[23:20] = 4'b0;
+          rd_dat_d0[24] = ext_mask_i;
+          rd_dat_d0[31:25] = 7'b0;
+        end
+      1'b1:
+        begin
+          // Reg ts_mask_sec
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0 = ts_sec_i[31:0];
+        end
+      default:
+        rd_ack_d0 = rd_req_int;
+      endcase
+    2'b10:
+      case (adr_int[2:2])
+      1'b0:
+        begin
+          // Reg ts_cycles
+          ts_cycles_rd_o = rd_req_int;
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0[27:0] = cycles_i;
+          rd_dat_d0[31:28] = 4'b0;
+        end
+      default:
+        rd_ack_d0 = rd_req_int;
+      endcase
+    default:
+      rd_ack_d0 = rd_req_int;
+    endcase
+  end
+endmodule

--- a/testfiles/issue10/test.sv
+++ b/testfiles/issue10/test.sv
@@ -70,7 +70,7 @@ module test
   assign awready = ~axi_awset;
   assign wready = ~axi_wset;
   assign bvalid = axi_wdone;
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -109,7 +109,7 @@ module test
   // AR and R channels
   assign arready = ~axi_arset;
   assign rvalid = axi_rdone;
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -142,7 +142,7 @@ module test
   assign rresp = 2'b00;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -164,7 +164,7 @@ module test
 
   // Register register1
   assign register1_o = register1_reg;
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -185,7 +185,7 @@ module test
 
   // Register block1_register3
   assign block1_register3_o = block1_register3_reg;
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -203,106 +203,106 @@ module test
   // Register block1_block2_register4
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0, register1_wack, block1_register3_wack)
+  always_comb
   begin
-    register1_wreq <= 2'b0;
-    block1_register3_wreq <= 1'b0;
+    register1_wreq = 2'b0;
+    block1_register3_wreq = 1'b0;
     case (wr_adr_d0[4:3])
     2'b00:
       case (wr_adr_d0[2:2])
       1'b0:
         begin
           // Reg register1
-          register1_wreq[0] <= wr_req_d0;
-          wr_ack <= register1_wack[0];
+          register1_wreq[0] = wr_req_d0;
+          wr_ack = register1_wack[0];
         end
       1'b1:
         begin
           // Reg register1
-          register1_wreq[1] <= wr_req_d0;
-          wr_ack <= register1_wack[1];
+          register1_wreq[1] = wr_req_d0;
+          wr_ack = register1_wack[1];
         end
       default:
-        wr_ack <= wr_req_d0;
+        wr_ack = wr_req_d0;
       endcase
     2'b10:
       case (wr_adr_d0[2:2])
       1'b0:
         // Reg block1_register2
-        wr_ack <= wr_req_d0;
+        wr_ack = wr_req_d0;
       1'b1:
         begin
           // Reg block1_register3
-          block1_register3_wreq <= wr_req_d0;
-          wr_ack <= block1_register3_wack;
+          block1_register3_wreq = wr_req_d0;
+          wr_ack = block1_register3_wack;
         end
       default:
-        wr_ack <= wr_req_d0;
+        wr_ack = wr_req_d0;
       endcase
     2'b11:
       case (wr_adr_d0[2:2])
       1'b0:
         // Reg block1_block2_register4
-        wr_ack <= wr_req_d0;
+        wr_ack = wr_req_d0;
       default:
-        wr_ack <= wr_req_d0;
+        wr_ack = wr_req_d0;
       endcase
     default:
-      wr_ack <= wr_req_d0;
+      wr_ack = wr_req_d0;
     endcase
   end
 
   // Process for read requests.
-  always @(rd_addr, rd_req, block1_register2_field1_i, block1_register2_field2_i, block1_register3_reg, block1_block2_register4_field3_i, block1_block2_register4_field4_i)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     case (rd_addr[4:3])
     2'b00:
       case (rd_addr[2:2])
       1'b0:
         // Reg register1
-        rd_ack_d0 <= rd_req;
+        rd_ack_d0 = rd_req;
       1'b1:
         // Reg register1
-        rd_ack_d0 <= rd_req;
+        rd_ack_d0 = rd_req;
       default:
-        rd_ack_d0 <= rd_req;
+        rd_ack_d0 = rd_req;
       endcase
     2'b10:
       case (rd_addr[2:2])
       1'b0:
         begin
           // Reg block1_register2
-          rd_ack_d0 <= rd_req;
-          rd_dat_d0[0] <= block1_register2_field1_i;
-          rd_dat_d0[3:1] <= block1_register2_field2_i;
-          rd_dat_d0[31:4] <= 28'b0;
+          rd_ack_d0 = rd_req;
+          rd_dat_d0[0] = block1_register2_field1_i;
+          rd_dat_d0[3:1] = block1_register2_field2_i;
+          rd_dat_d0[31:4] = 28'b0;
         end
       1'b1:
         begin
           // Reg block1_register3
-          rd_ack_d0 <= rd_req;
-          rd_dat_d0 <= block1_register3_reg;
+          rd_ack_d0 = rd_req;
+          rd_dat_d0 = block1_register3_reg;
         end
       default:
-        rd_ack_d0 <= rd_req;
+        rd_ack_d0 = rd_req;
       endcase
     2'b11:
       case (rd_addr[2:2])
       1'b0:
         begin
           // Reg block1_block2_register4
-          rd_ack_d0 <= rd_req;
-          rd_dat_d0[0] <= block1_block2_register4_field3_i;
-          rd_dat_d0[3:1] <= block1_block2_register4_field4_i;
-          rd_dat_d0[31:4] <= 28'b0;
+          rd_ack_d0 = rd_req;
+          rd_dat_d0[0] = block1_block2_register4_field3_i;
+          rd_dat_d0[3:1] = block1_block2_register4_field4_i;
+          rd_dat_d0[31:4] = 28'b0;
         end
       default:
-        rd_ack_d0 <= rd_req;
+        rd_ack_d0 = rd_req;
       endcase
     default:
-      rd_ack_d0 <= rd_req;
+      rd_ack_d0 = rd_req;
     endcase
   end
 endmodule

--- a/testfiles/issue10/test.v
+++ b/testfiles/issue10/test.v
@@ -1,0 +1,308 @@
+
+module test
+  (
+    input   wire aclk,
+    input   wire areset_n,
+    input   wire awvalid,
+    output  wire awready,
+    input   wire [4:2] awaddr,
+    input   wire [2:0] awprot,
+    input   wire wvalid,
+    output  wire wready,
+    input   wire [31:0] wdata,
+    input   wire [3:0] wstrb,
+    output  wire bvalid,
+    input   wire bready,
+    output  wire [1:0] bresp,
+    input   wire arvalid,
+    output  wire arready,
+    input   wire [4:2] araddr,
+    input   wire [2:0] arprot,
+    output  wire rvalid,
+    input   wire rready,
+    output  reg [31:0] rdata,
+    output  wire [1:0] rresp,
+
+    // Test register 1
+    output  wire [63:0] register1_o,
+
+    // Test register 2
+    // Test field 1
+    input   wire block1_register2_field1_i,
+    // Test field 2
+    input   wire [2:0] block1_register2_field2_i,
+
+    // Test register 3
+    output  wire [31:0] block1_register3_o,
+
+    // Test register 4
+    // Test field 3
+    input   wire block1_block2_register4_field3_i,
+    // Test field 4
+    input   wire [2:0] block1_block2_register4_field4_i
+  );
+  reg wr_req;
+  reg wr_ack;
+  reg [4:2] wr_addr;
+  reg [31:0] wr_data;
+  reg axi_awset;
+  reg axi_wset;
+  reg axi_wdone;
+  reg rd_req;
+  reg rd_ack;
+  reg [4:2] rd_addr;
+  reg [31:0] rd_data;
+  reg axi_arset;
+  reg axi_rdone;
+  reg [63:0] register1_reg;
+  reg [1:0] register1_wreq;
+  reg [1:0] register1_wack;
+  reg [31:0] block1_register3_reg;
+  reg block1_register3_wreq;
+  reg block1_register3_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [4:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+
+  // AW, W and B channels
+  assign awready = ~axi_awset;
+  assign wready = ~axi_wset;
+  assign bvalid = axi_wdone;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        wr_req <= 1'b0;
+        axi_awset <= 1'b0;
+        axi_wset <= 1'b0;
+        axi_wdone <= 1'b0;
+      end
+    else
+      begin
+        wr_req <= 1'b0;
+        if (awvalid == 1'b1 & axi_awset == 1'b0)
+          begin
+            wr_addr <= awaddr;
+            axi_awset <= 1'b1;
+            wr_req <= axi_wset;
+          end
+        if (wvalid == 1'b1 & axi_wset == 1'b0)
+          begin
+            wr_data <= wdata;
+            axi_wset <= 1'b1;
+            wr_req <= axi_awset | awvalid;
+          end
+        if ((axi_wdone & bready) == 1'b1)
+          begin
+            axi_wset <= 1'b0;
+            axi_awset <= 1'b0;
+            axi_wdone <= 1'b0;
+          end
+        if (wr_ack == 1'b1)
+          axi_wdone <= 1'b1;
+      end
+  end
+  assign bresp = 2'b00;
+
+  // AR and R channels
+  assign arready = ~axi_arset;
+  assign rvalid = axi_rdone;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        rd_req <= 1'b0;
+        axi_arset <= 1'b0;
+        axi_rdone <= 1'b0;
+        rdata <= 32'b0;
+      end
+    else
+      begin
+        rd_req <= 1'b0;
+        if (arvalid == 1'b1 & axi_arset == 1'b0)
+          begin
+            rd_addr <= araddr;
+            axi_arset <= 1'b1;
+            rd_req <= 1'b1;
+          end
+        if ((axi_rdone & rready) == 1'b1)
+          begin
+            axi_arset <= 1'b0;
+            axi_rdone <= 1'b0;
+          end
+        if (rd_ack == 1'b1)
+          begin
+            axi_rdone <= 1'b1;
+            rdata <= rd_data;
+          end
+      end
+  end
+  assign rresp = 2'b00;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        rd_ack <= 1'b0;
+        rd_data <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 3'b000;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack <= rd_ack_d0;
+        rd_data <= rd_dat_d0;
+        wr_req_d0 <= wr_req;
+        wr_adr_d0 <= wr_addr;
+        wr_dat_d0 <= wr_data;
+      end
+  end
+
+  // Register register1
+  assign register1_o = register1_reg;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        register1_reg <= 64'b0000000000000000000000000000000000000000000000000000000000000000;
+        register1_wack <= 2'b0;
+      end
+    else
+      begin
+        if (register1_wreq[0] == 1'b1)
+          register1_reg[31:0] <= wr_dat_d0;
+        if (register1_wreq[1] == 1'b1)
+          register1_reg[63:32] <= wr_dat_d0;
+        register1_wack <= register1_wreq;
+      end
+  end
+
+  // Register block1_register2
+
+  // Register block1_register3
+  assign block1_register3_o = block1_register3_reg;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        block1_register3_reg <= 32'b00000000000000000000000000000000;
+        block1_register3_wack <= 1'b0;
+      end
+    else
+      begin
+        if (block1_register3_wreq == 1'b1)
+          block1_register3_reg <= wr_dat_d0;
+        block1_register3_wack <= block1_register3_wreq;
+      end
+  end
+
+  // Register block1_block2_register4
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, register1_wack, block1_register3_wack)
+  begin
+    register1_wreq = 2'b0;
+    block1_register3_wreq = 1'b0;
+    case (wr_adr_d0[4:3])
+    2'b00:
+      case (wr_adr_d0[2:2])
+      1'b0:
+        begin
+          // Reg register1
+          register1_wreq[0] = wr_req_d0;
+          wr_ack = register1_wack[0];
+        end
+      1'b1:
+        begin
+          // Reg register1
+          register1_wreq[1] = wr_req_d0;
+          wr_ack = register1_wack[1];
+        end
+      default:
+        wr_ack = wr_req_d0;
+      endcase
+    2'b10:
+      case (wr_adr_d0[2:2])
+      1'b0:
+        // Reg block1_register2
+        wr_ack = wr_req_d0;
+      1'b1:
+        begin
+          // Reg block1_register3
+          block1_register3_wreq = wr_req_d0;
+          wr_ack = block1_register3_wack;
+        end
+      default:
+        wr_ack = wr_req_d0;
+      endcase
+    2'b11:
+      case (wr_adr_d0[2:2])
+      1'b0:
+        // Reg block1_block2_register4
+        wr_ack = wr_req_d0;
+      default:
+        wr_ack = wr_req_d0;
+      endcase
+    default:
+      wr_ack = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always @(rd_addr, rd_req, block1_register2_field1_i, block1_register2_field2_i, block1_register3_reg, block1_block2_register4_field3_i, block1_block2_register4_field4_i)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    case (rd_addr[4:3])
+    2'b00:
+      case (rd_addr[2:2])
+      1'b0:
+        // Reg register1
+        rd_ack_d0 = rd_req;
+      1'b1:
+        // Reg register1
+        rd_ack_d0 = rd_req;
+      default:
+        rd_ack_d0 = rd_req;
+      endcase
+    2'b10:
+      case (rd_addr[2:2])
+      1'b0:
+        begin
+          // Reg block1_register2
+          rd_ack_d0 = rd_req;
+          rd_dat_d0[0] = block1_register2_field1_i;
+          rd_dat_d0[3:1] = block1_register2_field2_i;
+          rd_dat_d0[31:4] = 28'b0;
+        end
+      1'b1:
+        begin
+          // Reg block1_register3
+          rd_ack_d0 = rd_req;
+          rd_dat_d0 = block1_register3_reg;
+        end
+      default:
+        rd_ack_d0 = rd_req;
+      endcase
+    2'b11:
+      case (rd_addr[2:2])
+      1'b0:
+        begin
+          // Reg block1_block2_register4
+          rd_ack_d0 = rd_req;
+          rd_dat_d0[0] = block1_block2_register4_field3_i;
+          rd_dat_d0[3:1] = block1_block2_register4_field4_i;
+          rd_dat_d0[31:4] = 28'b0;
+        end
+      default:
+        rd_ack_d0 = rd_req;
+      endcase
+    default:
+      rd_ack_d0 = rd_req;
+    endcase
+  end
+endmodule

--- a/testfiles/issue11/test_port1.sv
+++ b/testfiles/issue11/test_port1.sv
@@ -36,11 +36,11 @@ module sreg
   reg [31:0] wr_dat_d0;
 
   // WB decode signals
-  always @(wb_sel_i)
+  always_comb
   ;
   assign wb_en = wb_cyc_i & wb_stb_i;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_rip <= 1'b0;
@@ -49,7 +49,7 @@ module sreg
   end
   assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_wip <= 1'b0;
@@ -65,7 +65,7 @@ module sreg
   assign wb_err_o = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -86,7 +86,7 @@ module sreg
   // Register i1Thresholds
   assign i1Thresholds_highThreshold_o = i1Thresholds_highThreshold_reg;
   assign i1Thresholds_lowThreshold_o = i1Thresholds_lowThreshold_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -106,22 +106,22 @@ module sreg
   end
 
   // Process for write requests.
-  always @(wr_req_d0, i1Thresholds_wack)
+  always_comb
   begin
-    i1Thresholds_wreq <= 1'b0;
+    i1Thresholds_wreq = 1'b0;
     // Reg i1Thresholds
-    i1Thresholds_wreq <= wr_req_d0;
-    wr_ack_int <= i1Thresholds_wack;
+    i1Thresholds_wreq = wr_req_d0;
+    wr_ack_int = i1Thresholds_wack;
   end
 
   // Process for read requests.
-  always @(rd_req_int, i1Thresholds_lowThreshold_reg, i1Thresholds_highThreshold_reg)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     // Reg i1Thresholds
-    rd_ack_d0 <= rd_req_int;
-    rd_dat_d0[15:0] <= i1Thresholds_lowThreshold_reg;
-    rd_dat_d0[31:16] <= i1Thresholds_highThreshold_reg;
+    rd_ack_d0 = rd_req_int;
+    rd_dat_d0[15:0] = i1Thresholds_lowThreshold_reg;
+    rd_dat_d0[31:16] = i1Thresholds_highThreshold_reg;
   end
 endmodule

--- a/testfiles/issue11/test_port1.v
+++ b/testfiles/issue11/test_port1.v
@@ -1,0 +1,127 @@
+
+module sreg
+  (
+    input   wire rst_n_i,
+    input   wire clk_i,
+    input   wire wb_cyc_i,
+    input   wire wb_stb_i,
+    input   wire [3:0] wb_sel_i,
+    input   wire wb_we_i,
+    input   wire [31:0] wb_dat_i,
+    output  wire wb_ack_o,
+    output  wire wb_err_o,
+    output  wire wb_rty_o,
+    output  wire wb_stall_o,
+    output  reg [31:0] wb_dat_o,
+
+    // REG i1Thresholds
+    output  wire [15:0] i1Thresholds_highThreshold_o,
+    output  wire [15:0] i1Thresholds_lowThreshold_o
+  );
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg [15:0] i1Thresholds_highThreshold_reg;
+  reg [15:0] i1Thresholds_lowThreshold_reg;
+  reg i1Thresholds_wreq;
+  reg i1Thresholds_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [31:0] wr_dat_d0;
+
+  // WB decode signals
+  always @(wb_sel_i)
+  ;
+  assign wb_en = wb_cyc_i & wb_stb_i;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb_we_i)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb_we_i)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb_we_i) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb_ack_o = ack_int;
+  assign wb_stall_o = ~ack_int & wb_en;
+  assign wb_rty_o = 1'b0;
+  assign wb_err_o = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        rd_ack_int <= 1'b0;
+        wb_dat_o <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb_dat_o <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_dat_d0 <= wb_dat_i;
+      end
+  end
+
+  // Register i1Thresholds
+  assign i1Thresholds_highThreshold_o = i1Thresholds_highThreshold_reg;
+  assign i1Thresholds_lowThreshold_o = i1Thresholds_lowThreshold_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        i1Thresholds_highThreshold_reg <= 16'b0000000000000000;
+        i1Thresholds_lowThreshold_reg <= 16'b0000000000000000;
+        i1Thresholds_wack <= 1'b0;
+      end
+    else
+      begin
+        if (i1Thresholds_wreq == 1'b1)
+          begin
+            i1Thresholds_highThreshold_reg <= wr_dat_d0[31:16];
+            i1Thresholds_lowThreshold_reg <= wr_dat_d0[15:0];
+          end
+        i1Thresholds_wack <= i1Thresholds_wreq;
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_req_d0, i1Thresholds_wack)
+  begin
+    i1Thresholds_wreq = 1'b0;
+    // Reg i1Thresholds
+    i1Thresholds_wreq = wr_req_d0;
+    wr_ack_int = i1Thresholds_wack;
+  end
+
+  // Process for read requests.
+  always @(rd_req_int, i1Thresholds_lowThreshold_reg, i1Thresholds_highThreshold_reg)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    // Reg i1Thresholds
+    rd_ack_d0 = rd_req_int;
+    rd_dat_d0[15:0] = i1Thresholds_lowThreshold_reg;
+    rd_dat_d0[31:16] = i1Thresholds_highThreshold_reg;
+  end
+endmodule

--- a/testfiles/issue11/test_port1_field.sv
+++ b/testfiles/issue11/test_port1_field.sv
@@ -36,11 +36,11 @@ module sreg
   reg [31:0] wr_dat_d0;
 
   // WB decode signals
-  always @(wb_sel_i)
+  always_comb
   ;
   assign wb_en = wb_cyc_i & wb_stb_i;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_rip <= 1'b0;
@@ -49,7 +49,7 @@ module sreg
   end
   assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_wip <= 1'b0;
@@ -65,7 +65,7 @@ module sreg
   assign wb_err_o = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -86,7 +86,7 @@ module sreg
   // Register i1Thresholds
   assign i1Thresholds_highThreshold_o = i1Thresholds_highThreshold_reg;
   assign i1Thresholds_lowThreshold_o = i1Thresholds_lowThreshold_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -106,22 +106,22 @@ module sreg
   end
 
   // Process for write requests.
-  always @(wr_req_d0, i1Thresholds_wack)
+  always_comb
   begin
-    i1Thresholds_wreq <= 1'b0;
+    i1Thresholds_wreq = 1'b0;
     // Reg i1Thresholds
-    i1Thresholds_wreq <= wr_req_d0;
-    wr_ack_int <= i1Thresholds_wack;
+    i1Thresholds_wreq = wr_req_d0;
+    wr_ack_int = i1Thresholds_wack;
   end
 
   // Process for read requests.
-  always @(rd_req_int, i1Thresholds_lowThreshold_reg, i1Thresholds_highThreshold_reg)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     // Reg i1Thresholds
-    rd_ack_d0 <= rd_req_int;
-    rd_dat_d0[15:0] <= i1Thresholds_lowThreshold_reg;
-    rd_dat_d0[31:16] <= i1Thresholds_highThreshold_reg;
+    rd_ack_d0 = rd_req_int;
+    rd_dat_d0[15:0] = i1Thresholds_lowThreshold_reg;
+    rd_dat_d0[31:16] = i1Thresholds_highThreshold_reg;
   end
 endmodule

--- a/testfiles/issue11/test_port1_field.v
+++ b/testfiles/issue11/test_port1_field.v
@@ -1,0 +1,127 @@
+
+module sreg
+  (
+    input   wire rst_n_i,
+    input   wire clk_i,
+    input   wire wb_cyc_i,
+    input   wire wb_stb_i,
+    input   wire [3:0] wb_sel_i,
+    input   wire wb_we_i,
+    input   wire [31:0] wb_dat_i,
+    output  wire wb_ack_o,
+    output  wire wb_err_o,
+    output  wire wb_rty_o,
+    output  wire wb_stall_o,
+    output  reg [31:0] wb_dat_o,
+
+    // REG i1Thresholds
+    output  wire [15:0] i1Thresholds_highThreshold_o,
+    output  wire [15:0] i1Thresholds_lowThreshold_o
+  );
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg [15:0] i1Thresholds_highThreshold_reg;
+  reg [15:0] i1Thresholds_lowThreshold_reg;
+  reg i1Thresholds_wreq;
+  reg i1Thresholds_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [31:0] wr_dat_d0;
+
+  // WB decode signals
+  always @(wb_sel_i)
+  ;
+  assign wb_en = wb_cyc_i & wb_stb_i;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb_we_i)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb_we_i)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb_we_i) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb_ack_o = ack_int;
+  assign wb_stall_o = ~ack_int & wb_en;
+  assign wb_rty_o = 1'b0;
+  assign wb_err_o = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        rd_ack_int <= 1'b0;
+        wb_dat_o <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb_dat_o <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_dat_d0 <= wb_dat_i;
+      end
+  end
+
+  // Register i1Thresholds
+  assign i1Thresholds_highThreshold_o = i1Thresholds_highThreshold_reg;
+  assign i1Thresholds_lowThreshold_o = i1Thresholds_lowThreshold_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        i1Thresholds_highThreshold_reg <= 16'b0000000000000000;
+        i1Thresholds_lowThreshold_reg <= 16'b0000000000000000;
+        i1Thresholds_wack <= 1'b0;
+      end
+    else
+      begin
+        if (i1Thresholds_wreq == 1'b1)
+          begin
+            i1Thresholds_highThreshold_reg <= wr_dat_d0[31:16];
+            i1Thresholds_lowThreshold_reg <= wr_dat_d0[15:0];
+          end
+        i1Thresholds_wack <= i1Thresholds_wreq;
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_req_d0, i1Thresholds_wack)
+  begin
+    i1Thresholds_wreq = 1'b0;
+    // Reg i1Thresholds
+    i1Thresholds_wreq = wr_req_d0;
+    wr_ack_int = i1Thresholds_wack;
+  end
+
+  // Process for read requests.
+  always @(rd_req_int, i1Thresholds_lowThreshold_reg, i1Thresholds_highThreshold_reg)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    // Reg i1Thresholds
+    rd_ack_d0 = rd_req_int;
+    rd_dat_d0[15:0] = i1Thresholds_lowThreshold_reg;
+    rd_dat_d0[31:16] = i1Thresholds_highThreshold_reg;
+  end
+endmodule

--- a/testfiles/issue11/test_port1_reg.sv
+++ b/testfiles/issue11/test_port1_reg.sv
@@ -35,11 +35,11 @@ module sreg
   reg [31:0] wr_dat_d0;
 
   // WB decode signals
-  always @(wb_sel_i)
+  always_comb
   ;
   assign wb_en = wb_cyc_i & wb_stb_i;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_rip <= 1'b0;
@@ -48,7 +48,7 @@ module sreg
   end
   assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_wip <= 1'b0;
@@ -64,7 +64,7 @@ module sreg
   assign wb_err_o = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -85,7 +85,7 @@ module sreg
   // Register i1Thresholds
   assign i1Thresholds_o[31:16] = i1Thresholds_highThreshold_reg;
   assign i1Thresholds_o[15:0] = i1Thresholds_lowThreshold_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -105,22 +105,22 @@ module sreg
   end
 
   // Process for write requests.
-  always @(wr_req_d0, i1Thresholds_wack)
+  always_comb
   begin
-    i1Thresholds_wreq <= 1'b0;
+    i1Thresholds_wreq = 1'b0;
     // Reg i1Thresholds
-    i1Thresholds_wreq <= wr_req_d0;
-    wr_ack_int <= i1Thresholds_wack;
+    i1Thresholds_wreq = wr_req_d0;
+    wr_ack_int = i1Thresholds_wack;
   end
 
   // Process for read requests.
-  always @(rd_req_int, i1Thresholds_lowThreshold_reg, i1Thresholds_highThreshold_reg)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     // Reg i1Thresholds
-    rd_ack_d0 <= rd_req_int;
-    rd_dat_d0[15:0] <= i1Thresholds_lowThreshold_reg;
-    rd_dat_d0[31:16] <= i1Thresholds_highThreshold_reg;
+    rd_ack_d0 = rd_req_int;
+    rd_dat_d0[15:0] = i1Thresholds_lowThreshold_reg;
+    rd_dat_d0[31:16] = i1Thresholds_highThreshold_reg;
   end
 endmodule

--- a/testfiles/issue11/test_port1_reg.v
+++ b/testfiles/issue11/test_port1_reg.v
@@ -1,0 +1,126 @@
+
+module sreg
+  (
+    input   wire rst_n_i,
+    input   wire clk_i,
+    input   wire wb_cyc_i,
+    input   wire wb_stb_i,
+    input   wire [3:0] wb_sel_i,
+    input   wire wb_we_i,
+    input   wire [31:0] wb_dat_i,
+    output  wire wb_ack_o,
+    output  wire wb_err_o,
+    output  wire wb_rty_o,
+    output  wire wb_stall_o,
+    output  reg [31:0] wb_dat_o,
+
+    // REG i1Thresholds
+    output  wire [31:0] i1Thresholds_o
+  );
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg [15:0] i1Thresholds_highThreshold_reg;
+  reg [15:0] i1Thresholds_lowThreshold_reg;
+  reg i1Thresholds_wreq;
+  reg i1Thresholds_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [31:0] wr_dat_d0;
+
+  // WB decode signals
+  always @(wb_sel_i)
+  ;
+  assign wb_en = wb_cyc_i & wb_stb_i;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb_we_i)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb_we_i)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb_we_i) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb_ack_o = ack_int;
+  assign wb_stall_o = ~ack_int & wb_en;
+  assign wb_rty_o = 1'b0;
+  assign wb_err_o = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        rd_ack_int <= 1'b0;
+        wb_dat_o <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb_dat_o <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_dat_d0 <= wb_dat_i;
+      end
+  end
+
+  // Register i1Thresholds
+  assign i1Thresholds_o[31:16] = i1Thresholds_highThreshold_reg;
+  assign i1Thresholds_o[15:0] = i1Thresholds_lowThreshold_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        i1Thresholds_highThreshold_reg <= 16'b0000000000000000;
+        i1Thresholds_lowThreshold_reg <= 16'b0000000000000000;
+        i1Thresholds_wack <= 1'b0;
+      end
+    else
+      begin
+        if (i1Thresholds_wreq == 1'b1)
+          begin
+            i1Thresholds_highThreshold_reg <= wr_dat_d0[31:16];
+            i1Thresholds_lowThreshold_reg <= wr_dat_d0[15:0];
+          end
+        i1Thresholds_wack <= i1Thresholds_wreq;
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_req_d0, i1Thresholds_wack)
+  begin
+    i1Thresholds_wreq = 1'b0;
+    // Reg i1Thresholds
+    i1Thresholds_wreq = wr_req_d0;
+    wr_ack_int = i1Thresholds_wack;
+  end
+
+  // Process for read requests.
+  always @(rd_req_int, i1Thresholds_lowThreshold_reg, i1Thresholds_highThreshold_reg)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    // Reg i1Thresholds
+    rd_ack_d0 = rd_req_int;
+    rd_dat_d0[15:0] = i1Thresholds_lowThreshold_reg;
+    rd_dat_d0[31:16] = i1Thresholds_highThreshold_reg;
+  end
+endmodule

--- a/testfiles/issue11/test_port2_reg.sv
+++ b/testfiles/issue11/test_port2_reg.sv
@@ -30,11 +30,11 @@ module sreg
   reg wr_req_d0;
 
   // WB decode signals
-  always @(wb_sel_i)
+  always_comb
   ;
   assign wb_en = wb_cyc_i & wb_stb_i;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_rip <= 1'b0;
@@ -43,7 +43,7 @@ module sreg
   end
   assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_wip <= 1'b0;
@@ -59,7 +59,7 @@ module sreg
   assign wb_err_o = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -78,18 +78,18 @@ module sreg
   // Register i1Thresholds
 
   // Process for write requests.
-  always @(wr_req_d0)
+  always_comb
   // Reg i1Thresholds
-  wr_ack_int <= wr_req_d0;
+  wr_ack_int = wr_req_d0;
 
   // Process for read requests.
-  always @(rd_req_int, i1Thresholds_i)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     // Reg i1Thresholds
-    rd_ack_d0 <= rd_req_int;
-    rd_dat_d0[15:0] <= i1Thresholds_i[15:0];
-    rd_dat_d0[31:16] <= i1Thresholds_i[31:16];
+    rd_ack_d0 = rd_req_int;
+    rd_dat_d0[15:0] = i1Thresholds_i[15:0];
+    rd_dat_d0[31:16] = i1Thresholds_i[31:16];
   end
 endmodule

--- a/testfiles/issue11/test_port2_reg.v
+++ b/testfiles/issue11/test_port2_reg.v
@@ -1,0 +1,95 @@
+
+module sreg
+  (
+    input   wire rst_n_i,
+    input   wire clk_i,
+    input   wire wb_cyc_i,
+    input   wire wb_stb_i,
+    input   wire [3:0] wb_sel_i,
+    input   wire wb_we_i,
+    input   wire [31:0] wb_dat_i,
+    output  wire wb_ack_o,
+    output  wire wb_err_o,
+    output  wire wb_rty_o,
+    output  wire wb_stall_o,
+    output  reg [31:0] wb_dat_o,
+
+    // REG i1Thresholds
+    input   wire [31:0] i1Thresholds_i
+  );
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+
+  // WB decode signals
+  always @(wb_sel_i)
+  ;
+  assign wb_en = wb_cyc_i & wb_stb_i;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb_we_i)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb_we_i)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb_we_i) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb_ack_o = ack_int;
+  assign wb_stall_o = ~ack_int & wb_en;
+  assign wb_rty_o = 1'b0;
+  assign wb_err_o = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        rd_ack_int <= 1'b0;
+        wb_dat_o <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb_dat_o <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+      end
+  end
+
+  // Register i1Thresholds
+
+  // Process for write requests.
+  always @(wr_req_d0)
+  // Reg i1Thresholds
+  wr_ack_int = wr_req_d0;
+
+  // Process for read requests.
+  always @(rd_req_int, i1Thresholds_i)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    // Reg i1Thresholds
+    rd_ack_d0 = rd_req_int;
+    rd_dat_d0[15:0] = i1Thresholds_i[15:0];
+    rd_dat_d0[31:16] = i1Thresholds_i[31:16];
+  end
+endmodule

--- a/testfiles/issue11/test_port2_wire.sv
+++ b/testfiles/issue11/test_port2_wire.sv
@@ -35,11 +35,11 @@ module sreg
   reg [31:0] wr_dat_d0;
 
   // WB decode signals
-  always @(wb_sel_i)
+  always_comb
   ;
   assign wb_en = wb_cyc_i & wb_stb_i;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_rip <= 1'b0;
@@ -48,7 +48,7 @@ module sreg
   end
   assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_wip <= 1'b0;
@@ -64,7 +64,7 @@ module sreg
   assign wb_err_o = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -85,7 +85,7 @@ module sreg
   // Register i1Thresholds
   assign i1Thresholds_o[31:16] = wr_dat_d0[31:16];
   assign i1Thresholds_o[15:0] = i1Thresholds_lowThreshold_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -101,22 +101,22 @@ module sreg
   end
 
   // Process for write requests.
-  always @(wr_req_d0, i1Thresholds_wack)
+  always_comb
   begin
-    i1Thresholds_wreq <= 1'b0;
+    i1Thresholds_wreq = 1'b0;
     // Reg i1Thresholds
-    i1Thresholds_wreq <= wr_req_d0;
-    wr_ack_int <= i1Thresholds_wack;
+    i1Thresholds_wreq = wr_req_d0;
+    wr_ack_int = i1Thresholds_wack;
   end
 
   // Process for read requests.
-  always @(rd_req_int, i1Thresholds_lowThreshold_reg, i1Thresholds_i)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     // Reg i1Thresholds
-    rd_ack_d0 <= rd_req_int;
-    rd_dat_d0[15:0] <= i1Thresholds_lowThreshold_reg;
-    rd_dat_d0[31:16] <= i1Thresholds_i[31:16];
+    rd_ack_d0 = rd_req_int;
+    rd_dat_d0[15:0] = i1Thresholds_lowThreshold_reg;
+    rd_dat_d0[31:16] = i1Thresholds_i[31:16];
   end
 endmodule

--- a/testfiles/issue11/test_port2_wire.v
+++ b/testfiles/issue11/test_port2_wire.v
@@ -1,0 +1,122 @@
+
+module sreg
+  (
+    input   wire rst_n_i,
+    input   wire clk_i,
+    input   wire wb_cyc_i,
+    input   wire wb_stb_i,
+    input   wire [3:0] wb_sel_i,
+    input   wire wb_we_i,
+    input   wire [31:0] wb_dat_i,
+    output  wire wb_ack_o,
+    output  wire wb_err_o,
+    output  wire wb_rty_o,
+    output  wire wb_stall_o,
+    output  reg [31:0] wb_dat_o,
+
+    // REG i1Thresholds
+    input   wire [31:0] i1Thresholds_i,
+    output  wire [31:0] i1Thresholds_o
+  );
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg [15:0] i1Thresholds_lowThreshold_reg;
+  reg i1Thresholds_wreq;
+  reg i1Thresholds_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [31:0] wr_dat_d0;
+
+  // WB decode signals
+  always @(wb_sel_i)
+  ;
+  assign wb_en = wb_cyc_i & wb_stb_i;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb_we_i)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb_we_i)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb_we_i) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb_ack_o = ack_int;
+  assign wb_stall_o = ~ack_int & wb_en;
+  assign wb_rty_o = 1'b0;
+  assign wb_err_o = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        rd_ack_int <= 1'b0;
+        wb_dat_o <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb_dat_o <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_dat_d0 <= wb_dat_i;
+      end
+  end
+
+  // Register i1Thresholds
+  assign i1Thresholds_o[31:16] = wr_dat_d0[31:16];
+  assign i1Thresholds_o[15:0] = i1Thresholds_lowThreshold_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        i1Thresholds_lowThreshold_reg <= 16'b0000000000000000;
+        i1Thresholds_wack <= 1'b0;
+      end
+    else
+      begin
+        if (i1Thresholds_wreq == 1'b1)
+          i1Thresholds_lowThreshold_reg <= wr_dat_d0[15:0];
+        i1Thresholds_wack <= i1Thresholds_wreq;
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_req_d0, i1Thresholds_wack)
+  begin
+    i1Thresholds_wreq = 1'b0;
+    // Reg i1Thresholds
+    i1Thresholds_wreq = wr_req_d0;
+    wr_ack_int = i1Thresholds_wack;
+  end
+
+  // Process for read requests.
+  always @(rd_req_int, i1Thresholds_lowThreshold_reg, i1Thresholds_i)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    // Reg i1Thresholds
+    rd_ack_d0 = rd_req_int;
+    rd_dat_d0[15:0] = i1Thresholds_lowThreshold_reg;
+    rd_dat_d0[31:16] = i1Thresholds_i[31:16];
+  end
+endmodule

--- a/testfiles/issue13/mainMap2.sv
+++ b/testfiles/issue13/mainMap2.sv
@@ -52,7 +52,7 @@ module mainMap2
   assign VMEWrDone = wr_ack_int;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(Clk))
+  always_ff @(posedge(Clk))
   begin
     if (!rst_n)
       begin
@@ -74,7 +74,7 @@ module mainMap2
 
   // Interface subMap1
   assign subMap1_VMEWrData_o = wr_dat_d0;
-  always @(posedge(Clk))
+  always_ff @(posedge(Clk))
   begin
     if (!rst_n)
       subMap1_wt <= 1'b0;
@@ -82,15 +82,15 @@ module mainMap2
       subMap1_wt <= (subMap1_wt | subMap1_ws) & ~subMap1_VMEWrDone_i;
   end
   assign subMap1_VMEWrMem_o = subMap1_ws;
-  always @(VMEAddr, wr_adr_d0, subMap1_wt, subMap1_ws)
+  always_comb
   if ((subMap1_ws | subMap1_wt) == 1'b1)
-    subMap1_VMEAddr_o <= wr_adr_d0[12:2];
+    subMap1_VMEAddr_o = wr_adr_d0[12:2];
   else
-    subMap1_VMEAddr_o <= VMEAddr[12:2];
+    subMap1_VMEAddr_o = VMEAddr[12:2];
 
   // Interface subMap2
   assign subMap2_VMEWrData_o = wr_dat_d0;
-  always @(posedge(Clk))
+  always_ff @(posedge(Clk))
   begin
     if (!rst_n)
       subMap2_wt <= 1'b0;
@@ -98,59 +98,59 @@ module mainMap2
       subMap2_wt <= (subMap2_wt | subMap2_ws) & ~subMap2_VMEWrDone_i;
   end
   assign subMap2_VMEWrMem_o = subMap2_ws;
-  always @(VMEAddr, wr_adr_d0, subMap2_wt, subMap2_ws)
+  always_comb
   if ((subMap2_ws | subMap2_wt) == 1'b1)
-    subMap2_VMEAddr_o <= wr_adr_d0[12:2];
+    subMap2_VMEAddr_o = wr_adr_d0[12:2];
   else
-    subMap2_VMEAddr_o <= VMEAddr[12:2];
+    subMap2_VMEAddr_o = VMEAddr[12:2];
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0, subMap1_VMEWrDone_i, subMap2_VMEWrDone_i)
+  always_comb
   begin
-    subMap1_ws <= 1'b0;
-    subMap2_ws <= 1'b0;
+    subMap1_ws = 1'b0;
+    subMap2_ws = 1'b0;
     case (wr_adr_d0[14:13])
     2'b00:
       begin
         // Submap subMap1
-        subMap1_ws <= wr_req_d0;
-        wr_ack_int <= subMap1_VMEWrDone_i;
+        subMap1_ws = wr_req_d0;
+        wr_ack_int = subMap1_VMEWrDone_i;
       end
     2'b01:
       begin
         // Submap subMap2
-        subMap2_ws <= wr_req_d0;
-        wr_ack_int <= subMap2_VMEWrDone_i;
+        subMap2_ws = wr_req_d0;
+        wr_ack_int = subMap2_VMEWrDone_i;
       end
     default:
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     endcase
   end
 
   // Process for read requests.
-  always @(VMEAddr, VMERdMem, subMap1_VMERdData_i, subMap1_VMERdDone_i, subMap2_VMERdData_i, subMap2_VMERdDone_i)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
-    subMap1_VMERdMem_o <= 1'b0;
-    subMap2_VMERdMem_o <= 1'b0;
+    rd_dat_d0 = {32{1'bx}};
+    subMap1_VMERdMem_o = 1'b0;
+    subMap2_VMERdMem_o = 1'b0;
     case (VMEAddr[14:13])
     2'b00:
       begin
         // Submap subMap1
-        subMap1_VMERdMem_o <= VMERdMem;
-        rd_dat_d0 <= subMap1_VMERdData_i;
-        rd_ack_d0 <= subMap1_VMERdDone_i;
+        subMap1_VMERdMem_o = VMERdMem;
+        rd_dat_d0 = subMap1_VMERdData_i;
+        rd_ack_d0 = subMap1_VMERdDone_i;
       end
     2'b01:
       begin
         // Submap subMap2
-        subMap2_VMERdMem_o <= VMERdMem;
-        rd_dat_d0 <= subMap2_VMERdData_i;
-        rd_ack_d0 <= subMap2_VMERdDone_i;
+        subMap2_VMERdMem_o = VMERdMem;
+        rd_dat_d0 = subMap2_VMERdData_i;
+        rd_ack_d0 = subMap2_VMERdDone_i;
       end
     default:
-      rd_ack_d0 <= VMERdMem;
+      rd_ack_d0 = VMERdMem;
     endcase
   end
 endmodule

--- a/testfiles/issue13/mainMap2.v
+++ b/testfiles/issue13/mainMap2.v
@@ -1,0 +1,156 @@
+
+module mainMap2
+  (
+    input   wire Clk,
+    input   wire Rst,
+    input   wire [14:2] VMEAddr,
+    output  reg [31:0] VMERdData,
+    input   wire [31:0] VMEWrData,
+    input   wire VMERdMem,
+    input   wire VMEWrMem,
+    output  wire VMERdDone,
+    output  wire VMEWrDone,
+    output  wire VMERdError,
+    output  wire VMEWrError,
+
+    // CERN-BE bus subMap1
+    output  reg [12:2] subMap1_VMEAddr_o,
+    input   wire [31:0] subMap1_VMERdData_i,
+    output  wire [31:0] subMap1_VMEWrData_o,
+    output  reg subMap1_VMERdMem_o,
+    output  wire subMap1_VMEWrMem_o,
+    input   wire subMap1_VMERdDone_i,
+    input   wire subMap1_VMEWrDone_i,
+    input   wire subMap1_VMERdError_i,
+    input   wire subMap1_VMEWrError_i,
+
+    // CERN-BE bus subMap2
+    output  reg [12:2] subMap2_VMEAddr_o,
+    input   wire [31:0] subMap2_VMERdData_i,
+    output  wire [31:0] subMap2_VMEWrData_o,
+    output  reg subMap2_VMERdMem_o,
+    output  wire subMap2_VMEWrMem_o,
+    input   wire subMap2_VMERdDone_i,
+    input   wire subMap2_VMEWrDone_i,
+    input   wire subMap2_VMERdError_i,
+    input   wire subMap2_VMEWrError_i
+  );
+  wire rst_n;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [14:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+  reg subMap1_ws;
+  reg subMap1_wt;
+  reg subMap2_ws;
+  reg subMap2_wt;
+  assign rst_n = ~Rst;
+  assign VMERdDone = rd_ack_int;
+  assign VMEWrDone = wr_ack_int;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(Clk))
+  begin
+    if (!rst_n)
+      begin
+        rd_ack_int <= 1'b0;
+        VMERdData <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 13'b0000000000000;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        VMERdData <= rd_dat_d0;
+        wr_req_d0 <= VMEWrMem;
+        wr_adr_d0 <= VMEAddr;
+        wr_dat_d0 <= VMEWrData;
+      end
+  end
+
+  // Interface subMap1
+  assign subMap1_VMEWrData_o = wr_dat_d0;
+  always @(posedge(Clk))
+  begin
+    if (!rst_n)
+      subMap1_wt <= 1'b0;
+    else
+      subMap1_wt <= (subMap1_wt | subMap1_ws) & ~subMap1_VMEWrDone_i;
+  end
+  assign subMap1_VMEWrMem_o = subMap1_ws;
+  always @(VMEAddr, wr_adr_d0, subMap1_wt, subMap1_ws)
+  if ((subMap1_ws | subMap1_wt) == 1'b1)
+    subMap1_VMEAddr_o = wr_adr_d0[12:2];
+  else
+    subMap1_VMEAddr_o = VMEAddr[12:2];
+
+  // Interface subMap2
+  assign subMap2_VMEWrData_o = wr_dat_d0;
+  always @(posedge(Clk))
+  begin
+    if (!rst_n)
+      subMap2_wt <= 1'b0;
+    else
+      subMap2_wt <= (subMap2_wt | subMap2_ws) & ~subMap2_VMEWrDone_i;
+  end
+  assign subMap2_VMEWrMem_o = subMap2_ws;
+  always @(VMEAddr, wr_adr_d0, subMap2_wt, subMap2_ws)
+  if ((subMap2_ws | subMap2_wt) == 1'b1)
+    subMap2_VMEAddr_o = wr_adr_d0[12:2];
+  else
+    subMap2_VMEAddr_o = VMEAddr[12:2];
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, subMap1_VMEWrDone_i, subMap2_VMEWrDone_i)
+  begin
+    subMap1_ws = 1'b0;
+    subMap2_ws = 1'b0;
+    case (wr_adr_d0[14:13])
+    2'b00:
+      begin
+        // Submap subMap1
+        subMap1_ws = wr_req_d0;
+        wr_ack_int = subMap1_VMEWrDone_i;
+      end
+    2'b01:
+      begin
+        // Submap subMap2
+        subMap2_ws = wr_req_d0;
+        wr_ack_int = subMap2_VMEWrDone_i;
+      end
+    default:
+      wr_ack_int = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always @(VMEAddr, VMERdMem, subMap1_VMERdData_i, subMap1_VMERdDone_i, subMap2_VMERdData_i, subMap2_VMERdDone_i)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    subMap1_VMERdMem_o = 1'b0;
+    subMap2_VMERdMem_o = 1'b0;
+    case (VMEAddr[14:13])
+    2'b00:
+      begin
+        // Submap subMap1
+        subMap1_VMERdMem_o = VMERdMem;
+        rd_dat_d0 = subMap1_VMERdData_i;
+        rd_ack_d0 = subMap1_VMERdDone_i;
+      end
+    2'b01:
+      begin
+        // Submap subMap2
+        subMap2_VMERdMem_o = VMERdMem;
+        rd_dat_d0 = subMap2_VMERdData_i;
+        rd_ack_d0 = subMap2_VMERdDone_i;
+      end
+    default:
+      rd_ack_d0 = VMERdMem;
+    endcase
+  end
+endmodule

--- a/testfiles/issue14/test-axi.sv
+++ b/testfiles/issue14/test-axi.sv
@@ -52,7 +52,7 @@ module test_axi4
   assign awready = ~axi_awset;
   assign wready = ~axi_wset;
   assign bvalid = axi_wdone;
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -91,7 +91,7 @@ module test_axi4
   // AR and R channels
   assign arready = ~axi_arset;
   assign rvalid = axi_rdone;
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -124,7 +124,7 @@ module test_axi4
   assign rresp = 2'b00;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -146,7 +146,7 @@ module test_axi4
 
   // Register register1
   assign register1_o = register1_reg;
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -164,41 +164,41 @@ module test_axi4
   end
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0, register1_wack)
+  always_comb
   begin
-    register1_wreq <= 2'b0;
+    register1_wreq = 2'b0;
     case (wr_adr_d0[2:2])
     1'b0:
       begin
         // Reg register1
-        register1_wreq[0] <= wr_req_d0;
-        wr_ack <= register1_wack[0];
+        register1_wreq[0] = wr_req_d0;
+        wr_ack = register1_wack[0];
       end
     1'b1:
       begin
         // Reg register1
-        register1_wreq[1] <= wr_req_d0;
-        wr_ack <= register1_wack[1];
+        register1_wreq[1] = wr_req_d0;
+        wr_ack = register1_wack[1];
       end
     default:
-      wr_ack <= wr_req_d0;
+      wr_ack = wr_req_d0;
     endcase
   end
 
   // Process for read requests.
-  always @(rd_addr, rd_req)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     case (rd_addr[2:2])
     1'b0:
       // Reg register1
-      rd_ack_d0 <= rd_req;
+      rd_ack_d0 = rd_req;
     1'b1:
       // Reg register1
-      rd_ack_d0 <= rd_req;
+      rd_ack_d0 = rd_req;
     default:
-      rd_ack_d0 <= rd_req;
+      rd_ack_d0 = rd_req;
     endcase
   end
 endmodule

--- a/testfiles/issue14/test-axi.v
+++ b/testfiles/issue14/test-axi.v
@@ -1,0 +1,204 @@
+
+module test_axi4
+  (
+    input   wire aclk,
+    input   wire areset_n,
+    input   wire awvalid,
+    output  wire awready,
+    input   wire [2:2] awaddr,
+    input   wire [2:0] awprot,
+    input   wire wvalid,
+    output  wire wready,
+    input   wire [31:0] wdata,
+    input   wire [3:0] wstrb,
+    output  wire bvalid,
+    input   wire bready,
+    output  wire [1:0] bresp,
+    input   wire arvalid,
+    output  wire arready,
+    input   wire [2:2] araddr,
+    input   wire [2:0] arprot,
+    output  wire rvalid,
+    input   wire rready,
+    output  reg [31:0] rdata,
+    output  wire [1:0] rresp,
+
+    // Test register 1
+    output  wire [63:0] register1_o
+  );
+  reg wr_req;
+  reg wr_ack;
+  reg [2:2] wr_addr;
+  reg [31:0] wr_data;
+  reg axi_awset;
+  reg axi_wset;
+  reg axi_wdone;
+  reg rd_req;
+  reg rd_ack;
+  reg [2:2] rd_addr;
+  reg [31:0] rd_data;
+  reg axi_arset;
+  reg axi_rdone;
+  reg [63:0] register1_reg;
+  reg [1:0] register1_wreq;
+  reg [1:0] register1_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [2:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+
+  // AW, W and B channels
+  assign awready = ~axi_awset;
+  assign wready = ~axi_wset;
+  assign bvalid = axi_wdone;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        wr_req <= 1'b0;
+        axi_awset <= 1'b0;
+        axi_wset <= 1'b0;
+        axi_wdone <= 1'b0;
+      end
+    else
+      begin
+        wr_req <= 1'b0;
+        if (awvalid == 1'b1 & axi_awset == 1'b0)
+          begin
+            wr_addr <= awaddr;
+            axi_awset <= 1'b1;
+            wr_req <= axi_wset;
+          end
+        if (wvalid == 1'b1 & axi_wset == 1'b0)
+          begin
+            wr_data <= wdata;
+            axi_wset <= 1'b1;
+            wr_req <= axi_awset | awvalid;
+          end
+        if ((axi_wdone & bready) == 1'b1)
+          begin
+            axi_wset <= 1'b0;
+            axi_awset <= 1'b0;
+            axi_wdone <= 1'b0;
+          end
+        if (wr_ack == 1'b1)
+          axi_wdone <= 1'b1;
+      end
+  end
+  assign bresp = 2'b00;
+
+  // AR and R channels
+  assign arready = ~axi_arset;
+  assign rvalid = axi_rdone;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        rd_req <= 1'b0;
+        axi_arset <= 1'b0;
+        axi_rdone <= 1'b0;
+        rdata <= 32'b0;
+      end
+    else
+      begin
+        rd_req <= 1'b0;
+        if (arvalid == 1'b1 & axi_arset == 1'b0)
+          begin
+            rd_addr <= araddr;
+            axi_arset <= 1'b1;
+            rd_req <= 1'b1;
+          end
+        if ((axi_rdone & rready) == 1'b1)
+          begin
+            axi_arset <= 1'b0;
+            axi_rdone <= 1'b0;
+          end
+        if (rd_ack == 1'b1)
+          begin
+            axi_rdone <= 1'b1;
+            rdata <= rd_data;
+          end
+      end
+  end
+  assign rresp = 2'b00;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        rd_ack <= 1'b0;
+        rd_data <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 1'b0;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack <= rd_ack_d0;
+        rd_data <= rd_dat_d0;
+        wr_req_d0 <= wr_req;
+        wr_adr_d0 <= wr_addr;
+        wr_dat_d0 <= wr_data;
+      end
+  end
+
+  // Register register1
+  assign register1_o = register1_reg;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        register1_reg <= 64'b0000000000000000000000000000000000000000000000000000000000000000;
+        register1_wack <= 2'b0;
+      end
+    else
+      begin
+        if (register1_wreq[0] == 1'b1)
+          register1_reg[31:0] <= wr_dat_d0;
+        if (register1_wreq[1] == 1'b1)
+          register1_reg[63:32] <= wr_dat_d0;
+        register1_wack <= register1_wreq;
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, register1_wack)
+  begin
+    register1_wreq = 2'b0;
+    case (wr_adr_d0[2:2])
+    1'b0:
+      begin
+        // Reg register1
+        register1_wreq[0] = wr_req_d0;
+        wr_ack = register1_wack[0];
+      end
+    1'b1:
+      begin
+        // Reg register1
+        register1_wreq[1] = wr_req_d0;
+        wr_ack = register1_wack[1];
+      end
+    default:
+      wr_ack = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always @(rd_addr, rd_req)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    case (rd_addr[2:2])
+    1'b0:
+      // Reg register1
+      rd_ack_d0 = rd_req;
+    1'b1:
+      // Reg register1
+      rd_ack_d0 = rd_req;
+    default:
+      rd_ack_d0 = rd_req;
+    endcase
+  end
+endmodule

--- a/testfiles/issue14/test-be.sv
+++ b/testfiles/issue14/test-be.sv
@@ -52,7 +52,7 @@ module test_axi4
   assign awready = ~axi_awset;
   assign wready = ~axi_wset;
   assign bvalid = axi_wdone;
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -91,7 +91,7 @@ module test_axi4
   // AR and R channels
   assign arready = ~axi_arset;
   assign rvalid = axi_rdone;
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -124,7 +124,7 @@ module test_axi4
   assign rresp = 2'b00;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -146,7 +146,7 @@ module test_axi4
 
   // Register register1
   assign register1_o = register1_reg;
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -164,41 +164,41 @@ module test_axi4
   end
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0, register1_wack)
+  always_comb
   begin
-    register1_wreq <= 2'b0;
+    register1_wreq = 2'b0;
     case (wr_adr_d0[2:2])
     1'b0:
       begin
         // Reg register1
-        register1_wreq[1] <= wr_req_d0;
-        wr_ack <= register1_wack[1];
+        register1_wreq[1] = wr_req_d0;
+        wr_ack = register1_wack[1];
       end
     1'b1:
       begin
         // Reg register1
-        register1_wreq[0] <= wr_req_d0;
-        wr_ack <= register1_wack[0];
+        register1_wreq[0] = wr_req_d0;
+        wr_ack = register1_wack[0];
       end
     default:
-      wr_ack <= wr_req_d0;
+      wr_ack = wr_req_d0;
     endcase
   end
 
   // Process for read requests.
-  always @(rd_addr, rd_req)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     case (rd_addr[2:2])
     1'b0:
       // Reg register1
-      rd_ack_d0 <= rd_req;
+      rd_ack_d0 = rd_req;
     1'b1:
       // Reg register1
-      rd_ack_d0 <= rd_req;
+      rd_ack_d0 = rd_req;
     default:
-      rd_ack_d0 <= rd_req;
+      rd_ack_d0 = rd_req;
     endcase
   end
 endmodule

--- a/testfiles/issue14/test-be.v
+++ b/testfiles/issue14/test-be.v
@@ -1,0 +1,204 @@
+
+module test_axi4
+  (
+    input   wire aclk,
+    input   wire areset_n,
+    input   wire awvalid,
+    output  wire awready,
+    input   wire [2:2] awaddr,
+    input   wire [2:0] awprot,
+    input   wire wvalid,
+    output  wire wready,
+    input   wire [31:0] wdata,
+    input   wire [3:0] wstrb,
+    output  wire bvalid,
+    input   wire bready,
+    output  wire [1:0] bresp,
+    input   wire arvalid,
+    output  wire arready,
+    input   wire [2:2] araddr,
+    input   wire [2:0] arprot,
+    output  wire rvalid,
+    input   wire rready,
+    output  reg [31:0] rdata,
+    output  wire [1:0] rresp,
+
+    // Test register 1
+    output  wire [63:0] register1_o
+  );
+  reg wr_req;
+  reg wr_ack;
+  reg [2:2] wr_addr;
+  reg [31:0] wr_data;
+  reg axi_awset;
+  reg axi_wset;
+  reg axi_wdone;
+  reg rd_req;
+  reg rd_ack;
+  reg [2:2] rd_addr;
+  reg [31:0] rd_data;
+  reg axi_arset;
+  reg axi_rdone;
+  reg [63:0] register1_reg;
+  reg [1:0] register1_wreq;
+  reg [1:0] register1_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [2:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+
+  // AW, W and B channels
+  assign awready = ~axi_awset;
+  assign wready = ~axi_wset;
+  assign bvalid = axi_wdone;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        wr_req <= 1'b0;
+        axi_awset <= 1'b0;
+        axi_wset <= 1'b0;
+        axi_wdone <= 1'b0;
+      end
+    else
+      begin
+        wr_req <= 1'b0;
+        if (awvalid == 1'b1 & axi_awset == 1'b0)
+          begin
+            wr_addr <= awaddr;
+            axi_awset <= 1'b1;
+            wr_req <= axi_wset;
+          end
+        if (wvalid == 1'b1 & axi_wset == 1'b0)
+          begin
+            wr_data <= wdata;
+            axi_wset <= 1'b1;
+            wr_req <= axi_awset | awvalid;
+          end
+        if ((axi_wdone & bready) == 1'b1)
+          begin
+            axi_wset <= 1'b0;
+            axi_awset <= 1'b0;
+            axi_wdone <= 1'b0;
+          end
+        if (wr_ack == 1'b1)
+          axi_wdone <= 1'b1;
+      end
+  end
+  assign bresp = 2'b00;
+
+  // AR and R channels
+  assign arready = ~axi_arset;
+  assign rvalid = axi_rdone;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        rd_req <= 1'b0;
+        axi_arset <= 1'b0;
+        axi_rdone <= 1'b0;
+        rdata <= 32'b0;
+      end
+    else
+      begin
+        rd_req <= 1'b0;
+        if (arvalid == 1'b1 & axi_arset == 1'b0)
+          begin
+            rd_addr <= araddr;
+            axi_arset <= 1'b1;
+            rd_req <= 1'b1;
+          end
+        if ((axi_rdone & rready) == 1'b1)
+          begin
+            axi_arset <= 1'b0;
+            axi_rdone <= 1'b0;
+          end
+        if (rd_ack == 1'b1)
+          begin
+            axi_rdone <= 1'b1;
+            rdata <= rd_data;
+          end
+      end
+  end
+  assign rresp = 2'b00;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        rd_ack <= 1'b0;
+        rd_data <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 1'b0;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack <= rd_ack_d0;
+        rd_data <= rd_dat_d0;
+        wr_req_d0 <= wr_req;
+        wr_adr_d0 <= wr_addr;
+        wr_dat_d0 <= wr_data;
+      end
+  end
+
+  // Register register1
+  assign register1_o = register1_reg;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        register1_reg <= 64'b0000000000000000000000000000000000000000000000000000000000000000;
+        register1_wack <= 2'b0;
+      end
+    else
+      begin
+        if (register1_wreq[0] == 1'b1)
+          register1_reg[31:0] <= wr_dat_d0;
+        if (register1_wreq[1] == 1'b1)
+          register1_reg[63:32] <= wr_dat_d0;
+        register1_wack <= register1_wreq;
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, register1_wack)
+  begin
+    register1_wreq = 2'b0;
+    case (wr_adr_d0[2:2])
+    1'b0:
+      begin
+        // Reg register1
+        register1_wreq[1] = wr_req_d0;
+        wr_ack = register1_wack[1];
+      end
+    1'b1:
+      begin
+        // Reg register1
+        register1_wreq[0] = wr_req_d0;
+        wr_ack = register1_wack[0];
+      end
+    default:
+      wr_ack = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always @(rd_addr, rd_req)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    case (rd_addr[2:2])
+    1'b0:
+      // Reg register1
+      rd_ack_d0 = rd_req;
+    1'b1:
+      // Reg register1
+      rd_ack_d0 = rd_req;
+    default:
+      rd_ack_d0 = rd_req;
+    endcase
+  end
+endmodule

--- a/testfiles/issue14/test-le.sv
+++ b/testfiles/issue14/test-le.sv
@@ -52,7 +52,7 @@ module test_axi4
   assign awready = ~axi_awset;
   assign wready = ~axi_wset;
   assign bvalid = axi_wdone;
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -91,7 +91,7 @@ module test_axi4
   // AR and R channels
   assign arready = ~axi_arset;
   assign rvalid = axi_rdone;
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -124,7 +124,7 @@ module test_axi4
   assign rresp = 2'b00;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -146,7 +146,7 @@ module test_axi4
 
   // Register register1
   assign register1_o = register1_reg;
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -164,41 +164,41 @@ module test_axi4
   end
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0, register1_wack)
+  always_comb
   begin
-    register1_wreq <= 2'b0;
+    register1_wreq = 2'b0;
     case (wr_adr_d0[2:2])
     1'b0:
       begin
         // Reg register1
-        register1_wreq[0] <= wr_req_d0;
-        wr_ack <= register1_wack[0];
+        register1_wreq[0] = wr_req_d0;
+        wr_ack = register1_wack[0];
       end
     1'b1:
       begin
         // Reg register1
-        register1_wreq[1] <= wr_req_d0;
-        wr_ack <= register1_wack[1];
+        register1_wreq[1] = wr_req_d0;
+        wr_ack = register1_wack[1];
       end
     default:
-      wr_ack <= wr_req_d0;
+      wr_ack = wr_req_d0;
     endcase
   end
 
   // Process for read requests.
-  always @(rd_addr, rd_req)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     case (rd_addr[2:2])
     1'b0:
       // Reg register1
-      rd_ack_d0 <= rd_req;
+      rd_ack_d0 = rd_req;
     1'b1:
       // Reg register1
-      rd_ack_d0 <= rd_req;
+      rd_ack_d0 = rd_req;
     default:
-      rd_ack_d0 <= rd_req;
+      rd_ack_d0 = rd_req;
     endcase
   end
 endmodule

--- a/testfiles/issue14/test-le.v
+++ b/testfiles/issue14/test-le.v
@@ -1,0 +1,204 @@
+
+module test_axi4
+  (
+    input   wire aclk,
+    input   wire areset_n,
+    input   wire awvalid,
+    output  wire awready,
+    input   wire [2:2] awaddr,
+    input   wire [2:0] awprot,
+    input   wire wvalid,
+    output  wire wready,
+    input   wire [31:0] wdata,
+    input   wire [3:0] wstrb,
+    output  wire bvalid,
+    input   wire bready,
+    output  wire [1:0] bresp,
+    input   wire arvalid,
+    output  wire arready,
+    input   wire [2:2] araddr,
+    input   wire [2:0] arprot,
+    output  wire rvalid,
+    input   wire rready,
+    output  reg [31:0] rdata,
+    output  wire [1:0] rresp,
+
+    // Test register 1
+    output  wire [63:0] register1_o
+  );
+  reg wr_req;
+  reg wr_ack;
+  reg [2:2] wr_addr;
+  reg [31:0] wr_data;
+  reg axi_awset;
+  reg axi_wset;
+  reg axi_wdone;
+  reg rd_req;
+  reg rd_ack;
+  reg [2:2] rd_addr;
+  reg [31:0] rd_data;
+  reg axi_arset;
+  reg axi_rdone;
+  reg [63:0] register1_reg;
+  reg [1:0] register1_wreq;
+  reg [1:0] register1_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [2:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+
+  // AW, W and B channels
+  assign awready = ~axi_awset;
+  assign wready = ~axi_wset;
+  assign bvalid = axi_wdone;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        wr_req <= 1'b0;
+        axi_awset <= 1'b0;
+        axi_wset <= 1'b0;
+        axi_wdone <= 1'b0;
+      end
+    else
+      begin
+        wr_req <= 1'b0;
+        if (awvalid == 1'b1 & axi_awset == 1'b0)
+          begin
+            wr_addr <= awaddr;
+            axi_awset <= 1'b1;
+            wr_req <= axi_wset;
+          end
+        if (wvalid == 1'b1 & axi_wset == 1'b0)
+          begin
+            wr_data <= wdata;
+            axi_wset <= 1'b1;
+            wr_req <= axi_awset | awvalid;
+          end
+        if ((axi_wdone & bready) == 1'b1)
+          begin
+            axi_wset <= 1'b0;
+            axi_awset <= 1'b0;
+            axi_wdone <= 1'b0;
+          end
+        if (wr_ack == 1'b1)
+          axi_wdone <= 1'b1;
+      end
+  end
+  assign bresp = 2'b00;
+
+  // AR and R channels
+  assign arready = ~axi_arset;
+  assign rvalid = axi_rdone;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        rd_req <= 1'b0;
+        axi_arset <= 1'b0;
+        axi_rdone <= 1'b0;
+        rdata <= 32'b0;
+      end
+    else
+      begin
+        rd_req <= 1'b0;
+        if (arvalid == 1'b1 & axi_arset == 1'b0)
+          begin
+            rd_addr <= araddr;
+            axi_arset <= 1'b1;
+            rd_req <= 1'b1;
+          end
+        if ((axi_rdone & rready) == 1'b1)
+          begin
+            axi_arset <= 1'b0;
+            axi_rdone <= 1'b0;
+          end
+        if (rd_ack == 1'b1)
+          begin
+            axi_rdone <= 1'b1;
+            rdata <= rd_data;
+          end
+      end
+  end
+  assign rresp = 2'b00;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        rd_ack <= 1'b0;
+        rd_data <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 1'b0;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack <= rd_ack_d0;
+        rd_data <= rd_dat_d0;
+        wr_req_d0 <= wr_req;
+        wr_adr_d0 <= wr_addr;
+        wr_dat_d0 <= wr_data;
+      end
+  end
+
+  // Register register1
+  assign register1_o = register1_reg;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        register1_reg <= 64'b0000000000000000000000000000000000000000000000000000000000000000;
+        register1_wack <= 2'b0;
+      end
+    else
+      begin
+        if (register1_wreq[0] == 1'b1)
+          register1_reg[31:0] <= wr_dat_d0;
+        if (register1_wreq[1] == 1'b1)
+          register1_reg[63:32] <= wr_dat_d0;
+        register1_wack <= register1_wreq;
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, register1_wack)
+  begin
+    register1_wreq = 2'b0;
+    case (wr_adr_d0[2:2])
+    1'b0:
+      begin
+        // Reg register1
+        register1_wreq[0] = wr_req_d0;
+        wr_ack = register1_wack[0];
+      end
+    1'b1:
+      begin
+        // Reg register1
+        register1_wreq[1] = wr_req_d0;
+        wr_ack = register1_wack[1];
+      end
+    default:
+      wr_ack = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always @(rd_addr, rd_req)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    case (rd_addr[2:2])
+    1'b0:
+      // Reg register1
+      rd_ack_d0 = rd_req;
+    1'b1:
+      // Reg register1
+      rd_ack_d0 = rd_req;
+    default:
+      rd_ack_d0 = rd_req;
+    endcase
+  end
+endmodule

--- a/testfiles/issue39/addressingMemory.sv
+++ b/testfiles/issue39/addressingMemory.sv
@@ -41,7 +41,7 @@ module eda02175v2
   assign VMEWrDone = wr_ack_int;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(Clk))
+  always_ff @(posedge(Clk))
   begin
     if (!rst_n)
       begin
@@ -63,7 +63,7 @@ module eda02175v2
 
   // Interface acqVP
   assign acqVP_VMEWrData_o = wr_dat_d0;
-  always @(posedge(Clk))
+  always_ff @(posedge(Clk))
   begin
     if (!rst_n)
       acqVP_wt <= 1'b0;
@@ -71,15 +71,15 @@ module eda02175v2
       acqVP_wt <= (acqVP_wt | acqVP_ws) & ~acqVP_VMEWrDone_i;
   end
   assign acqVP_VMEWrMem_o = acqVP_ws;
-  always @(VMEAddr, wr_adr_d0, acqVP_wt, acqVP_ws)
+  always_comb
   if ((acqVP_ws | acqVP_wt) == 1'b1)
-    acqVP_VMEAddr_o <= wr_adr_d0[16:1];
+    acqVP_VMEAddr_o = wr_adr_d0[16:1];
   else
-    acqVP_VMEAddr_o <= VMEAddr[16:1];
+    acqVP_VMEAddr_o = VMEAddr[16:1];
 
   // Register softReset
   assign softReset_reset_o = softReset_reset_reg;
-  always @(posedge(Clk))
+  always_ff @(posedge(Clk))
   begin
     if (!rst_n)
       begin
@@ -95,61 +95,61 @@ module eda02175v2
   end
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0, acqVP_VMEWrDone_i, softReset_wack)
+  always_comb
   begin
-    acqVP_ws <= 1'b0;
-    softReset_wreq <= 1'b0;
+    acqVP_ws = 1'b0;
+    softReset_wreq = 1'b0;
     case (wr_adr_d0[20:20])
     1'b0:
       begin
         // Memory acqVP
-        acqVP_ws <= wr_req_d0;
-        wr_ack_int <= acqVP_VMEWrDone_i;
+        acqVP_ws = wr_req_d0;
+        wr_ack_int = acqVP_VMEWrDone_i;
       end
     1'b1:
       case (wr_adr_d0[19:1])
       19'b0000000000000000000:
         begin
           // Reg softReset
-          softReset_wreq <= wr_req_d0;
-          wr_ack_int <= softReset_wack;
+          softReset_wreq = wr_req_d0;
+          wr_ack_int = softReset_wack;
         end
       default:
-        wr_ack_int <= wr_req_d0;
+        wr_ack_int = wr_req_d0;
       endcase
     default:
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     endcase
   end
 
   // Process for read requests.
-  always @(VMEAddr, VMERdMem, acqVP_VMERdData_i, acqVP_VMERdDone_i, softReset_reset_reg)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {16{1'bx}};
-    acqVP_VMERdMem_o <= 1'b0;
+    rd_dat_d0 = {16{1'bx}};
+    acqVP_VMERdMem_o = 1'b0;
     case (VMEAddr[20:20])
     1'b0:
       begin
         // Memory acqVP
-        acqVP_VMERdMem_o <= VMERdMem;
-        rd_dat_d0 <= acqVP_VMERdData_i;
-        rd_ack_d0 <= acqVP_VMERdDone_i;
+        acqVP_VMERdMem_o = VMERdMem;
+        rd_dat_d0 = acqVP_VMERdData_i;
+        rd_ack_d0 = acqVP_VMERdDone_i;
       end
     1'b1:
       case (VMEAddr[19:1])
       19'b0000000000000000000:
         begin
           // Reg softReset
-          rd_ack_d0 <= VMERdMem;
-          rd_dat_d0[0] <= softReset_reset_reg;
-          rd_dat_d0[15:1] <= 15'b0;
+          rd_ack_d0 = VMERdMem;
+          rd_dat_d0[0] = softReset_reset_reg;
+          rd_dat_d0[15:1] = 15'b0;
         end
       default:
-        rd_ack_d0 <= VMERdMem;
+        rd_ack_d0 = VMERdMem;
       endcase
     default:
-      rd_ack_d0 <= VMERdMem;
+      rd_ack_d0 = VMERdMem;
     endcase
   end
 endmodule

--- a/testfiles/issue39/addressingMemory.v
+++ b/testfiles/issue39/addressingMemory.v
@@ -1,0 +1,155 @@
+
+module eda02175v2
+  (
+    input   wire Clk,
+    input   wire Rst,
+    input   wire [20:1] VMEAddr,
+    output  reg [15:0] VMERdData,
+    input   wire [15:0] VMEWrData,
+    input   wire VMERdMem,
+    input   wire VMEWrMem,
+    output  wire VMERdDone,
+    output  wire VMEWrDone,
+
+    // ViewPort to the internal acquisition RAM/SRAM blocs
+    output  reg [16:1] acqVP_VMEAddr_o,
+    input   wire [15:0] acqVP_VMERdData_i,
+    output  wire [15:0] acqVP_VMEWrData_o,
+    output  reg acqVP_VMERdMem_o,
+    output  wire acqVP_VMEWrMem_o,
+    input   wire acqVP_VMERdDone_i,
+    input   wire acqVP_VMEWrDone_i,
+
+    // Resets the system part of the logic in the FPGA. ONLY FOR LAB PURPOSES
+    output  wire softReset_reset_o
+  );
+  wire rst_n;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  reg softReset_reset_reg;
+  reg softReset_wreq;
+  reg softReset_wack;
+  reg rd_ack_d0;
+  reg [15:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [20:1] wr_adr_d0;
+  reg [15:0] wr_dat_d0;
+  reg acqVP_ws;
+  reg acqVP_wt;
+  assign rst_n = ~Rst;
+  assign VMERdDone = rd_ack_int;
+  assign VMEWrDone = wr_ack_int;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(Clk))
+  begin
+    if (!rst_n)
+      begin
+        rd_ack_int <= 1'b0;
+        VMERdData <= 16'b0000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 20'b00000000000000000000;
+        wr_dat_d0 <= 16'b0000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        VMERdData <= rd_dat_d0;
+        wr_req_d0 <= VMEWrMem;
+        wr_adr_d0 <= VMEAddr;
+        wr_dat_d0 <= VMEWrData;
+      end
+  end
+
+  // Interface acqVP
+  assign acqVP_VMEWrData_o = wr_dat_d0;
+  always @(posedge(Clk))
+  begin
+    if (!rst_n)
+      acqVP_wt <= 1'b0;
+    else
+      acqVP_wt <= (acqVP_wt | acqVP_ws) & ~acqVP_VMEWrDone_i;
+  end
+  assign acqVP_VMEWrMem_o = acqVP_ws;
+  always @(VMEAddr, wr_adr_d0, acqVP_wt, acqVP_ws)
+  if ((acqVP_ws | acqVP_wt) == 1'b1)
+    acqVP_VMEAddr_o = wr_adr_d0[16:1];
+  else
+    acqVP_VMEAddr_o = VMEAddr[16:1];
+
+  // Register softReset
+  assign softReset_reset_o = softReset_reset_reg;
+  always @(posedge(Clk))
+  begin
+    if (!rst_n)
+      begin
+        softReset_reset_reg <= 1'b0;
+        softReset_wack <= 1'b0;
+      end
+    else
+      begin
+        if (softReset_wreq == 1'b1)
+          softReset_reset_reg <= wr_dat_d0[0];
+        softReset_wack <= softReset_wreq;
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, acqVP_VMEWrDone_i, softReset_wack)
+  begin
+    acqVP_ws = 1'b0;
+    softReset_wreq = 1'b0;
+    case (wr_adr_d0[20:20])
+    1'b0:
+      begin
+        // Memory acqVP
+        acqVP_ws = wr_req_d0;
+        wr_ack_int = acqVP_VMEWrDone_i;
+      end
+    1'b1:
+      case (wr_adr_d0[19:1])
+      19'b0000000000000000000:
+        begin
+          // Reg softReset
+          softReset_wreq = wr_req_d0;
+          wr_ack_int = softReset_wack;
+        end
+      default:
+        wr_ack_int = wr_req_d0;
+      endcase
+    default:
+      wr_ack_int = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always @(VMEAddr, VMERdMem, acqVP_VMERdData_i, acqVP_VMERdDone_i, softReset_reset_reg)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {16{1'bx}};
+    acqVP_VMERdMem_o = 1'b0;
+    case (VMEAddr[20:20])
+    1'b0:
+      begin
+        // Memory acqVP
+        acqVP_VMERdMem_o = VMERdMem;
+        rd_dat_d0 = acqVP_VMERdData_i;
+        rd_ack_d0 = acqVP_VMERdDone_i;
+      end
+    1'b1:
+      case (VMEAddr[19:1])
+      19'b0000000000000000000:
+        begin
+          // Reg softReset
+          rd_ack_d0 = VMERdMem;
+          rd_dat_d0[0] = softReset_reset_reg;
+          rd_dat_d0[15:1] = 15'b0;
+        end
+      default:
+        rd_ack_d0 = VMERdMem;
+      endcase
+    default:
+      rd_ack_d0 = VMERdMem;
+    endcase
+  end
+endmodule

--- a/testfiles/issue40/bugConstraints.sv
+++ b/testfiles/issue40/bugConstraints.sv
@@ -36,7 +36,7 @@ module bugConstraintFields
   assign VMEWrDone = wr_ack_int;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(Clk))
+  always_ff @(posedge(Clk))
   begin
     if (!rst_n)
       begin
@@ -58,7 +58,7 @@ module bugConstraintFields
 
   // Register r1
   assign r1_o = r1_reg;
-  always @(posedge(Clk))
+  always_ff @(posedge(Clk))
   begin
     if (!rst_n)
       begin
@@ -75,7 +75,7 @@ module bugConstraintFields
 
   // Register r2
   assign r2_r2_o = r2_r2_reg;
-  always @(posedge(Clk))
+  always_ff @(posedge(Clk))
   begin
     if (!rst_n)
       begin
@@ -91,49 +91,49 @@ module bugConstraintFields
   end
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0, r1_wack, r2_wack)
+  always_comb
   begin
-    r1_wreq <= 1'b0;
-    r2_wreq <= 1'b0;
+    r1_wreq = 1'b0;
+    r2_wreq = 1'b0;
     case (wr_adr_d0[2:2])
     1'b0:
       begin
         // Reg r1
-        r1_wreq <= wr_req_d0;
-        wr_ack_int <= r1_wack;
+        r1_wreq = wr_req_d0;
+        wr_ack_int = r1_wack;
       end
     1'b1:
       begin
         // Reg r2
-        r2_wreq <= wr_req_d0;
-        wr_ack_int <= r2_wack;
+        r2_wreq = wr_req_d0;
+        wr_ack_int = r2_wack;
       end
     default:
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     endcase
   end
 
   // Process for read requests.
-  always @(VMEAddr, VMERdMem, r1_reg, r2_r2_reg)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     case (VMEAddr[2:2])
     1'b0:
       begin
         // Reg r1
-        rd_ack_d0 <= VMERdMem;
-        rd_dat_d0 <= r1_reg;
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = r1_reg;
       end
     1'b1:
       begin
         // Reg r2
-        rd_ack_d0 <= VMERdMem;
-        rd_dat_d0[10:0] <= r2_r2_reg;
-        rd_dat_d0[31:11] <= 21'b0;
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0[10:0] = r2_r2_reg;
+        rd_dat_d0[31:11] = 21'b0;
       end
     default:
-      rd_ack_d0 <= VMERdMem;
+      rd_ack_d0 = VMERdMem;
     endcase
   end
 endmodule

--- a/testfiles/issue40/bugConstraints.v
+++ b/testfiles/issue40/bugConstraints.v
@@ -1,0 +1,139 @@
+
+module bugConstraintFields
+  (
+    input   wire Clk,
+    input   wire Rst,
+    input   wire [2:2] VMEAddr,
+    output  reg [31:0] VMERdData,
+    input   wire [31:0] VMEWrData,
+    input   wire VMERdMem,
+    input   wire VMEWrMem,
+    output  wire VMERdDone,
+    output  wire VMEWrDone,
+
+    // REG r1
+    output  wire [31:0] r1_o,
+
+    // REG r2
+    output  wire [10:0] r2_r2_o
+  );
+  wire rst_n;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  reg [31:0] r1_reg;
+  reg r1_wreq;
+  reg r1_wack;
+  reg [10:0] r2_r2_reg;
+  reg r2_wreq;
+  reg r2_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [2:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+  assign rst_n = ~Rst;
+  assign VMERdDone = rd_ack_int;
+  assign VMEWrDone = wr_ack_int;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(Clk))
+  begin
+    if (!rst_n)
+      begin
+        rd_ack_int <= 1'b0;
+        VMERdData <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 1'b0;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        VMERdData <= rd_dat_d0;
+        wr_req_d0 <= VMEWrMem;
+        wr_adr_d0 <= VMEAddr;
+        wr_dat_d0 <= VMEWrData;
+      end
+  end
+
+  // Register r1
+  assign r1_o = r1_reg;
+  always @(posedge(Clk))
+  begin
+    if (!rst_n)
+      begin
+        r1_reg <= 32'b00000000000000000000000000000000;
+        r1_wack <= 1'b0;
+      end
+    else
+      begin
+        if (r1_wreq == 1'b1)
+          r1_reg <= wr_dat_d0;
+        r1_wack <= r1_wreq;
+      end
+  end
+
+  // Register r2
+  assign r2_r2_o = r2_r2_reg;
+  always @(posedge(Clk))
+  begin
+    if (!rst_n)
+      begin
+        r2_r2_reg <= 11'b00000000000;
+        r2_wack <= 1'b0;
+      end
+    else
+      begin
+        if (r2_wreq == 1'b1)
+          r2_r2_reg <= wr_dat_d0[10:0];
+        r2_wack <= r2_wreq;
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, r1_wack, r2_wack)
+  begin
+    r1_wreq = 1'b0;
+    r2_wreq = 1'b0;
+    case (wr_adr_d0[2:2])
+    1'b0:
+      begin
+        // Reg r1
+        r1_wreq = wr_req_d0;
+        wr_ack_int = r1_wack;
+      end
+    1'b1:
+      begin
+        // Reg r2
+        r2_wreq = wr_req_d0;
+        wr_ack_int = r2_wack;
+      end
+    default:
+      wr_ack_int = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always @(VMEAddr, VMERdMem, r1_reg, r2_r2_reg)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    case (VMEAddr[2:2])
+    1'b0:
+      begin
+        // Reg r1
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = r1_reg;
+      end
+    1'b1:
+      begin
+        // Reg r2
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0[10:0] = r2_r2_reg;
+        rd_dat_d0[31:11] = 21'b0;
+      end
+    default:
+      rd_ack_d0 = VMERdMem;
+    endcase
+  end
+endmodule

--- a/testfiles/issue41/bugBlockFields.sv
+++ b/testfiles/issue41/bugBlockFields.sv
@@ -36,7 +36,7 @@ module bugBlockRegField
   assign VMEWrDone = wr_ack_int;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(Clk))
+  always_ff @(posedge(Clk))
   begin
     if (!rst_n)
       begin
@@ -60,7 +60,7 @@ module bugBlockRegField
   assign b1_r1_f3_o = b1_r1_f3_reg;
   assign b1_r1_f4_o = b1_r1_f4_reg;
   assign b1_r1_f5_o = b1_r1_f5_reg;
-  always @(posedge(Clk))
+  always_ff @(posedge(Clk))
   begin
     if (!rst_n)
       begin
@@ -86,26 +86,26 @@ module bugBlockRegField
   end
 
   // Process for write requests.
-  always @(wr_req_d0, b1_r1_wack)
+  always_comb
   begin
-    b1_r1_wreq <= 1'b0;
+    b1_r1_wreq = 1'b0;
     // Reg b1_r1
-    b1_r1_wreq <= wr_req_d0;
-    wr_ack_int <= b1_r1_wack;
+    b1_r1_wreq = wr_req_d0;
+    wr_ack_int = b1_r1_wack;
   end
 
   // Process for read requests.
-  always @(VMERdMem, b1_r1_f1_reg, b1_r1_f4_reg, b1_r1_f3_reg, b1_r1_f2_reg, b1_r1_f5_reg)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     // Reg b1_r1
-    rd_ack_d0 <= VMERdMem;
-    rd_dat_d0[0] <= b1_r1_f1_reg;
-    rd_dat_d0[1] <= b1_r1_f4_reg;
-    rd_dat_d0[2] <= b1_r1_f3_reg;
-    rd_dat_d0[12:3] <= b1_r1_f2_reg;
-    rd_dat_d0[13] <= b1_r1_f5_reg;
-    rd_dat_d0[31:14] <= 18'b0;
+    rd_ack_d0 = VMERdMem;
+    rd_dat_d0[0] = b1_r1_f1_reg;
+    rd_dat_d0[1] = b1_r1_f4_reg;
+    rd_dat_d0[2] = b1_r1_f3_reg;
+    rd_dat_d0[12:3] = b1_r1_f2_reg;
+    rd_dat_d0[13] = b1_r1_f5_reg;
+    rd_dat_d0[31:14] = 18'b0;
   end
 endmodule

--- a/testfiles/issue41/bugBlockFields.v
+++ b/testfiles/issue41/bugBlockFields.v
@@ -1,0 +1,111 @@
+
+module bugBlockRegField
+  (
+    input   wire Clk,
+    input   wire Rst,
+    output  reg [31:0] VMERdData,
+    input   wire [31:0] VMEWrData,
+    input   wire VMERdMem,
+    input   wire VMEWrMem,
+    output  wire VMERdDone,
+    output  wire VMEWrDone,
+
+    // REG r1
+    output  wire b1_r1_f1_o,
+    output  wire [9:0] b1_r1_f2_o,
+    output  wire b1_r1_f3_o,
+    output  wire b1_r1_f4_o,
+    output  wire b1_r1_f5_o
+  );
+  wire rst_n;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  reg b1_r1_f1_reg;
+  reg [9:0] b1_r1_f2_reg;
+  reg b1_r1_f3_reg;
+  reg b1_r1_f4_reg;
+  reg b1_r1_f5_reg;
+  reg b1_r1_wreq;
+  reg b1_r1_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [31:0] wr_dat_d0;
+  assign rst_n = ~Rst;
+  assign VMERdDone = rd_ack_int;
+  assign VMEWrDone = wr_ack_int;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(Clk))
+  begin
+    if (!rst_n)
+      begin
+        rd_ack_int <= 1'b0;
+        VMERdData <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        VMERdData <= rd_dat_d0;
+        wr_req_d0 <= VMEWrMem;
+        wr_dat_d0 <= VMEWrData;
+      end
+  end
+
+  // Register b1_r1
+  assign b1_r1_f1_o = b1_r1_f1_reg;
+  assign b1_r1_f2_o = b1_r1_f2_reg;
+  assign b1_r1_f3_o = b1_r1_f3_reg;
+  assign b1_r1_f4_o = b1_r1_f4_reg;
+  assign b1_r1_f5_o = b1_r1_f5_reg;
+  always @(posedge(Clk))
+  begin
+    if (!rst_n)
+      begin
+        b1_r1_f1_reg <= 1'b0;
+        b1_r1_f2_reg <= 10'b0000000000;
+        b1_r1_f3_reg <= 1'b0;
+        b1_r1_f4_reg <= 1'b0;
+        b1_r1_f5_reg <= 1'b0;
+        b1_r1_wack <= 1'b0;
+      end
+    else
+      begin
+        if (b1_r1_wreq == 1'b1)
+          begin
+            b1_r1_f1_reg <= wr_dat_d0[0];
+            b1_r1_f2_reg <= wr_dat_d0[12:3];
+            b1_r1_f3_reg <= wr_dat_d0[2];
+            b1_r1_f4_reg <= wr_dat_d0[1];
+            b1_r1_f5_reg <= wr_dat_d0[13];
+          end
+        b1_r1_wack <= b1_r1_wreq;
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_req_d0, b1_r1_wack)
+  begin
+    b1_r1_wreq = 1'b0;
+    // Reg b1_r1
+    b1_r1_wreq = wr_req_d0;
+    wr_ack_int = b1_r1_wack;
+  end
+
+  // Process for read requests.
+  always @(VMERdMem, b1_r1_f1_reg, b1_r1_f4_reg, b1_r1_f3_reg, b1_r1_f2_reg, b1_r1_f5_reg)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    // Reg b1_r1
+    rd_ack_d0 = VMERdMem;
+    rd_dat_d0[0] = b1_r1_f1_reg;
+    rd_dat_d0[1] = b1_r1_f4_reg;
+    rd_dat_d0[2] = b1_r1_f3_reg;
+    rd_dat_d0[12:3] = b1_r1_f2_reg;
+    rd_dat_d0[13] = b1_r1_f5_reg;
+    rd_dat_d0[31:14] = 18'b0;
+  end
+endmodule

--- a/testfiles/issue44/m1.sv
+++ b/testfiles/issue44/m1.sv
@@ -63,11 +63,11 @@ module m1
   reg m2_wt;
 
   // WB decode signals
-  always @(wb_sel_i)
+  always_comb
   ;
   assign wb_en = wb_cyc_i & wb_stb_i;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_rip <= 1'b0;
@@ -76,7 +76,7 @@ module m1
   end
   assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_wip <= 1'b0;
@@ -92,7 +92,7 @@ module m1
   assign wb_err_o = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -114,7 +114,7 @@ module m1
 
   // Interface m0
   assign m0_VMEWrData_o = wr_dat_d0;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       m0_wt <= 1'b0;
@@ -122,15 +122,15 @@ module m1
       m0_wt <= (m0_wt | m0_ws) & ~m0_VMEWrDone_i;
   end
   assign m0_VMEWrMem_o = m0_ws;
-  always @(wb_adr_i, wr_adr_d0, m0_wt, m0_ws)
+  always_comb
   if ((m0_ws | m0_wt) == 1'b1)
-    m0_VMEAddr_o <= wr_adr_d0[12:2];
+    m0_VMEAddr_o = wr_adr_d0[12:2];
   else
-    m0_VMEAddr_o <= wb_adr_i[12:2];
+    m0_VMEAddr_o = wb_adr_i[12:2];
 
   // Interface m1
   assign m1_VMEWrData_o = wr_dat_d0;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       m1_wt <= 1'b0;
@@ -138,15 +138,15 @@ module m1
       m1_wt <= (m1_wt | m1_ws) & ~m1_VMEWrDone_i;
   end
   assign m1_VMEWrMem_o = m1_ws;
-  always @(wb_adr_i, wr_adr_d0, m1_wt, m1_ws)
+  always_comb
   if ((m1_ws | m1_wt) == 1'b1)
-    m1_VMEAddr_o <= wr_adr_d0[11:2];
+    m1_VMEAddr_o = wr_adr_d0[11:2];
   else
-    m1_VMEAddr_o <= wb_adr_i[11:2];
+    m1_VMEAddr_o = wb_adr_i[11:2];
 
   // Interface m2
   assign m2_VMEWrData_o = wr_dat_d0;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       m2_wt <= 1'b0;
@@ -154,84 +154,84 @@ module m1
       m2_wt <= (m2_wt | m2_ws) & ~m2_VMEWrDone_i;
   end
   assign m2_VMEWrMem_o = m2_ws;
-  always @(wb_adr_i, wr_adr_d0, m2_wt, m2_ws)
+  always_comb
   if ((m2_ws | m2_wt) == 1'b1)
-    m2_VMEAddr_o <= wr_adr_d0[11:2];
+    m2_VMEAddr_o = wr_adr_d0[11:2];
   else
-    m2_VMEAddr_o <= wb_adr_i[11:2];
+    m2_VMEAddr_o = wb_adr_i[11:2];
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0, m0_VMEWrDone_i, m1_VMEWrDone_i, m2_VMEWrDone_i)
+  always_comb
   begin
-    m0_ws <= 1'b0;
-    m1_ws <= 1'b0;
-    m2_ws <= 1'b0;
+    m0_ws = 1'b0;
+    m1_ws = 1'b0;
+    m2_ws = 1'b0;
     case (wr_adr_d0[13:13])
     1'b0:
       begin
         // Memory m0
-        m0_ws <= wr_req_d0;
-        wr_ack_int <= m0_VMEWrDone_i;
+        m0_ws = wr_req_d0;
+        wr_ack_int = m0_VMEWrDone_i;
       end
     1'b1:
       case (wr_adr_d0[12:12])
       1'b0:
         begin
           // Memory m1
-          m1_ws <= wr_req_d0;
-          wr_ack_int <= m1_VMEWrDone_i;
+          m1_ws = wr_req_d0;
+          wr_ack_int = m1_VMEWrDone_i;
         end
       1'b1:
         begin
           // Memory m2
-          m2_ws <= wr_req_d0;
-          wr_ack_int <= m2_VMEWrDone_i;
+          m2_ws = wr_req_d0;
+          wr_ack_int = m2_VMEWrDone_i;
         end
       default:
-        wr_ack_int <= wr_req_d0;
+        wr_ack_int = wr_req_d0;
       endcase
     default:
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     endcase
   end
 
   // Process for read requests.
-  always @(wb_adr_i, rd_req_int, m0_VMERdData_i, m0_VMERdDone_i, m1_VMERdData_i, m1_VMERdDone_i, m2_VMERdData_i, m2_VMERdDone_i)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
-    m0_VMERdMem_o <= 1'b0;
-    m1_VMERdMem_o <= 1'b0;
-    m2_VMERdMem_o <= 1'b0;
+    rd_dat_d0 = {32{1'bx}};
+    m0_VMERdMem_o = 1'b0;
+    m1_VMERdMem_o = 1'b0;
+    m2_VMERdMem_o = 1'b0;
     case (wb_adr_i[13:13])
     1'b0:
       begin
         // Memory m0
-        m0_VMERdMem_o <= rd_req_int;
-        rd_dat_d0 <= m0_VMERdData_i;
-        rd_ack_d0 <= m0_VMERdDone_i;
+        m0_VMERdMem_o = rd_req_int;
+        rd_dat_d0 = m0_VMERdData_i;
+        rd_ack_d0 = m0_VMERdDone_i;
       end
     1'b1:
       case (wb_adr_i[12:12])
       1'b0:
         begin
           // Memory m1
-          m1_VMERdMem_o <= rd_req_int;
-          rd_dat_d0 <= m1_VMERdData_i;
-          rd_ack_d0 <= m1_VMERdDone_i;
+          m1_VMERdMem_o = rd_req_int;
+          rd_dat_d0 = m1_VMERdData_i;
+          rd_ack_d0 = m1_VMERdDone_i;
         end
       1'b1:
         begin
           // Memory m2
-          m2_VMERdMem_o <= rd_req_int;
-          rd_dat_d0 <= m2_VMERdData_i;
-          rd_ack_d0 <= m2_VMERdDone_i;
+          m2_VMERdMem_o = rd_req_int;
+          rd_dat_d0 = m2_VMERdData_i;
+          rd_ack_d0 = m2_VMERdDone_i;
         end
       default:
-        rd_ack_d0 <= rd_req_int;
+        rd_ack_d0 = rd_req_int;
       endcase
     default:
-      rd_ack_d0 <= rd_req_int;
+      rd_ack_d0 = rd_req_int;
     endcase
   end
 endmodule

--- a/testfiles/issue44/m1.v
+++ b/testfiles/issue44/m1.v
@@ -1,0 +1,237 @@
+
+module m1
+  (
+    input   wire rst_n_i,
+    input   wire clk_i,
+    input   wire wb_cyc_i,
+    input   wire wb_stb_i,
+    input   wire [13:2] wb_adr_i,
+    input   wire [3:0] wb_sel_i,
+    input   wire wb_we_i,
+    input   wire [31:0] wb_dat_i,
+    output  wire wb_ack_o,
+    output  wire wb_err_o,
+    output  wire wb_rty_o,
+    output  wire wb_stall_o,
+    output  reg [31:0] wb_dat_o,
+
+    // CERN-BE bus m0
+    output  reg [12:2] m0_VMEAddr_o,
+    input   wire [31:0] m0_VMERdData_i,
+    output  wire [31:0] m0_VMEWrData_o,
+    output  reg m0_VMERdMem_o,
+    output  wire m0_VMEWrMem_o,
+    input   wire m0_VMERdDone_i,
+    input   wire m0_VMEWrDone_i,
+
+    // CERN-BE bus m1
+    output  reg [11:2] m1_VMEAddr_o,
+    input   wire [31:0] m1_VMERdData_i,
+    output  wire [31:0] m1_VMEWrData_o,
+    output  reg m1_VMERdMem_o,
+    output  wire m1_VMEWrMem_o,
+    input   wire m1_VMERdDone_i,
+    input   wire m1_VMEWrDone_i,
+
+    // CERN-BE bus m2
+    output  reg [11:2] m2_VMEAddr_o,
+    input   wire [31:0] m2_VMERdData_i,
+    output  wire [31:0] m2_VMEWrData_o,
+    output  reg m2_VMERdMem_o,
+    output  wire m2_VMEWrMem_o,
+    input   wire m2_VMERdDone_i,
+    input   wire m2_VMEWrDone_i
+  );
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [13:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+  reg m0_ws;
+  reg m0_wt;
+  reg m1_ws;
+  reg m1_wt;
+  reg m2_ws;
+  reg m2_wt;
+
+  // WB decode signals
+  always @(wb_sel_i)
+  ;
+  assign wb_en = wb_cyc_i & wb_stb_i;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb_we_i)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb_we_i)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb_we_i) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb_ack_o = ack_int;
+  assign wb_stall_o = ~ack_int & wb_en;
+  assign wb_rty_o = 1'b0;
+  assign wb_err_o = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        rd_ack_int <= 1'b0;
+        wb_dat_o <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 12'b000000000000;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb_dat_o <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_adr_d0 <= wb_adr_i;
+        wr_dat_d0 <= wb_dat_i;
+      end
+  end
+
+  // Interface m0
+  assign m0_VMEWrData_o = wr_dat_d0;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      m0_wt <= 1'b0;
+    else
+      m0_wt <= (m0_wt | m0_ws) & ~m0_VMEWrDone_i;
+  end
+  assign m0_VMEWrMem_o = m0_ws;
+  always @(wb_adr_i, wr_adr_d0, m0_wt, m0_ws)
+  if ((m0_ws | m0_wt) == 1'b1)
+    m0_VMEAddr_o = wr_adr_d0[12:2];
+  else
+    m0_VMEAddr_o = wb_adr_i[12:2];
+
+  // Interface m1
+  assign m1_VMEWrData_o = wr_dat_d0;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      m1_wt <= 1'b0;
+    else
+      m1_wt <= (m1_wt | m1_ws) & ~m1_VMEWrDone_i;
+  end
+  assign m1_VMEWrMem_o = m1_ws;
+  always @(wb_adr_i, wr_adr_d0, m1_wt, m1_ws)
+  if ((m1_ws | m1_wt) == 1'b1)
+    m1_VMEAddr_o = wr_adr_d0[11:2];
+  else
+    m1_VMEAddr_o = wb_adr_i[11:2];
+
+  // Interface m2
+  assign m2_VMEWrData_o = wr_dat_d0;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      m2_wt <= 1'b0;
+    else
+      m2_wt <= (m2_wt | m2_ws) & ~m2_VMEWrDone_i;
+  end
+  assign m2_VMEWrMem_o = m2_ws;
+  always @(wb_adr_i, wr_adr_d0, m2_wt, m2_ws)
+  if ((m2_ws | m2_wt) == 1'b1)
+    m2_VMEAddr_o = wr_adr_d0[11:2];
+  else
+    m2_VMEAddr_o = wb_adr_i[11:2];
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, m0_VMEWrDone_i, m1_VMEWrDone_i, m2_VMEWrDone_i)
+  begin
+    m0_ws = 1'b0;
+    m1_ws = 1'b0;
+    m2_ws = 1'b0;
+    case (wr_adr_d0[13:13])
+    1'b0:
+      begin
+        // Memory m0
+        m0_ws = wr_req_d0;
+        wr_ack_int = m0_VMEWrDone_i;
+      end
+    1'b1:
+      case (wr_adr_d0[12:12])
+      1'b0:
+        begin
+          // Memory m1
+          m1_ws = wr_req_d0;
+          wr_ack_int = m1_VMEWrDone_i;
+        end
+      1'b1:
+        begin
+          // Memory m2
+          m2_ws = wr_req_d0;
+          wr_ack_int = m2_VMEWrDone_i;
+        end
+      default:
+        wr_ack_int = wr_req_d0;
+      endcase
+    default:
+      wr_ack_int = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always @(wb_adr_i, rd_req_int, m0_VMERdData_i, m0_VMERdDone_i, m1_VMERdData_i, m1_VMERdDone_i, m2_VMERdData_i, m2_VMERdDone_i)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    m0_VMERdMem_o = 1'b0;
+    m1_VMERdMem_o = 1'b0;
+    m2_VMERdMem_o = 1'b0;
+    case (wb_adr_i[13:13])
+    1'b0:
+      begin
+        // Memory m0
+        m0_VMERdMem_o = rd_req_int;
+        rd_dat_d0 = m0_VMERdData_i;
+        rd_ack_d0 = m0_VMERdDone_i;
+      end
+    1'b1:
+      case (wb_adr_i[12:12])
+      1'b0:
+        begin
+          // Memory m1
+          m1_VMERdMem_o = rd_req_int;
+          rd_dat_d0 = m1_VMERdData_i;
+          rd_ack_d0 = m1_VMERdDone_i;
+        end
+      1'b1:
+        begin
+          // Memory m2
+          m2_VMERdMem_o = rd_req_int;
+          rd_dat_d0 = m2_VMERdData_i;
+          rd_ack_d0 = m2_VMERdDone_i;
+        end
+      default:
+        rd_ack_d0 = rd_req_int;
+      endcase
+    default:
+      rd_ack_d0 = rd_req_int;
+    endcase
+  end
+endmodule

--- a/testfiles/issue45/test16.sv
+++ b/testfiles/issue45/test16.sv
@@ -28,7 +28,7 @@ module test8
   assign VMEWrDone = wr_ack_int;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(Clk))
+  always_ff @(posedge(Clk))
   begin
     if (!rst_n)
       begin
@@ -48,7 +48,7 @@ module test8
 
   // Register r1
   assign r1_o = r1_reg;
-  always @(posedge(Clk))
+  always_ff @(posedge(Clk))
   begin
     if (!rst_n)
       begin
@@ -64,22 +64,22 @@ module test8
   end
 
   // Process for write requests.
-  always @(wr_req_d0, r1_wack)
+  always_comb
   begin
-    r1_wreq <= 1'b0;
+    r1_wreq = 1'b0;
     // Reg r1
-    r1_wreq <= wr_req_d0;
-    wr_ack_int <= r1_wack;
+    r1_wreq = wr_req_d0;
+    wr_ack_int = r1_wack;
   end
 
   // Process for read requests.
-  always @(VMERdMem, r1_reg)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     // Reg r1
-    rd_ack_d0 <= VMERdMem;
-    rd_dat_d0[15:0] <= r1_reg;
-    rd_dat_d0[31:16] <= 16'b0;
+    rd_ack_d0 = VMERdMem;
+    rd_dat_d0[15:0] = r1_reg;
+    rd_dat_d0[31:16] = 16'b0;
   end
 endmodule

--- a/testfiles/issue45/test16.v
+++ b/testfiles/issue45/test16.v
@@ -1,0 +1,85 @@
+
+module test8
+  (
+    input   wire Clk,
+    input   wire Rst,
+    output  reg [31:0] VMERdData,
+    input   wire [31:0] VMEWrData,
+    input   wire VMERdMem,
+    input   wire VMEWrMem,
+    output  wire VMERdDone,
+    output  wire VMEWrDone,
+
+    // REG r1
+    output  wire [15:0] r1_o
+  );
+  wire rst_n;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  reg [15:0] r1_reg;
+  reg r1_wreq;
+  reg r1_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [31:0] wr_dat_d0;
+  assign rst_n = ~Rst;
+  assign VMERdDone = rd_ack_int;
+  assign VMEWrDone = wr_ack_int;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(Clk))
+  begin
+    if (!rst_n)
+      begin
+        rd_ack_int <= 1'b0;
+        VMERdData <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        VMERdData <= rd_dat_d0;
+        wr_req_d0 <= VMEWrMem;
+        wr_dat_d0 <= VMEWrData;
+      end
+  end
+
+  // Register r1
+  assign r1_o = r1_reg;
+  always @(posedge(Clk))
+  begin
+    if (!rst_n)
+      begin
+        r1_reg <= 16'b0000000000000000;
+        r1_wack <= 1'b0;
+      end
+    else
+      begin
+        if (r1_wreq == 1'b1)
+          r1_reg <= wr_dat_d0[15:0];
+        r1_wack <= r1_wreq;
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_req_d0, r1_wack)
+  begin
+    r1_wreq = 1'b0;
+    // Reg r1
+    r1_wreq = wr_req_d0;
+    wr_ack_int = r1_wack;
+  end
+
+  // Process for read requests.
+  always @(VMERdMem, r1_reg)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    // Reg r1
+    rd_ack_d0 = VMERdMem;
+    rd_dat_d0[15:0] = r1_reg;
+    rd_dat_d0[31:16] = 16'b0;
+  end
+endmodule

--- a/testfiles/issue45/test8.sv
+++ b/testfiles/issue45/test8.sv
@@ -28,7 +28,7 @@ module test8
   assign VMEWrDone = wr_ack_int;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(Clk))
+  always_ff @(posedge(Clk))
   begin
     if (!rst_n)
       begin
@@ -48,7 +48,7 @@ module test8
 
   // Register r1
   assign r1_o = r1_reg;
-  always @(posedge(Clk))
+  always_ff @(posedge(Clk))
   begin
     if (!rst_n)
       begin
@@ -64,22 +64,22 @@ module test8
   end
 
   // Process for write requests.
-  always @(wr_req_d0, r1_wack)
+  always_comb
   begin
-    r1_wreq <= 1'b0;
+    r1_wreq = 1'b0;
     // Reg r1
-    r1_wreq <= wr_req_d0;
-    wr_ack_int <= r1_wack;
+    r1_wreq = wr_req_d0;
+    wr_ack_int = r1_wack;
   end
 
   // Process for read requests.
-  always @(VMERdMem, r1_reg)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     // Reg r1
-    rd_ack_d0 <= VMERdMem;
-    rd_dat_d0[7:0] <= r1_reg;
-    rd_dat_d0[31:8] <= 24'b0;
+    rd_ack_d0 = VMERdMem;
+    rd_dat_d0[7:0] = r1_reg;
+    rd_dat_d0[31:8] = 24'b0;
   end
 endmodule

--- a/testfiles/issue45/test8.v
+++ b/testfiles/issue45/test8.v
@@ -1,0 +1,85 @@
+
+module test8
+  (
+    input   wire Clk,
+    input   wire Rst,
+    output  reg [31:0] VMERdData,
+    input   wire [31:0] VMEWrData,
+    input   wire VMERdMem,
+    input   wire VMEWrMem,
+    output  wire VMERdDone,
+    output  wire VMEWrDone,
+
+    // REG r1
+    output  wire [7:0] r1_o
+  );
+  wire rst_n;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  reg [7:0] r1_reg;
+  reg r1_wreq;
+  reg r1_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [31:0] wr_dat_d0;
+  assign rst_n = ~Rst;
+  assign VMERdDone = rd_ack_int;
+  assign VMEWrDone = wr_ack_int;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(Clk))
+  begin
+    if (!rst_n)
+      begin
+        rd_ack_int <= 1'b0;
+        VMERdData <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        VMERdData <= rd_dat_d0;
+        wr_req_d0 <= VMEWrMem;
+        wr_dat_d0 <= VMEWrData;
+      end
+  end
+
+  // Register r1
+  assign r1_o = r1_reg;
+  always @(posedge(Clk))
+  begin
+    if (!rst_n)
+      begin
+        r1_reg <= 8'b00000000;
+        r1_wack <= 1'b0;
+      end
+    else
+      begin
+        if (r1_wreq == 1'b1)
+          r1_reg <= wr_dat_d0[7:0];
+        r1_wack <= r1_wreq;
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_req_d0, r1_wack)
+  begin
+    r1_wreq = 1'b0;
+    // Reg r1
+    r1_wreq = wr_req_d0;
+    wr_ack_int = r1_wack;
+  end
+
+  // Process for read requests.
+  always @(VMERdMem, r1_reg)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    // Reg r1
+    rd_ack_d0 = VMERdMem;
+    rd_dat_d0[7:0] = r1_reg;
+    rd_dat_d0[31:8] = 24'b0;
+  end
+endmodule

--- a/testfiles/issue52/hwInfo.sv
+++ b/testfiles/issue52/hwInfo.sv
@@ -44,7 +44,7 @@ module hwInfo
   assign VMEWrDone = wr_ack_int;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(Clk))
+  always_ff @(posedge(Clk))
   begin
     if (!rst_n)
       begin
@@ -74,7 +74,7 @@ module hwInfo
 
   // Register echo
   assign echo_echo_o = echo_echo_reg;
-  always @(posedge(Clk))
+  always_ff @(posedge(Clk))
   begin
     if (!rst_n)
       begin
@@ -90,144 +90,144 @@ module hwInfo
   end
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0, echo_wack)
+  always_comb
   begin
-    echo_wreq <= 2'b0;
+    echo_wreq = 2'b0;
     case (wr_adr_d0[4:1])
     4'b0000:
       // Reg stdVersion
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     4'b0001:
       // Reg stdVersion
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     4'b0010:
       // Reg serialNumber
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     4'b0011:
       // Reg serialNumber
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     4'b0100:
       // Reg serialNumber
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     4'b0101:
       // Reg serialNumber
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     4'b0110:
       // Reg firmwareVersion
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     4'b0111:
       // Reg firmwareVersion
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     4'b1000:
       // Reg memMapVersion
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     4'b1001:
       // Reg memMapVersion
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     4'b1010:
       begin
         // Reg echo
-        echo_wreq[1] <= wr_req_d0;
-        wr_ack_int <= echo_wack[1];
+        echo_wreq[1] = wr_req_d0;
+        wr_ack_int = echo_wack[1];
       end
     4'b1011:
       begin
         // Reg echo
-        echo_wreq[0] <= wr_req_d0;
-        wr_ack_int <= echo_wack[0];
+        echo_wreq[0] = wr_req_d0;
+        wr_ack_int = echo_wack[0];
       end
     default:
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     endcase
   end
 
   // Process for read requests.
-  always @(VMEAddr, VMERdMem, serialNumber_i, firmwareVersion_major_i, firmwareVersion_patch_i, firmwareVersion_minor_i, memMapVersion_major_i, memMapVersion_patch_i, memMapVersion_minor_i, echo_echo_reg)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {16{1'bx}};
+    rd_dat_d0 = {16{1'bx}};
     case (VMEAddr[4:1])
     4'b0000:
       begin
         // Reg stdVersion
-        rd_ack_d0 <= VMERdMem;
-        rd_dat_d0[7:0] <= 8'b00000001;
-        rd_dat_d0[15:8] <= 8'b0;
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0[7:0] = 8'b00000001;
+        rd_dat_d0[15:8] = 8'b0;
       end
     4'b0001:
       begin
         // Reg stdVersion
-        rd_ack_d0 <= VMERdMem;
-        rd_dat_d0[7:0] <= 8'b00000000;
-        rd_dat_d0[15:8] <= 8'b00000000;
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0[7:0] = 8'b00000000;
+        rd_dat_d0[15:8] = 8'b00000000;
       end
     4'b0010:
       begin
         // Reg serialNumber
-        rd_ack_d0 <= VMERdMem;
-        rd_dat_d0 <= serialNumber_i[63:48];
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = serialNumber_i[63:48];
       end
     4'b0011:
       begin
         // Reg serialNumber
-        rd_ack_d0 <= VMERdMem;
-        rd_dat_d0 <= serialNumber_i[47:32];
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = serialNumber_i[47:32];
       end
     4'b0100:
       begin
         // Reg serialNumber
-        rd_ack_d0 <= VMERdMem;
-        rd_dat_d0 <= serialNumber_i[31:16];
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = serialNumber_i[31:16];
       end
     4'b0101:
       begin
         // Reg serialNumber
-        rd_ack_d0 <= VMERdMem;
-        rd_dat_d0 <= serialNumber_i[15:0];
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = serialNumber_i[15:0];
       end
     4'b0110:
       begin
         // Reg firmwareVersion
-        rd_ack_d0 <= VMERdMem;
-        rd_dat_d0[7:0] <= firmwareVersion_major_i;
-        rd_dat_d0[15:8] <= 8'b0;
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0[7:0] = firmwareVersion_major_i;
+        rd_dat_d0[15:8] = 8'b0;
       end
     4'b0111:
       begin
         // Reg firmwareVersion
-        rd_ack_d0 <= VMERdMem;
-        rd_dat_d0[7:0] <= firmwareVersion_patch_i;
-        rd_dat_d0[15:8] <= firmwareVersion_minor_i;
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0[7:0] = firmwareVersion_patch_i;
+        rd_dat_d0[15:8] = firmwareVersion_minor_i;
       end
     4'b1000:
       begin
         // Reg memMapVersion
-        rd_ack_d0 <= VMERdMem;
-        rd_dat_d0[7:0] <= memMapVersion_major_i;
-        rd_dat_d0[15:8] <= 8'b0;
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0[7:0] = memMapVersion_major_i;
+        rd_dat_d0[15:8] = 8'b0;
       end
     4'b1001:
       begin
         // Reg memMapVersion
-        rd_ack_d0 <= VMERdMem;
-        rd_dat_d0[7:0] <= memMapVersion_patch_i;
-        rd_dat_d0[15:8] <= memMapVersion_minor_i;
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0[7:0] = memMapVersion_patch_i;
+        rd_dat_d0[15:8] = memMapVersion_minor_i;
       end
     4'b1010:
       begin
         // Reg echo
-        rd_ack_d0 <= VMERdMem;
-        rd_dat_d0[15:0] <= 16'b0;
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0[15:0] = 16'b0;
       end
     4'b1011:
       begin
         // Reg echo
-        rd_ack_d0 <= VMERdMem;
-        rd_dat_d0[7:0] <= echo_echo_reg;
-        rd_dat_d0[15:8] <= 8'b0;
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0[7:0] = echo_echo_reg;
+        rd_dat_d0[15:8] = 8'b0;
       end
     default:
-      rd_ack_d0 <= VMERdMem;
+      rd_ack_d0 = VMERdMem;
     endcase
   end
 endmodule

--- a/testfiles/issue52/hwInfo.v
+++ b/testfiles/issue52/hwInfo.v
@@ -1,0 +1,233 @@
+
+module hwInfo
+  (
+    input   wire Clk,
+    input   wire Rst,
+    input   wire [4:1] VMEAddr,
+    output  reg [15:0] VMERdData,
+    input   wire [15:0] VMEWrData,
+    input   wire VMERdMem,
+    input   wire VMEWrMem,
+    output  wire VMERdDone,
+    output  wire VMEWrDone,
+
+    // HW serial number
+    input   wire [63:0] serialNumber_i,
+
+    // Firmware Version
+    input   wire [7:0] firmwareVersion_major_i,
+    input   wire [7:0] firmwareVersion_minor_i,
+    input   wire [7:0] firmwareVersion_patch_i,
+
+    // Memory Map Version
+    input   wire [7:0] memMapVersion_major_i,
+    input   wire [7:0] memMapVersion_minor_i,
+    input   wire [7:0] memMapVersion_patch_i,
+
+    // Echo register
+    // This version of the standard foresees only 8bits linked to real memory
+    output  wire [7:0] echo_echo_o
+  );
+  wire rst_n;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  reg [7:0] echo_echo_reg;
+  reg [1:0] echo_wreq;
+  reg [1:0] echo_wack;
+  reg rd_ack_d0;
+  reg [15:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [4:1] wr_adr_d0;
+  reg [15:0] wr_dat_d0;
+  assign rst_n = ~Rst;
+  assign VMERdDone = rd_ack_int;
+  assign VMEWrDone = wr_ack_int;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(Clk))
+  begin
+    if (!rst_n)
+      begin
+        rd_ack_int <= 1'b0;
+        VMERdData <= 16'b0000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 4'b0000;
+        wr_dat_d0 <= 16'b0000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        VMERdData <= rd_dat_d0;
+        wr_req_d0 <= VMEWrMem;
+        wr_adr_d0 <= VMEAddr;
+        wr_dat_d0 <= VMEWrData;
+      end
+  end
+
+  // Register stdVersion
+
+  // Register serialNumber
+
+  // Register firmwareVersion
+
+  // Register memMapVersion
+
+  // Register echo
+  assign echo_echo_o = echo_echo_reg;
+  always @(posedge(Clk))
+  begin
+    if (!rst_n)
+      begin
+        echo_echo_reg <= 8'b00000000;
+        echo_wack <= 2'b0;
+      end
+    else
+      begin
+        if (echo_wreq[0] == 1'b1)
+          echo_echo_reg <= wr_dat_d0[7:0];
+        echo_wack <= echo_wreq;
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, echo_wack)
+  begin
+    echo_wreq = 2'b0;
+    case (wr_adr_d0[4:1])
+    4'b0000:
+      // Reg stdVersion
+      wr_ack_int = wr_req_d0;
+    4'b0001:
+      // Reg stdVersion
+      wr_ack_int = wr_req_d0;
+    4'b0010:
+      // Reg serialNumber
+      wr_ack_int = wr_req_d0;
+    4'b0011:
+      // Reg serialNumber
+      wr_ack_int = wr_req_d0;
+    4'b0100:
+      // Reg serialNumber
+      wr_ack_int = wr_req_d0;
+    4'b0101:
+      // Reg serialNumber
+      wr_ack_int = wr_req_d0;
+    4'b0110:
+      // Reg firmwareVersion
+      wr_ack_int = wr_req_d0;
+    4'b0111:
+      // Reg firmwareVersion
+      wr_ack_int = wr_req_d0;
+    4'b1000:
+      // Reg memMapVersion
+      wr_ack_int = wr_req_d0;
+    4'b1001:
+      // Reg memMapVersion
+      wr_ack_int = wr_req_d0;
+    4'b1010:
+      begin
+        // Reg echo
+        echo_wreq[1] = wr_req_d0;
+        wr_ack_int = echo_wack[1];
+      end
+    4'b1011:
+      begin
+        // Reg echo
+        echo_wreq[0] = wr_req_d0;
+        wr_ack_int = echo_wack[0];
+      end
+    default:
+      wr_ack_int = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always @(VMEAddr, VMERdMem, serialNumber_i, firmwareVersion_major_i, firmwareVersion_patch_i, firmwareVersion_minor_i, memMapVersion_major_i, memMapVersion_patch_i, memMapVersion_minor_i, echo_echo_reg)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {16{1'bx}};
+    case (VMEAddr[4:1])
+    4'b0000:
+      begin
+        // Reg stdVersion
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0[7:0] = 8'b00000001;
+        rd_dat_d0[15:8] = 8'b0;
+      end
+    4'b0001:
+      begin
+        // Reg stdVersion
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0[7:0] = 8'b00000000;
+        rd_dat_d0[15:8] = 8'b00000000;
+      end
+    4'b0010:
+      begin
+        // Reg serialNumber
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = serialNumber_i[63:48];
+      end
+    4'b0011:
+      begin
+        // Reg serialNumber
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = serialNumber_i[47:32];
+      end
+    4'b0100:
+      begin
+        // Reg serialNumber
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = serialNumber_i[31:16];
+      end
+    4'b0101:
+      begin
+        // Reg serialNumber
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = serialNumber_i[15:0];
+      end
+    4'b0110:
+      begin
+        // Reg firmwareVersion
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0[7:0] = firmwareVersion_major_i;
+        rd_dat_d0[15:8] = 8'b0;
+      end
+    4'b0111:
+      begin
+        // Reg firmwareVersion
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0[7:0] = firmwareVersion_patch_i;
+        rd_dat_d0[15:8] = firmwareVersion_minor_i;
+      end
+    4'b1000:
+      begin
+        // Reg memMapVersion
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0[7:0] = memMapVersion_major_i;
+        rd_dat_d0[15:8] = 8'b0;
+      end
+    4'b1001:
+      begin
+        // Reg memMapVersion
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0[7:0] = memMapVersion_patch_i;
+        rd_dat_d0[15:8] = memMapVersion_minor_i;
+      end
+    4'b1010:
+      begin
+        // Reg echo
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0[15:0] = 16'b0;
+      end
+    4'b1011:
+      begin
+        // Reg echo
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0[7:0] = echo_echo_reg;
+        rd_dat_d0[15:8] = 8'b0;
+      end
+    default:
+      rd_ack_d0 = VMERdMem;
+    endcase
+  end
+endmodule

--- a/testfiles/issue59/inherit.sv
+++ b/testfiles/issue59/inherit.sv
@@ -42,11 +42,11 @@ module inherit
   reg [31:0] wr_dat_d0;
 
   // WB decode signals
-  always @(wb_sel_i)
+  always_comb
   ;
   assign wb_en = wb_cyc_i & wb_stb_i;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_rip <= 1'b0;
@@ -55,7 +55,7 @@ module inherit
   end
   assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_wip <= 1'b0;
@@ -71,7 +71,7 @@ module inherit
   assign wb_err_o = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -93,7 +93,7 @@ module inherit
   assign reg0_field00_o = wr_dat_d0[1];
   assign reg0_field01_o = reg0_field01_reg;
   assign reg0_field02_o = wr_dat_d0[10:8];
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -110,26 +110,26 @@ module inherit
   assign reg0_wr_o = reg0_wack;
 
   // Process for write requests.
-  always @(wr_req_d0, reg0_wack)
+  always_comb
   begin
-    reg0_wreq <= 1'b0;
+    reg0_wreq = 1'b0;
     // Reg reg0
-    reg0_wreq <= wr_req_d0;
-    wr_ack_int <= reg0_wack;
+    reg0_wreq = wr_req_d0;
+    wr_ack_int = reg0_wack;
   end
 
   // Process for read requests.
-  always @(rd_req_int, reg0_field00_i, reg0_field01_reg, reg0_field02_i)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     // Reg reg0
-    rd_ack_d0 <= rd_req_int;
-    rd_dat_d0[0] <= 1'b0;
-    rd_dat_d0[1] <= reg0_field00_i;
-    rd_dat_d0[3:2] <= 2'b0;
-    rd_dat_d0[7:4] <= reg0_field01_reg;
-    rd_dat_d0[10:8] <= reg0_field02_i;
-    rd_dat_d0[31:11] <= 21'b0;
+    rd_ack_d0 = rd_req_int;
+    rd_dat_d0[0] = 1'b0;
+    rd_dat_d0[1] = reg0_field00_i;
+    rd_dat_d0[3:2] = 2'b0;
+    rd_dat_d0[7:4] = reg0_field01_reg;
+    rd_dat_d0[10:8] = reg0_field02_i;
+    rd_dat_d0[31:11] = 21'b0;
   end
 endmodule

--- a/testfiles/issue59/inherit.v
+++ b/testfiles/issue59/inherit.v
@@ -1,0 +1,135 @@
+
+module inherit
+  (
+    input   wire rst_n_i,
+    input   wire clk_i,
+    input   wire wb_cyc_i,
+    input   wire wb_stb_i,
+    input   wire [3:0] wb_sel_i,
+    input   wire wb_we_i,
+    input   wire [31:0] wb_dat_i,
+    output  wire wb_ack_o,
+    output  wire wb_err_o,
+    output  wire wb_rty_o,
+    output  wire wb_stall_o,
+    output  reg [31:0] wb_dat_o,
+
+    // a normal reg with some fields
+    // 1-bit field
+    input   wire reg0_field00_i,
+    output  wire reg0_field00_o,
+    // multi bit field
+    output  wire [3:0] reg0_field01_o,
+    // a field with a preset value
+    input   wire [2:0] reg0_field02_i,
+    output  wire [2:0] reg0_field02_o,
+    output  wire reg0_wr_o
+  );
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg [3:0] reg0_field01_reg;
+  reg reg0_wreq;
+  reg reg0_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [31:0] wr_dat_d0;
+
+  // WB decode signals
+  always @(wb_sel_i)
+  ;
+  assign wb_en = wb_cyc_i & wb_stb_i;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb_we_i)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb_we_i)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb_we_i) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb_ack_o = ack_int;
+  assign wb_stall_o = ~ack_int & wb_en;
+  assign wb_rty_o = 1'b0;
+  assign wb_err_o = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        rd_ack_int <= 1'b0;
+        wb_dat_o <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb_dat_o <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_dat_d0 <= wb_dat_i;
+      end
+  end
+
+  // Register reg0
+  assign reg0_field00_o = wr_dat_d0[1];
+  assign reg0_field01_o = reg0_field01_reg;
+  assign reg0_field02_o = wr_dat_d0[10:8];
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        reg0_field01_reg <= 4'b0000;
+        reg0_wack <= 1'b0;
+      end
+    else
+      begin
+        if (reg0_wreq == 1'b1)
+          reg0_field01_reg <= wr_dat_d0[7:4];
+        reg0_wack <= reg0_wreq;
+      end
+  end
+  assign reg0_wr_o = reg0_wack;
+
+  // Process for write requests.
+  always @(wr_req_d0, reg0_wack)
+  begin
+    reg0_wreq = 1'b0;
+    // Reg reg0
+    reg0_wreq = wr_req_d0;
+    wr_ack_int = reg0_wack;
+  end
+
+  // Process for read requests.
+  always @(rd_req_int, reg0_field00_i, reg0_field01_reg, reg0_field02_i)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    // Reg reg0
+    rd_ack_d0 = rd_req_int;
+    rd_dat_d0[0] = 1'b0;
+    rd_dat_d0[1] = reg0_field00_i;
+    rd_dat_d0[3:2] = 2'b0;
+    rd_dat_d0[7:4] = reg0_field01_reg;
+    rd_dat_d0[10:8] = reg0_field02_i;
+    rd_dat_d0[31:11] = 21'b0;
+  end
+endmodule

--- a/testfiles/issue64/simple_reg1.sv
+++ b/testfiles/issue64/simple_reg1.sv
@@ -34,11 +34,11 @@ module sreg_map
   reg [31:0] wr_dat_d0;
 
   // WB decode signals
-  always @(wb_sel_i)
+  always_comb
   ;
   assign wb_en = wb_cyc_i & wb_stb_i;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_rip <= 1'b0;
@@ -47,7 +47,7 @@ module sreg_map
   end
   assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_wip <= 1'b0;
@@ -63,7 +63,7 @@ module sreg_map
   assign wb_err_o = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -83,7 +83,7 @@ module sreg_map
 
   // Register areg
   assign areg_o = areg_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -99,21 +99,21 @@ module sreg_map
   end
 
   // Process for write requests.
-  always @(wr_req_d0, areg_wack)
+  always_comb
   begin
-    areg_wreq <= 1'b0;
+    areg_wreq = 1'b0;
     // Reg areg
-    areg_wreq <= wr_req_d0;
-    wr_ack_int <= areg_wack;
+    areg_wreq = wr_req_d0;
+    wr_ack_int = areg_wack;
   end
 
   // Process for read requests.
-  always @(rd_req_int, areg_reg)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     // Reg areg
-    rd_ack_d0 <= rd_req_int;
-    rd_dat_d0 <= areg_reg;
+    rd_ack_d0 = rd_req_int;
+    rd_dat_d0 = areg_reg;
   end
 endmodule

--- a/testfiles/issue64/simple_reg1.v
+++ b/testfiles/issue64/simple_reg1.v
@@ -1,0 +1,119 @@
+
+module sreg_map
+  (
+    input   wire rst_n_i,
+    input   wire clk_i,
+    input   wire wb_cyc_i,
+    input   wire wb_stb_i,
+    input   wire [3:0] wb_sel_i,
+    input   wire wb_we_i,
+    input   wire [31:0] wb_dat_i,
+    output  wire wb_ack_o,
+    output  wire wb_err_o,
+    output  wire wb_rty_o,
+    output  wire wb_stall_o,
+    output  reg [31:0] wb_dat_o,
+
+    // REG areg
+    output  wire [31:0] areg_o
+  );
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg [31:0] areg_reg;
+  reg areg_wreq;
+  reg areg_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [31:0] wr_dat_d0;
+
+  // WB decode signals
+  always @(wb_sel_i)
+  ;
+  assign wb_en = wb_cyc_i & wb_stb_i;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb_we_i)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb_we_i)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb_we_i) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb_ack_o = ack_int;
+  assign wb_stall_o = ~ack_int & wb_en;
+  assign wb_rty_o = 1'b0;
+  assign wb_err_o = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        rd_ack_int <= 1'b0;
+        wb_dat_o <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb_dat_o <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_dat_d0 <= wb_dat_i;
+      end
+  end
+
+  // Register areg
+  assign areg_o = areg_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        areg_reg <= 32'b00000000000000000000000000000000;
+        areg_wack <= 1'b0;
+      end
+    else
+      begin
+        if (areg_wreq == 1'b1)
+          areg_reg <= wr_dat_d0;
+        areg_wack <= areg_wreq;
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_req_d0, areg_wack)
+  begin
+    areg_wreq = 1'b0;
+    // Reg areg
+    areg_wreq = wr_req_d0;
+    wr_ack_int = areg_wack;
+  end
+
+  // Process for read requests.
+  always @(rd_req_int, areg_reg)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    // Reg areg
+    rd_ack_d0 = rd_req_int;
+    rd_dat_d0 = areg_reg;
+  end
+endmodule

--- a/testfiles/issue66/m1.sv
+++ b/testfiles/issue66/m1.sv
@@ -38,7 +38,7 @@ module m1
   assign VMEWrDone = wr_ack_int;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(Clk))
+  always_ff @(posedge(Clk))
   begin
     if (!rst_n)
       begin
@@ -60,7 +60,7 @@ module m1
 
   // Register r1
   assign r1_o = r1_reg;
-  always @(posedge(Clk))
+  always_ff @(posedge(Clk))
   begin
     if (!rst_n)
       begin
@@ -77,7 +77,7 @@ module m1
 
   // Register r2
   assign r2_o = r2_reg;
-  always @(posedge(Clk))
+  always_ff @(posedge(Clk))
   begin
     if (!rst_n)
       begin
@@ -93,50 +93,50 @@ module m1
   end
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0, r1_wack, r2_wack)
+  always_comb
   begin
-    r1_wreq <= 1'b0;
-    r2_wreq <= 1'b0;
+    r1_wreq = 1'b0;
+    r2_wreq = 1'b0;
     case (wr_adr_d0[19:2])
     18'b000000000000000000:
       begin
         // Reg r1
-        r1_wreq <= wr_req_d0;
-        wr_ack_int <= r1_wack;
+        r1_wreq = wr_req_d0;
+        wr_ack_int = r1_wack;
       end
     18'b000000000000000001:
       begin
         // Reg r2
-        r2_wreq <= wr_req_d0;
-        wr_ack_int <= r2_wack;
+        r2_wreq = wr_req_d0;
+        wr_ack_int = r2_wack;
       end
     default:
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     endcase
   end
 
   // Process for read requests.
-  always @(VMEAddr, VMERdMem, r1_reg, r2_reg)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     case (VMEAddr[19:2])
     18'b000000000000000000:
       begin
         // Reg r1
-        rd_ack_d0 <= VMERdMem;
-        rd_dat_d0[7:0] <= r1_reg;
-        rd_dat_d0[31:8] <= 24'b0;
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0[7:0] = r1_reg;
+        rd_dat_d0[31:8] = 24'b0;
       end
     18'b000000000000000001:
       begin
         // Reg r2
-        rd_ack_d0 <= VMERdMem;
-        rd_dat_d0[15:0] <= r2_reg;
-        rd_dat_d0[31:16] <= 16'b0;
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0[15:0] = r2_reg;
+        rd_dat_d0[31:16] = 16'b0;
       end
     default:
-      rd_ack_d0 <= VMERdMem;
+      rd_ack_d0 = VMERdMem;
     endcase
   end
 endmodule

--- a/testfiles/issue66/m1.v
+++ b/testfiles/issue66/m1.v
@@ -1,0 +1,142 @@
+
+module m1
+  (
+    input   wire Clk,
+    input   wire Rst,
+    input   wire [19:2] VMEAddr,
+    output  reg [31:0] VMERdData,
+    input   wire [31:0] VMEWrData,
+    input   wire VMERdMem,
+    input   wire VMEWrMem,
+    output  wire VMERdDone,
+    output  wire VMEWrDone,
+    output  wire VMERdError,
+    output  wire VMEWrError,
+
+    // REG r1
+    output  wire [7:0] r1_o,
+
+    // REG r2
+    output  wire [15:0] r2_o
+  );
+  wire rst_n;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  reg [7:0] r1_reg;
+  reg r1_wreq;
+  reg r1_wack;
+  reg [15:0] r2_reg;
+  reg r2_wreq;
+  reg r2_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [19:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+  assign rst_n = ~Rst;
+  assign VMERdDone = rd_ack_int;
+  assign VMEWrDone = wr_ack_int;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(Clk))
+  begin
+    if (!rst_n)
+      begin
+        rd_ack_int <= 1'b0;
+        VMERdData <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 18'b000000000000000000;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        VMERdData <= rd_dat_d0;
+        wr_req_d0 <= VMEWrMem;
+        wr_adr_d0 <= VMEAddr;
+        wr_dat_d0 <= VMEWrData;
+      end
+  end
+
+  // Register r1
+  assign r1_o = r1_reg;
+  always @(posedge(Clk))
+  begin
+    if (!rst_n)
+      begin
+        r1_reg <= 8'b00000000;
+        r1_wack <= 1'b0;
+      end
+    else
+      begin
+        if (r1_wreq == 1'b1)
+          r1_reg <= wr_dat_d0[7:0];
+        r1_wack <= r1_wreq;
+      end
+  end
+
+  // Register r2
+  assign r2_o = r2_reg;
+  always @(posedge(Clk))
+  begin
+    if (!rst_n)
+      begin
+        r2_reg <= 16'b0000000000000000;
+        r2_wack <= 1'b0;
+      end
+    else
+      begin
+        if (r2_wreq == 1'b1)
+          r2_reg <= wr_dat_d0[15:0];
+        r2_wack <= r2_wreq;
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, r1_wack, r2_wack)
+  begin
+    r1_wreq = 1'b0;
+    r2_wreq = 1'b0;
+    case (wr_adr_d0[19:2])
+    18'b000000000000000000:
+      begin
+        // Reg r1
+        r1_wreq = wr_req_d0;
+        wr_ack_int = r1_wack;
+      end
+    18'b000000000000000001:
+      begin
+        // Reg r2
+        r2_wreq = wr_req_d0;
+        wr_ack_int = r2_wack;
+      end
+    default:
+      wr_ack_int = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always @(VMEAddr, VMERdMem, r1_reg, r2_reg)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    case (VMEAddr[19:2])
+    18'b000000000000000000:
+      begin
+        // Reg r1
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0[7:0] = r1_reg;
+        rd_dat_d0[31:8] = 24'b0;
+      end
+    18'b000000000000000001:
+      begin
+        // Reg r2
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0[15:0] = r2_reg;
+        rd_dat_d0[31:16] = 16'b0;
+      end
+    default:
+      rd_ack_d0 = VMERdMem;
+    endcase
+  end
+endmodule

--- a/testfiles/issue75/m1.sv
+++ b/testfiles/issue75/m1.sv
@@ -30,7 +30,7 @@ module m1
   assign VMEWrDone = wr_ack_int;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(Clk))
+  always_ff @(posedge(Clk))
   begin
     if (!rst_n)
       begin
@@ -52,7 +52,7 @@ module m1
 
   // Register r1
   assign r1_o = r1_reg;
-  always @(posedge(Clk))
+  always_ff @(posedge(Clk))
   begin
     if (!rst_n)
       begin
@@ -74,47 +74,47 @@ module m1
   end
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0, r1_wack)
+  always_comb
   begin
-    r1_wreq <= 2'b0;
+    r1_wreq = 2'b0;
     case (wr_adr_d0[2:2])
     1'b0:
       begin
         // Reg r1
-        r1_wreq[1] <= wr_req_d0;
-        wr_ack_int <= r1_wack[1];
+        r1_wreq[1] = wr_req_d0;
+        wr_ack_int = r1_wack[1];
       end
     1'b1:
       begin
         // Reg r1
-        r1_wreq[0] <= wr_req_d0;
-        wr_ack_int <= r1_wack[0];
+        r1_wreq[0] = wr_req_d0;
+        wr_ack_int = r1_wack[0];
       end
     default:
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     endcase
   end
 
   // Process for read requests.
-  always @(VMEAddr, VMERdMem)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     case (VMEAddr[2:2])
     1'b0:
       begin
         // Reg r1
-        rd_ack_d0 <= VMERdMem;
-        rd_dat_d0 <= 32'b00000000000000000000000000000000;
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = 32'b00000000000000000000000000000000;
       end
     1'b1:
       begin
         // Reg r1
-        rd_ack_d0 <= VMERdMem;
-        rd_dat_d0 <= 32'b00000000000000000000000000000000;
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = 32'b00000000000000000000000000000000;
       end
     default:
-      rd_ack_d0 <= VMERdMem;
+      rd_ack_d0 = VMERdMem;
     endcase
   end
 endmodule

--- a/testfiles/issue75/m1.v
+++ b/testfiles/issue75/m1.v
@@ -1,0 +1,120 @@
+
+module m1
+  (
+    input   wire Clk,
+    input   wire Rst,
+    input   wire [2:2] VMEAddr,
+    output  reg [31:0] VMERdData,
+    input   wire [31:0] VMEWrData,
+    input   wire VMERdMem,
+    input   wire VMEWrMem,
+    output  wire VMERdDone,
+    output  wire VMEWrDone,
+
+    // REG r1
+    output  wire [63:0] r1_o
+  );
+  wire rst_n;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  reg [63:0] r1_reg;
+  reg [1:0] r1_wreq;
+  reg [1:0] r1_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [2:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+  assign rst_n = ~Rst;
+  assign VMERdDone = rd_ack_int;
+  assign VMEWrDone = wr_ack_int;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(Clk))
+  begin
+    if (!rst_n)
+      begin
+        rd_ack_int <= 1'b0;
+        VMERdData <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 1'b0;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        VMERdData <= rd_dat_d0;
+        wr_req_d0 <= VMEWrMem;
+        wr_adr_d0 <= VMEAddr;
+        wr_dat_d0 <= VMEWrData;
+      end
+  end
+
+  // Register r1
+  assign r1_o = r1_reg;
+  always @(posedge(Clk))
+  begin
+    if (!rst_n)
+      begin
+        r1_reg <= 64'b0000000000000000000000000000000000000000000000000000000000000000;
+        r1_wack <= 2'b0;
+      end
+    else
+      begin
+        if (r1_wreq[0] == 1'b1)
+          r1_reg[31:0] <= wr_dat_d0;
+        else
+          r1_reg[31:0] <= 32'b00000000000000000000000000000000;
+        if (r1_wreq[1] == 1'b1)
+          r1_reg[63:32] <= wr_dat_d0;
+        else
+          r1_reg[63:32] <= 32'b00000000000000000000000000000000;
+        r1_wack <= r1_wreq;
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, r1_wack)
+  begin
+    r1_wreq = 2'b0;
+    case (wr_adr_d0[2:2])
+    1'b0:
+      begin
+        // Reg r1
+        r1_wreq[1] = wr_req_d0;
+        wr_ack_int = r1_wack[1];
+      end
+    1'b1:
+      begin
+        // Reg r1
+        r1_wreq[0] = wr_req_d0;
+        wr_ack_int = r1_wack[0];
+      end
+    default:
+      wr_ack_int = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always @(VMEAddr, VMERdMem)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    case (VMEAddr[2:2])
+    1'b0:
+      begin
+        // Reg r1
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = 32'b00000000000000000000000000000000;
+      end
+    1'b1:
+      begin
+        // Reg r1
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = 32'b00000000000000000000000000000000;
+      end
+    default:
+      rd_ack_d0 = VMERdMem;
+    endcase
+  end
+endmodule

--- a/testfiles/issue77/m1.sv
+++ b/testfiles/issue77/m1.sv
@@ -47,7 +47,7 @@ module m1
   assign awready = ~axi_awset;
   assign wready = ~axi_wset;
   assign bvalid = axi_wdone;
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -85,7 +85,7 @@ module m1
   // AR and R channels
   assign arready = ~axi_arset;
   assign rvalid = axi_rdone;
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -117,7 +117,7 @@ module m1
   assign rresp = 2'b00;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -137,7 +137,7 @@ module m1
 
   // Register r1
   assign r1_o = r1_reg;
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -153,21 +153,21 @@ module m1
   end
 
   // Process for write requests.
-  always @(wr_req_d0, r1_wack)
+  always_comb
   begin
-    r1_wreq <= 1'b0;
+    r1_wreq = 1'b0;
     // Reg r1
-    r1_wreq <= wr_req_d0;
-    wr_ack <= r1_wack;
+    r1_wreq = wr_req_d0;
+    wr_ack = r1_wack;
   end
 
   // Process for read requests.
-  always @(rd_req, r1_reg)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     // Reg r1
-    rd_ack_d0 <= rd_req;
-    rd_dat_d0 <= r1_reg;
+    rd_ack_d0 = rd_req;
+    rd_dat_d0 = r1_reg;
   end
 endmodule

--- a/testfiles/issue77/m1.v
+++ b/testfiles/issue77/m1.v
@@ -1,0 +1,173 @@
+
+module m1
+  (
+    input   wire aclk,
+    input   wire areset_n,
+    input   wire awvalid,
+    output  wire awready,
+    input   wire [2:0] awprot,
+    input   wire wvalid,
+    output  wire wready,
+    input   wire [31:0] wdata,
+    input   wire [3:0] wstrb,
+    output  wire bvalid,
+    input   wire bready,
+    output  wire [1:0] bresp,
+    input   wire arvalid,
+    output  wire arready,
+    input   wire [2:0] arprot,
+    output  wire rvalid,
+    input   wire rready,
+    output  reg [31:0] rdata,
+    output  wire [1:0] rresp,
+
+    // REG r1
+    output  wire [31:0] r1_o
+  );
+  reg wr_req;
+  reg wr_ack;
+  reg [31:0] wr_data;
+  reg axi_awset;
+  reg axi_wset;
+  reg axi_wdone;
+  reg rd_req;
+  reg rd_ack;
+  reg [31:0] rd_data;
+  reg axi_arset;
+  reg axi_rdone;
+  reg [31:0] r1_reg;
+  reg r1_wreq;
+  reg r1_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [31:0] wr_dat_d0;
+
+  // AW, W and B channels
+  assign awready = ~axi_awset;
+  assign wready = ~axi_wset;
+  assign bvalid = axi_wdone;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        wr_req <= 1'b0;
+        axi_awset <= 1'b0;
+        axi_wset <= 1'b0;
+        axi_wdone <= 1'b0;
+      end
+    else
+      begin
+        wr_req <= 1'b0;
+        if (awvalid == 1'b1 & axi_awset == 1'b0)
+          begin
+            axi_awset <= 1'b1;
+            wr_req <= axi_wset;
+          end
+        if (wvalid == 1'b1 & axi_wset == 1'b0)
+          begin
+            wr_data <= wdata;
+            axi_wset <= 1'b1;
+            wr_req <= axi_awset | awvalid;
+          end
+        if ((axi_wdone & bready) == 1'b1)
+          begin
+            axi_wset <= 1'b0;
+            axi_awset <= 1'b0;
+            axi_wdone <= 1'b0;
+          end
+        if (wr_ack == 1'b1)
+          axi_wdone <= 1'b1;
+      end
+  end
+  assign bresp = 2'b00;
+
+  // AR and R channels
+  assign arready = ~axi_arset;
+  assign rvalid = axi_rdone;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        rd_req <= 1'b0;
+        axi_arset <= 1'b0;
+        axi_rdone <= 1'b0;
+        rdata <= 32'b0;
+      end
+    else
+      begin
+        rd_req <= 1'b0;
+        if (arvalid == 1'b1 & axi_arset == 1'b0)
+          begin
+            axi_arset <= 1'b1;
+            rd_req <= 1'b1;
+          end
+        if ((axi_rdone & rready) == 1'b1)
+          begin
+            axi_arset <= 1'b0;
+            axi_rdone <= 1'b0;
+          end
+        if (rd_ack == 1'b1)
+          begin
+            axi_rdone <= 1'b1;
+            rdata <= rd_data;
+          end
+      end
+  end
+  assign rresp = 2'b00;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        rd_ack <= 1'b0;
+        rd_data <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack <= rd_ack_d0;
+        rd_data <= rd_dat_d0;
+        wr_req_d0 <= wr_req;
+        wr_dat_d0 <= wr_data;
+      end
+  end
+
+  // Register r1
+  assign r1_o = r1_reg;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        r1_reg <= 32'b00000000000000000000000000000000;
+        r1_wack <= 1'b0;
+      end
+    else
+      begin
+        if (r1_wreq == 1'b1)
+          r1_reg <= wr_dat_d0;
+        r1_wack <= r1_wreq;
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_req_d0, r1_wack)
+  begin
+    r1_wreq = 1'b0;
+    // Reg r1
+    r1_wreq = wr_req_d0;
+    wr_ack = r1_wack;
+  end
+
+  // Process for read requests.
+  always @(rd_req, r1_reg)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    // Reg r1
+    rd_ack_d0 = rd_req;
+    rd_dat_d0 = r1_reg;
+  end
+endmodule

--- a/testfiles/issue77/m2.sv
+++ b/testfiles/issue77/m2.sv
@@ -34,11 +34,11 @@ module m2
   reg [31:0] wr_dat_d0;
 
   // WB decode signals
-  always @(wb_sel_i)
+  always_comb
   ;
   assign wb_en = wb_cyc_i & wb_stb_i;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_rip <= 1'b0;
@@ -47,7 +47,7 @@ module m2
   end
   assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_wip <= 1'b0;
@@ -63,7 +63,7 @@ module m2
   assign wb_err_o = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -83,7 +83,7 @@ module m2
 
   // Register r1
   assign r1_o = r1_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -99,21 +99,21 @@ module m2
   end
 
   // Process for write requests.
-  always @(wr_req_d0, r1_wack)
+  always_comb
   begin
-    r1_wreq <= 1'b0;
+    r1_wreq = 1'b0;
     // Reg r1
-    r1_wreq <= wr_req_d0;
-    wr_ack_int <= r1_wack;
+    r1_wreq = wr_req_d0;
+    wr_ack_int = r1_wack;
   end
 
   // Process for read requests.
-  always @(rd_req_int, r1_reg)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     // Reg r1
-    rd_ack_d0 <= rd_req_int;
-    rd_dat_d0 <= r1_reg;
+    rd_ack_d0 = rd_req_int;
+    rd_dat_d0 = r1_reg;
   end
 endmodule

--- a/testfiles/issue77/m2.v
+++ b/testfiles/issue77/m2.v
@@ -1,0 +1,119 @@
+
+module m2
+  (
+    input   wire rst_n_i,
+    input   wire clk_i,
+    input   wire wb_cyc_i,
+    input   wire wb_stb_i,
+    input   wire [3:0] wb_sel_i,
+    input   wire wb_we_i,
+    input   wire [31:0] wb_dat_i,
+    output  wire wb_ack_o,
+    output  wire wb_err_o,
+    output  wire wb_rty_o,
+    output  wire wb_stall_o,
+    output  reg [31:0] wb_dat_o,
+
+    // REG r1
+    output  wire [31:0] r1_o
+  );
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg [31:0] r1_reg;
+  reg r1_wreq;
+  reg r1_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [31:0] wr_dat_d0;
+
+  // WB decode signals
+  always @(wb_sel_i)
+  ;
+  assign wb_en = wb_cyc_i & wb_stb_i;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb_we_i)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb_we_i)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb_we_i) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb_ack_o = ack_int;
+  assign wb_stall_o = ~ack_int & wb_en;
+  assign wb_rty_o = 1'b0;
+  assign wb_err_o = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        rd_ack_int <= 1'b0;
+        wb_dat_o <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb_dat_o <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_dat_d0 <= wb_dat_i;
+      end
+  end
+
+  // Register r1
+  assign r1_o = r1_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        r1_reg <= 32'b00000000000000000000000000000000;
+        r1_wack <= 1'b0;
+      end
+    else
+      begin
+        if (r1_wreq == 1'b1)
+          r1_reg <= wr_dat_d0;
+        r1_wack <= r1_wreq;
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_req_d0, r1_wack)
+  begin
+    r1_wreq = 1'b0;
+    // Reg r1
+    r1_wreq = wr_req_d0;
+    wr_ack_int = r1_wack;
+  end
+
+  // Process for read requests.
+  always @(rd_req_int, r1_reg)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    // Reg r1
+    rd_ack_d0 = rd_req_int;
+    rd_dat_d0 = r1_reg;
+  end
+endmodule

--- a/testfiles/issue77/m3.sv
+++ b/testfiles/issue77/m3.sv
@@ -28,7 +28,7 @@ module m2
   assign VMEWrDone = wr_ack_int;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(Clk))
+  always_ff @(posedge(Clk))
   begin
     if (!rst_n)
       begin
@@ -48,7 +48,7 @@ module m2
 
   // Register r1
   assign r1_o = r1_reg;
-  always @(posedge(Clk))
+  always_ff @(posedge(Clk))
   begin
     if (!rst_n)
       begin
@@ -64,21 +64,21 @@ module m2
   end
 
   // Process for write requests.
-  always @(wr_req_d0, r1_wack)
+  always_comb
   begin
-    r1_wreq <= 1'b0;
+    r1_wreq = 1'b0;
     // Reg r1
-    r1_wreq <= wr_req_d0;
-    wr_ack_int <= r1_wack;
+    r1_wreq = wr_req_d0;
+    wr_ack_int = r1_wack;
   end
 
   // Process for read requests.
-  always @(VMERdMem, r1_reg)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     // Reg r1
-    rd_ack_d0 <= VMERdMem;
-    rd_dat_d0 <= r1_reg;
+    rd_ack_d0 = VMERdMem;
+    rd_dat_d0 = r1_reg;
   end
 endmodule

--- a/testfiles/issue77/m3.v
+++ b/testfiles/issue77/m3.v
@@ -1,0 +1,84 @@
+
+module m2
+  (
+    input   wire Clk,
+    input   wire Rst,
+    output  reg [31:0] VMERdData,
+    input   wire [31:0] VMEWrData,
+    input   wire VMERdMem,
+    input   wire VMEWrMem,
+    output  wire VMERdDone,
+    output  wire VMEWrDone,
+
+    // REG r1
+    output  wire [31:0] r1_o
+  );
+  wire rst_n;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  reg [31:0] r1_reg;
+  reg r1_wreq;
+  reg r1_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [31:0] wr_dat_d0;
+  assign rst_n = ~Rst;
+  assign VMERdDone = rd_ack_int;
+  assign VMEWrDone = wr_ack_int;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(Clk))
+  begin
+    if (!rst_n)
+      begin
+        rd_ack_int <= 1'b0;
+        VMERdData <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        VMERdData <= rd_dat_d0;
+        wr_req_d0 <= VMEWrMem;
+        wr_dat_d0 <= VMEWrData;
+      end
+  end
+
+  // Register r1
+  assign r1_o = r1_reg;
+  always @(posedge(Clk))
+  begin
+    if (!rst_n)
+      begin
+        r1_reg <= 32'b00000000000000000000000000000000;
+        r1_wack <= 1'b0;
+      end
+    else
+      begin
+        if (r1_wreq == 1'b1)
+          r1_reg <= wr_dat_d0;
+        r1_wack <= r1_wreq;
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_req_d0, r1_wack)
+  begin
+    r1_wreq = 1'b0;
+    // Reg r1
+    r1_wreq = wr_req_d0;
+    wr_ack_int = r1_wack;
+  end
+
+  // Process for read requests.
+  always @(VMERdMem, r1_reg)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    // Reg r1
+    rd_ack_d0 = VMERdMem;
+    rd_dat_d0 = r1_reg;
+  end
+endmodule

--- a/testfiles/issue77/s1.sv
+++ b/testfiles/issue77/s1.sv
@@ -64,7 +64,7 @@ module s1
   assign awready = ~axi_awset;
   assign wready = ~axi_wset;
   assign bvalid = axi_wdone;
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -106,7 +106,7 @@ module s1
   // AR and R channels
   assign arready = ~axi_arset;
   assign rvalid = axi_rdone;
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -138,7 +138,7 @@ module s1
   assign rresp = 2'b00;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -160,7 +160,7 @@ module s1
 
   // Interface sub
   assign sub_tr = sub_wt | sub_rt;
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -181,39 +181,39 @@ module s1
   assign sub_stb_o = sub_tr;
   assign sub_wack = sub_ack_i & sub_wt;
   assign sub_rack = sub_ack_i & sub_rt;
-  always @(wr_sel_d0)
+  always_comb
   begin
-    sub_sel_o <= 4'b0;
+    sub_sel_o = 4'b0;
     if (~(wr_sel_d0[7:0] == 8'b0))
-      sub_sel_o[0] <= 1'b1;
+      sub_sel_o[0] = 1'b1;
     if (~(wr_sel_d0[15:8] == 8'b0))
-      sub_sel_o[1] <= 1'b1;
+      sub_sel_o[1] = 1'b1;
     if (~(wr_sel_d0[23:16] == 8'b0))
-      sub_sel_o[2] <= 1'b1;
+      sub_sel_o[2] = 1'b1;
     if (~(wr_sel_d0[31:24] == 8'b0))
-      sub_sel_o[3] <= 1'b1;
+      sub_sel_o[3] = 1'b1;
   end
   assign sub_we_o = sub_wt;
   assign sub_dat_o = wr_dat_d0;
 
   // Process for write requests.
-  always @(wr_req_d0, sub_wack)
+  always_comb
   begin
-    sub_we <= 1'b0;
+    sub_we = 1'b0;
     // Submap sub
-    sub_we <= wr_req_d0;
-    wr_ack <= sub_wack;
+    sub_we = wr_req_d0;
+    wr_ack = sub_wack;
   end
 
   // Process for read requests.
-  always @(rd_req, sub_dat_i, sub_rack)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
-    sub_re <= 1'b0;
+    rd_dat_d0 = {32{1'bx}};
+    sub_re = 1'b0;
     // Submap sub
-    sub_re <= rd_req;
-    rd_dat_d0 <= sub_dat_i;
-    rd_ack_d0 <= sub_rack;
+    sub_re = rd_req;
+    rd_dat_d0 = sub_dat_i;
+    rd_ack_d0 = sub_rack;
   end
 endmodule

--- a/testfiles/issue77/s1.v
+++ b/testfiles/issue77/s1.v
@@ -1,0 +1,219 @@
+
+module s1
+  (
+    input   wire aclk,
+    input   wire areset_n,
+    input   wire awvalid,
+    output  wire awready,
+    input   wire [2:0] awprot,
+    input   wire wvalid,
+    output  wire wready,
+    input   wire [31:0] wdata,
+    input   wire [3:0] wstrb,
+    output  wire bvalid,
+    input   wire bready,
+    output  wire [1:0] bresp,
+    input   wire arvalid,
+    output  wire arready,
+    input   wire [2:0] arprot,
+    output  wire rvalid,
+    input   wire rready,
+    output  reg [31:0] rdata,
+    output  wire [1:0] rresp,
+
+    // WB bus sub
+    output  wire sub_cyc_o,
+    output  wire sub_stb_o,
+    output  reg [3:0] sub_sel_o,
+    output  wire sub_we_o,
+    output  wire [31:0] sub_dat_o,
+    input   wire sub_ack_i,
+    input   wire sub_err_i,
+    input   wire sub_rty_i,
+    input   wire sub_stall_i,
+    input   wire [31:0] sub_dat_i
+  );
+  reg wr_req;
+  reg wr_ack;
+  reg [31:0] wr_data;
+  reg [31:0] wr_sel;
+  reg axi_awset;
+  reg axi_wset;
+  reg axi_wdone;
+  reg rd_req;
+  reg rd_ack;
+  reg [31:0] rd_data;
+  reg axi_arset;
+  reg axi_rdone;
+  reg sub_re;
+  reg sub_we;
+  reg sub_wt;
+  reg sub_rt;
+  wire sub_tr;
+  wire sub_wack;
+  wire sub_rack;
+  reg sub_wr;
+  reg sub_rr;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [31:0] wr_dat_d0;
+  reg [31:0] wr_sel_d0;
+
+  // AW, W and B channels
+  assign awready = ~axi_awset;
+  assign wready = ~axi_wset;
+  assign bvalid = axi_wdone;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        wr_req <= 1'b0;
+        axi_awset <= 1'b0;
+        axi_wset <= 1'b0;
+        axi_wdone <= 1'b0;
+      end
+    else
+      begin
+        wr_req <= 1'b0;
+        if (awvalid == 1'b1 & axi_awset == 1'b0)
+          begin
+            axi_awset <= 1'b1;
+            wr_req <= axi_wset;
+          end
+        if (wvalid == 1'b1 & axi_wset == 1'b0)
+          begin
+            wr_data <= wdata;
+            wr_sel[7:0] <= {8{wstrb[0]}};
+            wr_sel[15:8] <= {8{wstrb[1]}};
+            wr_sel[23:16] <= {8{wstrb[2]}};
+            wr_sel[31:24] <= {8{wstrb[3]}};
+            axi_wset <= 1'b1;
+            wr_req <= axi_awset | awvalid;
+          end
+        if ((axi_wdone & bready) == 1'b1)
+          begin
+            axi_wset <= 1'b0;
+            axi_awset <= 1'b0;
+            axi_wdone <= 1'b0;
+          end
+        if (wr_ack == 1'b1)
+          axi_wdone <= 1'b1;
+      end
+  end
+  assign bresp = 2'b00;
+
+  // AR and R channels
+  assign arready = ~axi_arset;
+  assign rvalid = axi_rdone;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        rd_req <= 1'b0;
+        axi_arset <= 1'b0;
+        axi_rdone <= 1'b0;
+        rdata <= 32'b0;
+      end
+    else
+      begin
+        rd_req <= 1'b0;
+        if (arvalid == 1'b1 & axi_arset == 1'b0)
+          begin
+            axi_arset <= 1'b1;
+            rd_req <= 1'b1;
+          end
+        if ((axi_rdone & rready) == 1'b1)
+          begin
+            axi_arset <= 1'b0;
+            axi_rdone <= 1'b0;
+          end
+        if (rd_ack == 1'b1)
+          begin
+            axi_rdone <= 1'b1;
+            rdata <= rd_data;
+          end
+      end
+  end
+  assign rresp = 2'b00;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        rd_ack <= 1'b0;
+        rd_data <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+        wr_sel_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack <= rd_ack_d0;
+        rd_data <= rd_dat_d0;
+        wr_req_d0 <= wr_req;
+        wr_dat_d0 <= wr_data;
+        wr_sel_d0 <= wr_sel;
+      end
+  end
+
+  // Interface sub
+  assign sub_tr = sub_wt | sub_rt;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        sub_rt <= 1'b0;
+        sub_wt <= 1'b0;
+        sub_wr <= 1'b0;
+        sub_rr <= 1'b0;
+      end
+    else
+      begin
+        sub_wr <= (sub_wr | sub_we) & ~sub_wack;
+        sub_wt <= (sub_wt | (sub_wr & ~sub_tr)) & ~sub_wack;
+        sub_rr <= (sub_rr | sub_re) & ~sub_rack;
+        sub_rt <= (sub_rt | (sub_rr & ~(sub_wr | sub_tr))) & ~sub_rack;
+      end
+  end
+  assign sub_cyc_o = sub_tr;
+  assign sub_stb_o = sub_tr;
+  assign sub_wack = sub_ack_i & sub_wt;
+  assign sub_rack = sub_ack_i & sub_rt;
+  always @(wr_sel_d0)
+  begin
+    sub_sel_o = 4'b0;
+    if (~(wr_sel_d0[7:0] == 8'b0))
+      sub_sel_o[0] = 1'b1;
+    if (~(wr_sel_d0[15:8] == 8'b0))
+      sub_sel_o[1] = 1'b1;
+    if (~(wr_sel_d0[23:16] == 8'b0))
+      sub_sel_o[2] = 1'b1;
+    if (~(wr_sel_d0[31:24] == 8'b0))
+      sub_sel_o[3] = 1'b1;
+  end
+  assign sub_we_o = sub_wt;
+  assign sub_dat_o = wr_dat_d0;
+
+  // Process for write requests.
+  always @(wr_req_d0, sub_wack)
+  begin
+    sub_we = 1'b0;
+    // Submap sub
+    sub_we = wr_req_d0;
+    wr_ack = sub_wack;
+  end
+
+  // Process for read requests.
+  always @(rd_req, sub_dat_i, sub_rack)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    sub_re = 1'b0;
+    // Submap sub
+    sub_re = rd_req;
+    rd_dat_d0 = sub_dat_i;
+    rd_ack_d0 = sub_rack;
+  end
+endmodule

--- a/testfiles/issue77/s2.sv
+++ b/testfiles/issue77/s2.sv
@@ -57,7 +57,7 @@ module s2
   assign awready = ~axi_awset;
   assign wready = ~axi_wset;
   assign bvalid = axi_wdone;
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -95,7 +95,7 @@ module s2
   // AR and R channels
   assign arready = ~axi_arset;
   assign rvalid = axi_rdone;
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -127,7 +127,7 @@ module s2
   assign rresp = 2'b00;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -147,7 +147,7 @@ module s2
 
   // Interface sub
   assign sub_VMEWrData_o = wr_dat_d0;
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -168,27 +168,27 @@ module s2
   assign sub_ws = sub_wr & ~(sub_rt | sub_wt);
 
   // Process for write requests.
-  always @(wr_req_d0, sub_ws, sub_VMEWrDone_i)
+  always_comb
   begin
-    sub_we <= 1'b0;
-    sub_VMEWrMem_o <= 1'b0;
+    sub_we = 1'b0;
+    sub_VMEWrMem_o = 1'b0;
     // Submap sub
-    sub_we <= wr_req_d0;
-    sub_VMEWrMem_o <= sub_ws;
-    wr_ack <= sub_VMEWrDone_i;
+    sub_we = wr_req_d0;
+    sub_VMEWrMem_o = sub_ws;
+    wr_ack = sub_VMEWrDone_i;
   end
 
   // Process for read requests.
-  always @(rd_req, sub_rs, sub_VMERdData_i, sub_VMERdDone_i)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
-    sub_VMERdMem_o <= 1'b0;
-    sub_re <= 1'b0;
+    rd_dat_d0 = {32{1'bx}};
+    sub_VMERdMem_o = 1'b0;
+    sub_re = 1'b0;
     // Submap sub
-    sub_re <= rd_req;
-    sub_VMERdMem_o <= sub_rs;
-    rd_dat_d0 <= sub_VMERdData_i;
-    rd_ack_d0 <= sub_VMERdDone_i;
+    sub_re = rd_req;
+    sub_VMERdMem_o = sub_rs;
+    rd_dat_d0 = sub_VMERdData_i;
+    rd_ack_d0 = sub_VMERdDone_i;
   end
 endmodule

--- a/testfiles/issue77/s2.v
+++ b/testfiles/issue77/s2.v
@@ -1,0 +1,194 @@
+
+module s2
+  (
+    input   wire aclk,
+    input   wire areset_n,
+    input   wire awvalid,
+    output  wire awready,
+    input   wire [2:0] awprot,
+    input   wire wvalid,
+    output  wire wready,
+    input   wire [31:0] wdata,
+    input   wire [3:0] wstrb,
+    output  wire bvalid,
+    input   wire bready,
+    output  wire [1:0] bresp,
+    input   wire arvalid,
+    output  wire arready,
+    input   wire [2:0] arprot,
+    output  wire rvalid,
+    input   wire rready,
+    output  reg [31:0] rdata,
+    output  wire [1:0] rresp,
+
+    // CERN-BE bus sub
+    input   wire [31:0] sub_VMERdData_i,
+    output  wire [31:0] sub_VMEWrData_o,
+    output  reg sub_VMERdMem_o,
+    output  reg sub_VMEWrMem_o,
+    input   wire sub_VMERdDone_i,
+    input   wire sub_VMEWrDone_i
+  );
+  reg wr_req;
+  reg wr_ack;
+  reg [31:0] wr_data;
+  reg axi_awset;
+  reg axi_wset;
+  reg axi_wdone;
+  reg rd_req;
+  reg rd_ack;
+  reg [31:0] rd_data;
+  reg axi_arset;
+  reg axi_rdone;
+  reg sub_wr;
+  reg sub_rr;
+  wire sub_ws;
+  wire sub_rs;
+  reg sub_re;
+  reg sub_we;
+  reg sub_wt;
+  reg sub_rt;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [31:0] wr_dat_d0;
+
+  // AW, W and B channels
+  assign awready = ~axi_awset;
+  assign wready = ~axi_wset;
+  assign bvalid = axi_wdone;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        wr_req <= 1'b0;
+        axi_awset <= 1'b0;
+        axi_wset <= 1'b0;
+        axi_wdone <= 1'b0;
+      end
+    else
+      begin
+        wr_req <= 1'b0;
+        if (awvalid == 1'b1 & axi_awset == 1'b0)
+          begin
+            axi_awset <= 1'b1;
+            wr_req <= axi_wset;
+          end
+        if (wvalid == 1'b1 & axi_wset == 1'b0)
+          begin
+            wr_data <= wdata;
+            axi_wset <= 1'b1;
+            wr_req <= axi_awset | awvalid;
+          end
+        if ((axi_wdone & bready) == 1'b1)
+          begin
+            axi_wset <= 1'b0;
+            axi_awset <= 1'b0;
+            axi_wdone <= 1'b0;
+          end
+        if (wr_ack == 1'b1)
+          axi_wdone <= 1'b1;
+      end
+  end
+  assign bresp = 2'b00;
+
+  // AR and R channels
+  assign arready = ~axi_arset;
+  assign rvalid = axi_rdone;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        rd_req <= 1'b0;
+        axi_arset <= 1'b0;
+        axi_rdone <= 1'b0;
+        rdata <= 32'b0;
+      end
+    else
+      begin
+        rd_req <= 1'b0;
+        if (arvalid == 1'b1 & axi_arset == 1'b0)
+          begin
+            axi_arset <= 1'b1;
+            rd_req <= 1'b1;
+          end
+        if ((axi_rdone & rready) == 1'b1)
+          begin
+            axi_arset <= 1'b0;
+            axi_rdone <= 1'b0;
+          end
+        if (rd_ack == 1'b1)
+          begin
+            axi_rdone <= 1'b1;
+            rdata <= rd_data;
+          end
+      end
+  end
+  assign rresp = 2'b00;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        rd_ack <= 1'b0;
+        rd_data <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack <= rd_ack_d0;
+        rd_data <= rd_dat_d0;
+        wr_req_d0 <= wr_req;
+        wr_dat_d0 <= wr_data;
+      end
+  end
+
+  // Interface sub
+  assign sub_VMEWrData_o = wr_dat_d0;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        sub_wr <= 1'b0;
+        sub_wt <= 1'b0;
+        sub_rr <= 1'b0;
+        sub_rt <= 1'b0;
+      end
+    else
+      begin
+        sub_wr <= (sub_wr | sub_we) & ~sub_VMEWrDone_i;
+        sub_wt <= (sub_wt | sub_ws) & ~sub_VMEWrDone_i;
+        sub_rr <= (sub_rr | sub_re) & ~sub_VMERdDone_i;
+        sub_rt <= (sub_rt | sub_rs) & ~sub_VMERdDone_i;
+      end
+  end
+  assign sub_rs = sub_rr & ~(sub_wr | (sub_rt | sub_wt));
+  assign sub_ws = sub_wr & ~(sub_rt | sub_wt);
+
+  // Process for write requests.
+  always @(wr_req_d0, sub_ws, sub_VMEWrDone_i)
+  begin
+    sub_we = 1'b0;
+    sub_VMEWrMem_o = 1'b0;
+    // Submap sub
+    sub_we = wr_req_d0;
+    sub_VMEWrMem_o = sub_ws;
+    wr_ack = sub_VMEWrDone_i;
+  end
+
+  // Process for read requests.
+  always @(rd_req, sub_rs, sub_VMERdData_i, sub_VMERdDone_i)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    sub_VMERdMem_o = 1'b0;
+    sub_re = 1'b0;
+    // Submap sub
+    sub_re = rd_req;
+    sub_VMERdMem_o = sub_rs;
+    rd_dat_d0 = sub_VMERdData_i;
+    rd_ack_d0 = sub_VMERdDone_i;
+  end
+endmodule

--- a/testfiles/issue77/s3.sv
+++ b/testfiles/issue77/s3.sv
@@ -67,7 +67,7 @@ module s3
   assign awready = ~axi_awset;
   assign wready = ~axi_wset;
   assign bvalid = axi_wdone;
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -109,7 +109,7 @@ module s3
   // AR and R channels
   assign arready = ~axi_arset;
   assign rvalid = axi_rdone;
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -141,7 +141,7 @@ module s3
   assign rresp = 2'b00;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -166,23 +166,23 @@ module s3
   assign sub_awprot_o = 3'b000;
   assign sub_wvalid_o = sub_w_val;
   assign sub_wdata_o = wr_dat_d0;
-  always @(wr_sel_d0)
+  always_comb
   begin
-    sub_wstrb_o <= 4'b0;
+    sub_wstrb_o = 4'b0;
     if (~(wr_sel_d0[7:0] == 8'b0))
-      sub_wstrb_o[0] <= 1'b1;
+      sub_wstrb_o[0] = 1'b1;
     if (~(wr_sel_d0[15:8] == 8'b0))
-      sub_wstrb_o[1] <= 1'b1;
+      sub_wstrb_o[1] = 1'b1;
     if (~(wr_sel_d0[23:16] == 8'b0))
-      sub_wstrb_o[2] <= 1'b1;
+      sub_wstrb_o[2] = 1'b1;
     if (~(wr_sel_d0[31:24] == 8'b0))
-      sub_wstrb_o[3] <= 1'b1;
+      sub_wstrb_o[3] = 1'b1;
   end
   assign sub_bready_o = 1'b1;
   assign sub_arvalid_o = sub_ar_val;
   assign sub_arprot_o = 3'b000;
   assign sub_rready_o = 1'b1;
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -199,23 +199,23 @@ module s3
   end
 
   // Process for write requests.
-  always @(wr_req_d0, sub_bvalid_i)
+  always_comb
   begin
-    sub_wr <= 1'b0;
+    sub_wr = 1'b0;
     // Submap sub
-    sub_wr <= wr_req_d0;
-    wr_ack <= sub_bvalid_i;
+    sub_wr = wr_req_d0;
+    wr_ack = sub_bvalid_i;
   end
 
   // Process for read requests.
-  always @(rd_req, sub_rdata_i, sub_rvalid_i)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
-    sub_rd <= 1'b0;
+    rd_dat_d0 = {32{1'bx}};
+    sub_rd = 1'b0;
     // Submap sub
-    sub_rd <= rd_req;
-    rd_dat_d0 <= sub_rdata_i;
-    rd_ack_d0 <= sub_rvalid_i;
+    sub_rd = rd_req;
+    rd_dat_d0 = sub_rdata_i;
+    rd_ack_d0 = sub_rvalid_i;
   end
 endmodule

--- a/testfiles/issue77/s3.v
+++ b/testfiles/issue77/s3.v
@@ -1,0 +1,221 @@
+
+module s3
+  (
+    input   wire aclk,
+    input   wire areset_n,
+    input   wire awvalid,
+    output  wire awready,
+    input   wire [2:0] awprot,
+    input   wire wvalid,
+    output  wire wready,
+    input   wire [31:0] wdata,
+    input   wire [3:0] wstrb,
+    output  wire bvalid,
+    input   wire bready,
+    output  wire [1:0] bresp,
+    input   wire arvalid,
+    output  wire arready,
+    input   wire [2:0] arprot,
+    output  wire rvalid,
+    input   wire rready,
+    output  reg [31:0] rdata,
+    output  wire [1:0] rresp,
+
+    // AXI-4 lite bus sub
+    output  wire sub_awvalid_o,
+    input   wire sub_awready_i,
+    output  wire [2:0] sub_awprot_o,
+    output  wire sub_wvalid_o,
+    input   wire sub_wready_i,
+    output  wire [31:0] sub_wdata_o,
+    output  reg [3:0] sub_wstrb_o,
+    input   wire sub_bvalid_i,
+    output  wire sub_bready_o,
+    input   wire [1:0] sub_bresp_i,
+    output  wire sub_arvalid_o,
+    input   wire sub_arready_i,
+    output  wire [2:0] sub_arprot_o,
+    input   wire sub_rvalid_i,
+    output  wire sub_rready_o,
+    input   wire [31:0] sub_rdata_i,
+    input   wire [1:0] sub_rresp_i
+  );
+  reg wr_req;
+  reg wr_ack;
+  reg [31:0] wr_data;
+  reg [31:0] wr_sel;
+  reg axi_awset;
+  reg axi_wset;
+  reg axi_wdone;
+  reg rd_req;
+  reg rd_ack;
+  reg [31:0] rd_data;
+  reg axi_arset;
+  reg axi_rdone;
+  reg sub_aw_val;
+  reg sub_w_val;
+  reg sub_ar_val;
+  reg sub_rd;
+  reg sub_wr;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [31:0] wr_dat_d0;
+  reg [31:0] wr_sel_d0;
+
+  // AW, W and B channels
+  assign awready = ~axi_awset;
+  assign wready = ~axi_wset;
+  assign bvalid = axi_wdone;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        wr_req <= 1'b0;
+        axi_awset <= 1'b0;
+        axi_wset <= 1'b0;
+        axi_wdone <= 1'b0;
+      end
+    else
+      begin
+        wr_req <= 1'b0;
+        if (awvalid == 1'b1 & axi_awset == 1'b0)
+          begin
+            axi_awset <= 1'b1;
+            wr_req <= axi_wset;
+          end
+        if (wvalid == 1'b1 & axi_wset == 1'b0)
+          begin
+            wr_data <= wdata;
+            wr_sel[7:0] <= {8{wstrb[0]}};
+            wr_sel[15:8] <= {8{wstrb[1]}};
+            wr_sel[23:16] <= {8{wstrb[2]}};
+            wr_sel[31:24] <= {8{wstrb[3]}};
+            axi_wset <= 1'b1;
+            wr_req <= axi_awset | awvalid;
+          end
+        if ((axi_wdone & bready) == 1'b1)
+          begin
+            axi_wset <= 1'b0;
+            axi_awset <= 1'b0;
+            axi_wdone <= 1'b0;
+          end
+        if (wr_ack == 1'b1)
+          axi_wdone <= 1'b1;
+      end
+  end
+  assign bresp = 2'b00;
+
+  // AR and R channels
+  assign arready = ~axi_arset;
+  assign rvalid = axi_rdone;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        rd_req <= 1'b0;
+        axi_arset <= 1'b0;
+        axi_rdone <= 1'b0;
+        rdata <= 32'b0;
+      end
+    else
+      begin
+        rd_req <= 1'b0;
+        if (arvalid == 1'b1 & axi_arset == 1'b0)
+          begin
+            axi_arset <= 1'b1;
+            rd_req <= 1'b1;
+          end
+        if ((axi_rdone & rready) == 1'b1)
+          begin
+            axi_arset <= 1'b0;
+            axi_rdone <= 1'b0;
+          end
+        if (rd_ack == 1'b1)
+          begin
+            axi_rdone <= 1'b1;
+            rdata <= rd_data;
+          end
+      end
+  end
+  assign rresp = 2'b00;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        rd_ack <= 1'b0;
+        rd_data <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+        wr_sel_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack <= rd_ack_d0;
+        rd_data <= rd_dat_d0;
+        wr_req_d0 <= wr_req;
+        wr_dat_d0 <= wr_data;
+        wr_sel_d0 <= wr_sel;
+      end
+  end
+
+  // Interface sub
+  assign sub_awvalid_o = sub_aw_val;
+  assign sub_awprot_o = 3'b000;
+  assign sub_wvalid_o = sub_w_val;
+  assign sub_wdata_o = wr_dat_d0;
+  always @(wr_sel_d0)
+  begin
+    sub_wstrb_o = 4'b0;
+    if (~(wr_sel_d0[7:0] == 8'b0))
+      sub_wstrb_o[0] = 1'b1;
+    if (~(wr_sel_d0[15:8] == 8'b0))
+      sub_wstrb_o[1] = 1'b1;
+    if (~(wr_sel_d0[23:16] == 8'b0))
+      sub_wstrb_o[2] = 1'b1;
+    if (~(wr_sel_d0[31:24] == 8'b0))
+      sub_wstrb_o[3] = 1'b1;
+  end
+  assign sub_bready_o = 1'b1;
+  assign sub_arvalid_o = sub_ar_val;
+  assign sub_arprot_o = 3'b000;
+  assign sub_rready_o = 1'b1;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        sub_aw_val <= 1'b0;
+        sub_w_val <= 1'b0;
+        sub_ar_val <= 1'b0;
+      end
+    else
+      begin
+        sub_aw_val <= sub_wr | (sub_aw_val & ~sub_awready_i);
+        sub_w_val <= sub_wr | (sub_w_val & ~sub_wready_i);
+        sub_ar_val <= sub_rd | (sub_ar_val & ~sub_arready_i);
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_req_d0, sub_bvalid_i)
+  begin
+    sub_wr = 1'b0;
+    // Submap sub
+    sub_wr = wr_req_d0;
+    wr_ack = sub_bvalid_i;
+  end
+
+  // Process for read requests.
+  always @(rd_req, sub_rdata_i, sub_rvalid_i)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    sub_rd = 1'b0;
+    // Submap sub
+    sub_rd = rd_req;
+    rd_dat_d0 = sub_rdata_i;
+    rd_ack_d0 = sub_rvalid_i;
+  end
+endmodule

--- a/testfiles/issue77/s4.sv
+++ b/testfiles/issue77/s4.sv
@@ -57,16 +57,16 @@ module s4
   reg [31:0] wr_sel_d0;
 
   // WB decode signals
-  always @(wb_sel_i)
+  always_comb
   begin
-    wr_sel[7:0] <= {8{wb_sel_i[0]}};
-    wr_sel[15:8] <= {8{wb_sel_i[1]}};
-    wr_sel[23:16] <= {8{wb_sel_i[2]}};
-    wr_sel[31:24] <= {8{wb_sel_i[3]}};
+    wr_sel[7:0] = {8{wb_sel_i[0]}};
+    wr_sel[15:8] = {8{wb_sel_i[1]}};
+    wr_sel[23:16] = {8{wb_sel_i[2]}};
+    wr_sel[31:24] = {8{wb_sel_i[3]}};
   end
   assign wb_en = wb_cyc_i & wb_stb_i;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_rip <= 1'b0;
@@ -75,7 +75,7 @@ module s4
   end
   assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_wip <= 1'b0;
@@ -91,7 +91,7 @@ module s4
   assign wb_err_o = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -115,7 +115,7 @@ module s4
 
   // Register r1
   assign r1_o = r1_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -132,7 +132,7 @@ module s4
 
   // Interface sub
   assign sub_tr = sub_wt | sub_rt;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -149,66 +149,66 @@ module s4
   assign sub_stb_o = sub_tr;
   assign sub_wack = sub_ack_i & sub_wt;
   assign sub_rack = sub_ack_i & sub_rt;
-  always @(wr_sel_d0)
+  always_comb
   begin
-    sub_sel_o <= 4'b0;
+    sub_sel_o = 4'b0;
     if (~(wr_sel_d0[7:0] == 8'b0))
-      sub_sel_o[0] <= 1'b1;
+      sub_sel_o[0] = 1'b1;
     if (~(wr_sel_d0[15:8] == 8'b0))
-      sub_sel_o[1] <= 1'b1;
+      sub_sel_o[1] = 1'b1;
     if (~(wr_sel_d0[23:16] == 8'b0))
-      sub_sel_o[2] <= 1'b1;
+      sub_sel_o[2] = 1'b1;
     if (~(wr_sel_d0[31:24] == 8'b0))
-      sub_sel_o[3] <= 1'b1;
+      sub_sel_o[3] = 1'b1;
   end
   assign sub_we_o = sub_wt;
   assign sub_dat_o = wr_dat_d0;
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0, r1_wack, sub_wack)
+  always_comb
   begin
-    r1_wreq <= 1'b0;
-    sub_we <= 1'b0;
+    r1_wreq = 1'b0;
+    sub_we = 1'b0;
     case (wr_adr_d0[2:2])
     1'b0:
       begin
         // Reg r1
-        r1_wreq <= wr_req_d0;
-        wr_ack_int <= r1_wack;
+        r1_wreq = wr_req_d0;
+        wr_ack_int = r1_wack;
       end
     1'b1:
       begin
         // Submap sub
-        sub_we <= wr_req_d0;
-        wr_ack_int <= sub_wack;
+        sub_we = wr_req_d0;
+        wr_ack_int = sub_wack;
       end
     default:
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     endcase
   end
 
   // Process for read requests.
-  always @(wb_adr_i, rd_req_int, r1_reg, sub_dat_i, sub_rack)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
-    sub_re <= 1'b0;
+    rd_dat_d0 = {32{1'bx}};
+    sub_re = 1'b0;
     case (wb_adr_i[2:2])
     1'b0:
       begin
         // Reg r1
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0 <= r1_reg;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = r1_reg;
       end
     1'b1:
       begin
         // Submap sub
-        sub_re <= rd_req_int;
-        rd_dat_d0 <= sub_dat_i;
-        rd_ack_d0 <= sub_rack;
+        sub_re = rd_req_int;
+        rd_dat_d0 = sub_dat_i;
+        rd_ack_d0 = sub_rack;
       end
     default:
-      rd_ack_d0 <= rd_req_int;
+      rd_ack_d0 = rd_req_int;
     endcase
   end
 endmodule

--- a/testfiles/issue77/s4.v
+++ b/testfiles/issue77/s4.v
@@ -1,0 +1,214 @@
+
+module s4
+  (
+    input   wire rst_n_i,
+    input   wire clk_i,
+    input   wire wb_cyc_i,
+    input   wire wb_stb_i,
+    input   wire [2:2] wb_adr_i,
+    input   wire [3:0] wb_sel_i,
+    input   wire wb_we_i,
+    input   wire [31:0] wb_dat_i,
+    output  wire wb_ack_o,
+    output  wire wb_err_o,
+    output  wire wb_rty_o,
+    output  wire wb_stall_o,
+    output  reg [31:0] wb_dat_o,
+
+    // REG r1
+    output  wire [31:0] r1_o,
+
+    // WB bus sub
+    output  wire sub_cyc_o,
+    output  wire sub_stb_o,
+    output  reg [3:0] sub_sel_o,
+    output  wire sub_we_o,
+    output  wire [31:0] sub_dat_o,
+    input   wire sub_ack_i,
+    input   wire sub_err_i,
+    input   wire sub_rty_i,
+    input   wire sub_stall_i,
+    input   wire [31:0] sub_dat_i
+  );
+  reg [31:0] wr_sel;
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg [31:0] r1_reg;
+  reg r1_wreq;
+  reg r1_wack;
+  reg sub_re;
+  reg sub_we;
+  reg sub_wt;
+  reg sub_rt;
+  wire sub_tr;
+  wire sub_wack;
+  wire sub_rack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [2:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+  reg [31:0] wr_sel_d0;
+
+  // WB decode signals
+  always @(wb_sel_i)
+  begin
+    wr_sel[7:0] = {8{wb_sel_i[0]}};
+    wr_sel[15:8] = {8{wb_sel_i[1]}};
+    wr_sel[23:16] = {8{wb_sel_i[2]}};
+    wr_sel[31:24] = {8{wb_sel_i[3]}};
+  end
+  assign wb_en = wb_cyc_i & wb_stb_i;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb_we_i)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb_we_i)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb_we_i) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb_ack_o = ack_int;
+  assign wb_stall_o = ~ack_int & wb_en;
+  assign wb_rty_o = 1'b0;
+  assign wb_err_o = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        rd_ack_int <= 1'b0;
+        wb_dat_o <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 1'b0;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+        wr_sel_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb_dat_o <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_adr_d0 <= wb_adr_i;
+        wr_dat_d0 <= wb_dat_i;
+        wr_sel_d0 <= wr_sel;
+      end
+  end
+
+  // Register r1
+  assign r1_o = r1_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        r1_reg <= 32'b00000000000000000000000000000000;
+        r1_wack <= 1'b0;
+      end
+    else
+      begin
+        if (r1_wreq == 1'b1)
+          r1_reg <= wr_dat_d0;
+        r1_wack <= r1_wreq;
+      end
+  end
+
+  // Interface sub
+  assign sub_tr = sub_wt | sub_rt;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        sub_rt <= 1'b0;
+        sub_wt <= 1'b0;
+      end
+    else
+      begin
+        sub_rt <= (sub_rt | sub_re) & ~sub_rack;
+        sub_wt <= (sub_wt | sub_we) & ~sub_wack;
+      end
+  end
+  assign sub_cyc_o = sub_tr;
+  assign sub_stb_o = sub_tr;
+  assign sub_wack = sub_ack_i & sub_wt;
+  assign sub_rack = sub_ack_i & sub_rt;
+  always @(wr_sel_d0)
+  begin
+    sub_sel_o = 4'b0;
+    if (~(wr_sel_d0[7:0] == 8'b0))
+      sub_sel_o[0] = 1'b1;
+    if (~(wr_sel_d0[15:8] == 8'b0))
+      sub_sel_o[1] = 1'b1;
+    if (~(wr_sel_d0[23:16] == 8'b0))
+      sub_sel_o[2] = 1'b1;
+    if (~(wr_sel_d0[31:24] == 8'b0))
+      sub_sel_o[3] = 1'b1;
+  end
+  assign sub_we_o = sub_wt;
+  assign sub_dat_o = wr_dat_d0;
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, r1_wack, sub_wack)
+  begin
+    r1_wreq = 1'b0;
+    sub_we = 1'b0;
+    case (wr_adr_d0[2:2])
+    1'b0:
+      begin
+        // Reg r1
+        r1_wreq = wr_req_d0;
+        wr_ack_int = r1_wack;
+      end
+    1'b1:
+      begin
+        // Submap sub
+        sub_we = wr_req_d0;
+        wr_ack_int = sub_wack;
+      end
+    default:
+      wr_ack_int = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always @(wb_adr_i, rd_req_int, r1_reg, sub_dat_i, sub_rack)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    sub_re = 1'b0;
+    case (wb_adr_i[2:2])
+    1'b0:
+      begin
+        // Reg r1
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = r1_reg;
+      end
+    1'b1:
+      begin
+        // Submap sub
+        sub_re = rd_req_int;
+        rd_dat_d0 = sub_dat_i;
+        rd_ack_d0 = sub_rack;
+      end
+    default:
+      rd_ack_d0 = rd_req_int;
+    endcase
+  end
+endmodule

--- a/testfiles/issue77/s5.sv
+++ b/testfiles/issue77/s5.sv
@@ -48,16 +48,16 @@ module s5
   reg [31:0] wr_sel_d0;
 
   // WB decode signals
-  always @(wb_sel_i)
+  always_comb
   begin
-    wr_sel[7:0] <= {8{wb_sel_i[0]}};
-    wr_sel[15:8] <= {8{wb_sel_i[1]}};
-    wr_sel[23:16] <= {8{wb_sel_i[2]}};
-    wr_sel[31:24] <= {8{wb_sel_i[3]}};
+    wr_sel[7:0] = {8{wb_sel_i[0]}};
+    wr_sel[15:8] = {8{wb_sel_i[1]}};
+    wr_sel[23:16] = {8{wb_sel_i[2]}};
+    wr_sel[31:24] = {8{wb_sel_i[3]}};
   end
   assign wb_en = wb_cyc_i & wb_stb_i;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_rip <= 1'b0;
@@ -66,7 +66,7 @@ module s5
   end
   assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_wip <= 1'b0;
@@ -82,7 +82,7 @@ module s5
   assign wb_err_o = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -106,7 +106,7 @@ module s5
 
   // Register r1
   assign r1_o = r1_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -123,7 +123,7 @@ module s5
 
   // Interface sub
   assign sub_tr = sub_wt | sub_rt;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -141,66 +141,66 @@ module s5
   assign sub_wack = sub.ack & sub_wt;
   assign sub_rack = sub.ack & sub_rt;
   assign sub.adr = {30'b0, 2'b0};
-  always @(wr_sel_d0)
+  always_comb
   begin
-    sub.sel <= 4'b0;
+    sub.sel = 4'b0;
     if (~(wr_sel_d0[7:0] == 8'b0))
-      sub.sel[0] <= 1'b1;
+      sub.sel[0] = 1'b1;
     if (~(wr_sel_d0[15:8] == 8'b0))
-      sub.sel[1] <= 1'b1;
+      sub.sel[1] = 1'b1;
     if (~(wr_sel_d0[23:16] == 8'b0))
-      sub.sel[2] <= 1'b1;
+      sub.sel[2] = 1'b1;
     if (~(wr_sel_d0[31:24] == 8'b0))
-      sub.sel[3] <= 1'b1;
+      sub.sel[3] = 1'b1;
   end
   assign sub.we = sub_wt;
   assign sub.dato = wr_dat_d0;
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0, r1_wack, sub_wack)
+  always_comb
   begin
-    r1_wreq <= 1'b0;
-    sub_we <= 1'b0;
+    r1_wreq = 1'b0;
+    sub_we = 1'b0;
     case (wr_adr_d0[2:2])
     1'b0:
       begin
         // Reg r1
-        r1_wreq <= wr_req_d0;
-        wr_ack_int <= r1_wack;
+        r1_wreq = wr_req_d0;
+        wr_ack_int = r1_wack;
       end
     1'b1:
       begin
         // Submap sub
-        sub_we <= wr_req_d0;
-        wr_ack_int <= sub_wack;
+        sub_we = wr_req_d0;
+        wr_ack_int = sub_wack;
       end
     default:
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     endcase
   end
 
   // Process for read requests.
-  always @(wb_adr_i, rd_req_int, r1_reg, sub.dati, sub_rack)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
-    sub_re <= 1'b0;
+    rd_dat_d0 = {32{1'bx}};
+    sub_re = 1'b0;
     case (wb_adr_i[2:2])
     1'b0:
       begin
         // Reg r1
-        rd_ack_d0 <= rd_req_int;
-        rd_dat_d0 <= r1_reg;
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = r1_reg;
       end
     1'b1:
       begin
         // Submap sub
-        sub_re <= rd_req_int;
-        rd_dat_d0 <= sub.dati;
-        rd_ack_d0 <= sub_rack;
+        sub_re = rd_req_int;
+        rd_dat_d0 = sub.dati;
+        rd_ack_d0 = sub_rack;
       end
     default:
-      rd_ack_d0 <= rd_req_int;
+      rd_ack_d0 = rd_req_int;
     endcase
   end
 endmodule

--- a/testfiles/issue77/s5.v
+++ b/testfiles/issue77/s5.v
@@ -1,0 +1,206 @@
+
+module s5
+  (
+    input   wire rst_n_i,
+    input   wire clk_i,
+    input   wire wb_cyc_i,
+    input   wire wb_stb_i,
+    input   wire [2:2] wb_adr_i,
+    input   wire [3:0] wb_sel_i,
+    input   wire wb_we_i,
+    input   wire [31:0] wb_dat_i,
+    output  wire wb_ack_o,
+    output  wire wb_err_o,
+    output  wire wb_rty_o,
+    output  wire wb_stall_o,
+    output  reg [31:0] wb_dat_o,
+
+    // REG r1
+    output  wire [31:0] r1_o,
+
+    // WB bus sub
+    t_wishbone.master sub
+  );
+  reg [31:0] wr_sel;
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg [31:0] r1_reg;
+  reg r1_wreq;
+  reg r1_wack;
+  reg sub_re;
+  reg sub_we;
+  reg sub_wt;
+  reg sub_rt;
+  wire sub_tr;
+  wire sub_wack;
+  wire sub_rack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [2:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+  reg [31:0] wr_sel_d0;
+
+  // WB decode signals
+  always @(wb_sel_i)
+  begin
+    wr_sel[7:0] = {8{wb_sel_i[0]}};
+    wr_sel[15:8] = {8{wb_sel_i[1]}};
+    wr_sel[23:16] = {8{wb_sel_i[2]}};
+    wr_sel[31:24] = {8{wb_sel_i[3]}};
+  end
+  assign wb_en = wb_cyc_i & wb_stb_i;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb_we_i)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb_we_i)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb_we_i) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb_ack_o = ack_int;
+  assign wb_stall_o = ~ack_int & wb_en;
+  assign wb_rty_o = 1'b0;
+  assign wb_err_o = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        rd_ack_int <= 1'b0;
+        wb_dat_o <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 1'b0;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+        wr_sel_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb_dat_o <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_adr_d0 <= wb_adr_i;
+        wr_dat_d0 <= wb_dat_i;
+        wr_sel_d0 <= wr_sel;
+      end
+  end
+
+  // Register r1
+  assign r1_o = r1_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        r1_reg <= 32'b00000000000000000000000000000000;
+        r1_wack <= 1'b0;
+      end
+    else
+      begin
+        if (r1_wreq == 1'b1)
+          r1_reg <= wr_dat_d0;
+        r1_wack <= r1_wreq;
+      end
+  end
+
+  // Interface sub
+  assign sub_tr = sub_wt | sub_rt;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        sub_rt <= 1'b0;
+        sub_wt <= 1'b0;
+      end
+    else
+      begin
+        sub_rt <= (sub_rt | sub_re) & ~sub_rack;
+        sub_wt <= (sub_wt | sub_we) & ~sub_wack;
+      end
+  end
+  assign sub.cyc = sub_tr;
+  assign sub.stb = sub_tr;
+  assign sub_wack = sub.ack & sub_wt;
+  assign sub_rack = sub.ack & sub_rt;
+  assign sub.adr = {30'b0, 2'b0};
+  always @(wr_sel_d0)
+  begin
+    sub.sel = 4'b0;
+    if (~(wr_sel_d0[7:0] == 8'b0))
+      sub.sel[0] = 1'b1;
+    if (~(wr_sel_d0[15:8] == 8'b0))
+      sub.sel[1] = 1'b1;
+    if (~(wr_sel_d0[23:16] == 8'b0))
+      sub.sel[2] = 1'b1;
+    if (~(wr_sel_d0[31:24] == 8'b0))
+      sub.sel[3] = 1'b1;
+  end
+  assign sub.we = sub_wt;
+  assign sub.dato = wr_dat_d0;
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, r1_wack, sub_wack)
+  begin
+    r1_wreq = 1'b0;
+    sub_we = 1'b0;
+    case (wr_adr_d0[2:2])
+    1'b0:
+      begin
+        // Reg r1
+        r1_wreq = wr_req_d0;
+        wr_ack_int = r1_wack;
+      end
+    1'b1:
+      begin
+        // Submap sub
+        sub_we = wr_req_d0;
+        wr_ack_int = sub_wack;
+      end
+    default:
+      wr_ack_int = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always @(wb_adr_i, rd_req_int, r1_reg, sub.dati, sub_rack)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    sub_re = 1'b0;
+    case (wb_adr_i[2:2])
+    1'b0:
+      begin
+        // Reg r1
+        rd_ack_d0 = rd_req_int;
+        rd_dat_d0 = r1_reg;
+      end
+    1'b1:
+      begin
+        // Submap sub
+        sub_re = rd_req_int;
+        rd_dat_d0 = sub.dati;
+        rd_ack_d0 = sub_rack;
+      end
+    default:
+      rd_ack_d0 = rd_req_int;
+    endcase
+  end
+endmodule

--- a/testfiles/issue77/s6.sv
+++ b/testfiles/issue77/s6.sv
@@ -23,11 +23,11 @@ module s6
   reg [31:0] wr_dat_d0;
 
   // WB decode signals
-  always @(wb.sel)
+  always_comb
   ;
   assign wb_en = wb.cyc & wb.stb;
 
-  always @(posedge(wb.clk))
+  always_ff @(posedge(wb.clk))
   begin
     if (!wb.rst_n)
       wb_rip <= 1'b0;
@@ -36,7 +36,7 @@ module s6
   end
   assign rd_req_int = (wb_en & ~wb.we) & ~wb_rip;
 
-  always @(posedge(wb.clk))
+  always_ff @(posedge(wb.clk))
   begin
     if (!wb.rst_n)
       wb_wip <= 1'b0;
@@ -52,7 +52,7 @@ module s6
   assign wb.err = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(wb.clk))
+  always_ff @(posedge(wb.clk))
   begin
     if (!wb.rst_n)
       begin
@@ -72,7 +72,7 @@ module s6
 
   // Register r1
   assign r1_o = r1_reg;
-  always @(posedge(wb.clk))
+  always_ff @(posedge(wb.clk))
   begin
     if (!wb.rst_n)
       begin
@@ -88,21 +88,21 @@ module s6
   end
 
   // Process for write requests.
-  always @(wr_req_d0, r1_wack)
+  always_comb
   begin
-    r1_wreq <= 1'b0;
+    r1_wreq = 1'b0;
     // Reg r1
-    r1_wreq <= wr_req_d0;
-    wr_ack_int <= r1_wack;
+    r1_wreq = wr_req_d0;
+    wr_ack_int = r1_wack;
   end
 
   // Process for read requests.
-  always @(rd_req_int, r1_reg)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     // Reg r1
-    rd_ack_d0 <= rd_req_int;
-    rd_dat_d0 <= r1_reg;
+    rd_ack_d0 = rd_req_int;
+    rd_dat_d0 = r1_reg;
   end
 endmodule

--- a/testfiles/issue77/s6.v
+++ b/testfiles/issue77/s6.v
@@ -1,0 +1,108 @@
+
+module s6
+  (
+    t_wishbone.slave wb,
+
+    // REG r1
+    output  wire [31:0] r1_o
+  );
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg [31:0] r1_reg;
+  reg r1_wreq;
+  reg r1_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [31:0] wr_dat_d0;
+
+  // WB decode signals
+  always @(wb.sel)
+  ;
+  assign wb_en = wb.cyc & wb.stb;
+
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb.we)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb.we) & ~wb_rip;
+
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb.we)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb.we) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb.ack = ack_int;
+  assign wb.stall = ~ack_int & wb_en;
+  assign wb.rty = 1'b0;
+  assign wb.err = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      begin
+        rd_ack_int <= 1'b0;
+        wb.dati <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb.dati <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_dat_d0 <= wb.dato;
+      end
+  end
+
+  // Register r1
+  assign r1_o = r1_reg;
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      begin
+        r1_reg <= 32'b00000000000000000000000000000000;
+        r1_wack <= 1'b0;
+      end
+    else
+      begin
+        if (r1_wreq == 1'b1)
+          r1_reg <= wr_dat_d0;
+        r1_wack <= r1_wreq;
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_req_d0, r1_wack)
+  begin
+    r1_wreq = 1'b0;
+    // Reg r1
+    r1_wreq = wr_req_d0;
+    wr_ack_int = r1_wack;
+  end
+
+  // Process for read requests.
+  always @(rd_req_int, r1_reg)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    // Reg r1
+    rd_ack_d0 = rd_req_int;
+    rd_dat_d0 = r1_reg;
+  end
+endmodule

--- a/testfiles/issue79/CSR.sv
+++ b/testfiles/issue79/CSR.sv
@@ -85,16 +85,16 @@ module csr
   reg [3:0] adc_meas_sel_int;
 
   // WB decode signals
-  always @(wb_sel_i)
+  always_comb
   begin
-    wr_sel[7:0] <= {8{wb_sel_i[0]}};
-    wr_sel[15:8] <= {8{wb_sel_i[1]}};
-    wr_sel[23:16] <= {8{wb_sel_i[2]}};
-    wr_sel[31:24] <= {8{wb_sel_i[3]}};
+    wr_sel[7:0] = {8{wb_sel_i[0]}};
+    wr_sel[15:8] = {8{wb_sel_i[1]}};
+    wr_sel[23:16] = {8{wb_sel_i[2]}};
+    wr_sel[31:24] = {8{wb_sel_i[3]}};
   end
   assign wb_en = wb_cyc_i & wb_stb_i;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_rip <= 1'b0;
@@ -103,7 +103,7 @@ module csr
   end
   assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
 
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       wb_wip <= 1'b0;
@@ -119,7 +119,7 @@ module csr
   assign wb_err_o = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -147,7 +147,7 @@ module csr
 
   // Register cal_ctrl
   assign cal_ctrl_cal_sel_o = cal_ctrl_cal_sel_reg;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -164,7 +164,7 @@ module csr
 
   // Interface i2c_master
   assign i2c_master_tr = i2c_master_wt | i2c_master_rt;
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       begin
@@ -182,17 +182,17 @@ module csr
   assign i2c_master_wack = i2c_master_ack_i & i2c_master_wt;
   assign i2c_master_rack = i2c_master_ack_i & i2c_master_rt;
   assign i2c_master_adr_o = wb_adr_i[4:2];
-  always @(wr_sel_d0)
+  always_comb
   begin
-    i2c_master_sel_o <= 4'b0;
+    i2c_master_sel_o = 4'b0;
     if (~(wr_sel_d0[7:0] == 8'b0))
-      i2c_master_sel_o[0] <= 1'b1;
+      i2c_master_sel_o[0] = 1'b1;
     if (~(wr_sel_d0[15:8] == 8'b0))
-      i2c_master_sel_o[1] <= 1'b1;
+      i2c_master_sel_o[1] = 1'b1;
     if (~(wr_sel_d0[23:16] == 8'b0))
-      i2c_master_sel_o[2] <= 1'b1;
+      i2c_master_sel_o[2] = 1'b1;
     if (~(wr_sel_d0[31:24] == 8'b0))
-      i2c_master_sel_o[3] <= 1'b1;
+      i2c_master_sel_o[3] = 1'b1;
   end
   assign i2c_master_we_o = i2c_master_wt;
   assign i2c_master_dat_o = wr_dat_d0;
@@ -222,19 +222,19 @@ module csr
       .wr_b_i(adc_offs_data_we_i)
     );
   
-  always @(wr_sel_d0)
+  always_comb
   begin
-    adc_offs_sel_int <= 4'b0;
+    adc_offs_sel_int = 4'b0;
     if (~(wr_sel_d0[7:0] == 8'b0))
-      adc_offs_sel_int[0] <= 1'b1;
+      adc_offs_sel_int[0] = 1'b1;
     if (~(wr_sel_d0[15:8] == 8'b0))
-      adc_offs_sel_int[1] <= 1'b1;
+      adc_offs_sel_int[1] = 1'b1;
     if (~(wr_sel_d0[23:16] == 8'b0))
-      adc_offs_sel_int[2] <= 1'b1;
+      adc_offs_sel_int[2] = 1'b1;
     if (~(wr_sel_d0[31:24] == 8'b0))
-      adc_offs_sel_int[3] <= 1'b1;
+      adc_offs_sel_int[3] = 1'b1;
   end
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       adc_offs_data_rack <= 1'b0;
@@ -267,19 +267,19 @@ module csr
       .wr_b_i(adc_meas_data_we_i)
     );
   
-  always @(wr_sel_d0)
+  always_comb
   begin
-    adc_meas_sel_int <= 4'b0;
+    adc_meas_sel_int = 4'b0;
     if (~(wr_sel_d0[7:0] == 8'b0))
-      adc_meas_sel_int[0] <= 1'b1;
+      adc_meas_sel_int[0] = 1'b1;
     if (~(wr_sel_d0[15:8] == 8'b0))
-      adc_meas_sel_int[1] <= 1'b1;
+      adc_meas_sel_int[1] = 1'b1;
     if (~(wr_sel_d0[23:16] == 8'b0))
-      adc_meas_sel_int[2] <= 1'b1;
+      adc_meas_sel_int[2] = 1'b1;
     if (~(wr_sel_d0[31:24] == 8'b0))
-      adc_meas_sel_int[3] <= 1'b1;
+      adc_meas_sel_int[3] = 1'b1;
   end
-  always @(posedge(clk_i))
+  always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
       adc_meas_data_rack <= 1'b0;
@@ -288,10 +288,10 @@ module csr
   end
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0, cal_ctrl_wack, i2c_master_wack)
+  always_comb
   begin
-    cal_ctrl_wreq <= 1'b0;
-    i2c_master_we <= 1'b0;
+    cal_ctrl_wreq = 1'b0;
+    i2c_master_we = 1'b0;
     case (wr_adr_d0[15:14])
     2'b00:
       case (wr_adr_d0[13:5])
@@ -301,58 +301,58 @@ module csr
           case (wr_adr_d0[2:2])
           1'b0:
             // Reg ident
-            wr_ack_int <= wr_req_d0;
+            wr_ack_int = wr_req_d0;
           1'b1:
             // Reg ident
-            wr_ack_int <= wr_req_d0;
+            wr_ack_int = wr_req_d0;
           default:
-            wr_ack_int <= wr_req_d0;
+            wr_ack_int = wr_req_d0;
           endcase
         2'b01:
           case (wr_adr_d0[2:2])
           1'b0:
             // Reg version
-            wr_ack_int <= wr_req_d0;
+            wr_ack_int = wr_req_d0;
           1'b1:
             begin
               // Reg cal_ctrl
-              cal_ctrl_wreq <= wr_req_d0;
-              wr_ack_int <= cal_ctrl_wack;
+              cal_ctrl_wreq = wr_req_d0;
+              wr_ack_int = cal_ctrl_wack;
             end
           default:
-            wr_ack_int <= wr_req_d0;
+            wr_ack_int = wr_req_d0;
           endcase
         default:
-          wr_ack_int <= wr_req_d0;
+          wr_ack_int = wr_req_d0;
         endcase
       9'b000000001:
         begin
           // Submap i2c_master
-          i2c_master_we <= wr_req_d0;
-          wr_ack_int <= i2c_master_wack;
+          i2c_master_we = wr_req_d0;
+          wr_ack_int = i2c_master_wack;
         end
       default:
-        wr_ack_int <= wr_req_d0;
+        wr_ack_int = wr_req_d0;
       endcase
     2'b01:
       // Memory adc_offs
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     2'b10:
       // Memory adc_meas
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     default:
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     endcase
   end
 
   // Process for read requests.
-  always @(wb_adr_i, rd_req_int, ident_i, version_i, cal_ctrl_cal_sel_reg, i2c_master_dat_i, i2c_master_rack, adc_offs_data_int_dato, adc_offs_data_rack, adc_meas_data_int_dato, adc_meas_data_rack)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
-    i2c_master_re <= 1'b0;
-    adc_offs_data_rreq <= 1'b0;
-    adc_meas_data_rreq <= 1'b0;
+    rd_dat_d0 = {32{1'bx}};
+    i2c_master_re = 1'b0;
+    adc_offs_data_rreq = 1'b0;
+    adc_meas_data_rreq = 1'b0;
     case (wb_adr_i[15:14])
     2'b00:
       case (wb_adr_i[13:5])
@@ -363,65 +363,65 @@ module csr
           1'b0:
             begin
               // Reg ident
-              rd_ack_d0 <= rd_req_int;
-              rd_dat_d0 <= ident_i[63:32];
+              rd_ack_d0 = rd_req_int;
+              rd_dat_d0 = ident_i[63:32];
             end
           1'b1:
             begin
               // Reg ident
-              rd_ack_d0 <= rd_req_int;
-              rd_dat_d0 <= ident_i[31:0];
+              rd_ack_d0 = rd_req_int;
+              rd_dat_d0 = ident_i[31:0];
             end
           default:
-            rd_ack_d0 <= rd_req_int;
+            rd_ack_d0 = rd_req_int;
           endcase
         2'b01:
           case (wb_adr_i[2:2])
           1'b0:
             begin
               // Reg version
-              rd_ack_d0 <= rd_req_int;
-              rd_dat_d0 <= version_i;
+              rd_ack_d0 = rd_req_int;
+              rd_dat_d0 = version_i;
             end
           1'b1:
             begin
               // Reg cal_ctrl
-              rd_ack_d0 <= rd_req_int;
-              rd_dat_d0[1:0] <= cal_ctrl_cal_sel_reg;
-              rd_dat_d0[31:2] <= 30'b0;
+              rd_ack_d0 = rd_req_int;
+              rd_dat_d0[1:0] = cal_ctrl_cal_sel_reg;
+              rd_dat_d0[31:2] = 30'b0;
             end
           default:
-            rd_ack_d0 <= rd_req_int;
+            rd_ack_d0 = rd_req_int;
           endcase
         default:
-          rd_ack_d0 <= rd_req_int;
+          rd_ack_d0 = rd_req_int;
         endcase
       9'b000000001:
         begin
           // Submap i2c_master
-          i2c_master_re <= rd_req_int;
-          rd_dat_d0 <= i2c_master_dat_i;
-          rd_ack_d0 <= i2c_master_rack;
+          i2c_master_re = rd_req_int;
+          rd_dat_d0 = i2c_master_dat_i;
+          rd_ack_d0 = i2c_master_rack;
         end
       default:
-        rd_ack_d0 <= rd_req_int;
+        rd_ack_d0 = rd_req_int;
       endcase
     2'b01:
       begin
         // Memory adc_offs
-        rd_dat_d0 <= adc_offs_data_int_dato;
-        adc_offs_data_rreq <= rd_req_int;
-        rd_ack_d0 <= adc_offs_data_rack;
+        rd_dat_d0 = adc_offs_data_int_dato;
+        adc_offs_data_rreq = rd_req_int;
+        rd_ack_d0 = adc_offs_data_rack;
       end
     2'b10:
       begin
         // Memory adc_meas
-        rd_dat_d0 <= adc_meas_data_int_dato;
-        adc_meas_data_rreq <= rd_req_int;
-        rd_ack_d0 <= adc_meas_data_rack;
+        rd_dat_d0 = adc_meas_data_int_dato;
+        adc_meas_data_rreq = rd_req_int;
+        rd_ack_d0 = adc_meas_data_rack;
       end
     default:
-      rd_ack_d0 <= rd_req_int;
+      rd_ack_d0 = rd_req_int;
     endcase
   end
 endmodule

--- a/testfiles/issue79/CSR.v
+++ b/testfiles/issue79/CSR.v
@@ -1,0 +1,427 @@
+
+module csr
+  (
+    input   wire rst_n_i,
+    input   wire clk_i,
+    input   wire wb_cyc_i,
+    input   wire wb_stb_i,
+    input   wire [15:2] wb_adr_i,
+    input   wire [3:0] wb_sel_i,
+    input   wire wb_we_i,
+    input   wire [31:0] wb_dat_i,
+    output  wire wb_ack_o,
+    output  wire wb_err_o,
+    output  wire wb_rty_o,
+    output  wire wb_stall_o,
+    output  reg [31:0] wb_dat_o,
+
+    // Board identifier
+    input   wire [63:0] ident_i,
+
+    // Firmware version
+    input   wire [31:0] version_i,
+
+    // Calibrator control bits
+    // Calibrator/ADC select: 00=C1/A1, 01=C2/A2, 10=C1+2/A1, 11=C1+2/A2
+    output  wire [1:0] cal_ctrl_cal_sel_o,
+
+    // OpenCores I2C Master
+    output  wire i2c_master_cyc_o,
+    output  wire i2c_master_stb_o,
+    output  wire [4:2] i2c_master_adr_o,
+    output  reg [3:0] i2c_master_sel_o,
+    output  wire i2c_master_we_o,
+    output  wire [31:0] i2c_master_dat_o,
+    input   wire i2c_master_ack_i,
+    input   wire i2c_master_err_i,
+    input   wire i2c_master_rty_i,
+    input   wire i2c_master_stall_i,
+    input   wire [31:0] i2c_master_dat_i,
+
+    // RAM port for adc_offs
+    input   wire [11:0] adc_offs_adr_i,
+    input   wire adc_offs_data_we_i,
+    input   wire [31:0] adc_offs_data_dat_i,
+
+    // RAM port for adc_meas
+    input   wire [11:0] adc_meas_adr_i,
+    input   wire adc_meas_data_we_i,
+    input   wire [31:0] adc_meas_data_dat_i
+  );
+  reg [31:0] wr_sel;
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg [1:0] cal_ctrl_cal_sel_reg;
+  reg cal_ctrl_wreq;
+  reg cal_ctrl_wack;
+  reg i2c_master_re;
+  reg i2c_master_we;
+  reg i2c_master_wt;
+  reg i2c_master_rt;
+  wire i2c_master_tr;
+  wire i2c_master_wack;
+  wire i2c_master_rack;
+  wire [31:0] adc_offs_data_int_dato;
+  wire [31:0] adc_offs_data_ext_dat;
+  reg adc_offs_data_rreq;
+  reg adc_offs_data_rack;
+  wire [31:0] adc_meas_data_int_dato;
+  wire [31:0] adc_meas_data_ext_dat;
+  reg adc_meas_data_rreq;
+  reg adc_meas_data_rack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [15:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+  reg [31:0] wr_sel_d0;
+  reg [3:0] adc_offs_sel_int;
+  reg [3:0] adc_meas_sel_int;
+
+  // WB decode signals
+  always @(wb_sel_i)
+  begin
+    wr_sel[7:0] = {8{wb_sel_i[0]}};
+    wr_sel[15:8] = {8{wb_sel_i[1]}};
+    wr_sel[23:16] = {8{wb_sel_i[2]}};
+    wr_sel[31:24] = {8{wb_sel_i[3]}};
+  end
+  assign wb_en = wb_cyc_i & wb_stb_i;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb_we_i)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb_we_i)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb_we_i) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb_ack_o = ack_int;
+  assign wb_stall_o = ~ack_int & wb_en;
+  assign wb_rty_o = 1'b0;
+  assign wb_err_o = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        rd_ack_int <= 1'b0;
+        wb_dat_o <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 14'b00000000000000;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+        wr_sel_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb_dat_o <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_adr_d0 <= wb_adr_i;
+        wr_dat_d0 <= wb_dat_i;
+        wr_sel_d0 <= wr_sel;
+      end
+  end
+
+  // Register ident
+
+  // Register version
+
+  // Register cal_ctrl
+  assign cal_ctrl_cal_sel_o = cal_ctrl_cal_sel_reg;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        cal_ctrl_cal_sel_reg <= 2'b00;
+        cal_ctrl_wack <= 1'b0;
+      end
+    else
+      begin
+        if (cal_ctrl_wreq == 1'b1)
+          cal_ctrl_cal_sel_reg <= wr_dat_d0[1:0];
+        cal_ctrl_wack <= cal_ctrl_wreq;
+      end
+  end
+
+  // Interface i2c_master
+  assign i2c_master_tr = i2c_master_wt | i2c_master_rt;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        i2c_master_rt <= 1'b0;
+        i2c_master_wt <= 1'b0;
+      end
+    else
+      begin
+        i2c_master_rt <= (i2c_master_rt | i2c_master_re) & ~i2c_master_rack;
+        i2c_master_wt <= (i2c_master_wt | i2c_master_we) & ~i2c_master_wack;
+      end
+  end
+  assign i2c_master_cyc_o = i2c_master_tr;
+  assign i2c_master_stb_o = i2c_master_tr;
+  assign i2c_master_wack = i2c_master_ack_i & i2c_master_wt;
+  assign i2c_master_rack = i2c_master_ack_i & i2c_master_rt;
+  assign i2c_master_adr_o = wb_adr_i[4:2];
+  always @(wr_sel_d0)
+  begin
+    i2c_master_sel_o = 4'b0;
+    if (~(wr_sel_d0[7:0] == 8'b0))
+      i2c_master_sel_o[0] = 1'b1;
+    if (~(wr_sel_d0[15:8] == 8'b0))
+      i2c_master_sel_o[1] = 1'b1;
+    if (~(wr_sel_d0[23:16] == 8'b0))
+      i2c_master_sel_o[2] = 1'b1;
+    if (~(wr_sel_d0[31:24] == 8'b0))
+      i2c_master_sel_o[3] = 1'b1;
+  end
+  assign i2c_master_we_o = i2c_master_wt;
+  assign i2c_master_dat_o = wr_dat_d0;
+
+  // Memory adc_offs
+  cheby_dpssram #(
+      .g_data_width(32),
+      .g_size(4096),
+      .g_addr_width(12),
+      .g_dual_clock(1'b0),
+      .g_use_bwsel(1'b1)
+    )
+  adc_offs_data_raminst (
+      .clk_a_i(clk_i),
+      .clk_b_i(clk_i),
+      .addr_a_i(wb_adr_i[13:2]),
+      .bwsel_a_i(adc_offs_sel_int),
+      .data_a_i({32{1'bx}}),
+      .data_a_o(adc_offs_data_int_dato),
+      .rd_a_i(adc_offs_data_rreq),
+      .wr_a_i(1'b0),
+      .addr_b_i(adc_offs_adr_i),
+      .bwsel_b_i({4{1'b1}}),
+      .data_b_i(adc_offs_data_dat_i),
+      .data_b_o(adc_offs_data_ext_dat),
+      .rd_b_i(1'b0),
+      .wr_b_i(adc_offs_data_we_i)
+    );
+  
+  always @(wr_sel_d0)
+  begin
+    adc_offs_sel_int = 4'b0;
+    if (~(wr_sel_d0[7:0] == 8'b0))
+      adc_offs_sel_int[0] = 1'b1;
+    if (~(wr_sel_d0[15:8] == 8'b0))
+      adc_offs_sel_int[1] = 1'b1;
+    if (~(wr_sel_d0[23:16] == 8'b0))
+      adc_offs_sel_int[2] = 1'b1;
+    if (~(wr_sel_d0[31:24] == 8'b0))
+      adc_offs_sel_int[3] = 1'b1;
+  end
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      adc_offs_data_rack <= 1'b0;
+    else
+      adc_offs_data_rack <= adc_offs_data_rreq;
+  end
+
+  // Memory adc_meas
+  cheby_dpssram #(
+      .g_data_width(32),
+      .g_size(4096),
+      .g_addr_width(12),
+      .g_dual_clock(1'b0),
+      .g_use_bwsel(1'b1)
+    )
+  adc_meas_data_raminst (
+      .clk_a_i(clk_i),
+      .clk_b_i(clk_i),
+      .addr_a_i(wb_adr_i[13:2]),
+      .bwsel_a_i(adc_meas_sel_int),
+      .data_a_i({32{1'bx}}),
+      .data_a_o(adc_meas_data_int_dato),
+      .rd_a_i(adc_meas_data_rreq),
+      .wr_a_i(1'b0),
+      .addr_b_i(adc_meas_adr_i),
+      .bwsel_b_i({4{1'b1}}),
+      .data_b_i(adc_meas_data_dat_i),
+      .data_b_o(adc_meas_data_ext_dat),
+      .rd_b_i(1'b0),
+      .wr_b_i(adc_meas_data_we_i)
+    );
+  
+  always @(wr_sel_d0)
+  begin
+    adc_meas_sel_int = 4'b0;
+    if (~(wr_sel_d0[7:0] == 8'b0))
+      adc_meas_sel_int[0] = 1'b1;
+    if (~(wr_sel_d0[15:8] == 8'b0))
+      adc_meas_sel_int[1] = 1'b1;
+    if (~(wr_sel_d0[23:16] == 8'b0))
+      adc_meas_sel_int[2] = 1'b1;
+    if (~(wr_sel_d0[31:24] == 8'b0))
+      adc_meas_sel_int[3] = 1'b1;
+  end
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      adc_meas_data_rack <= 1'b0;
+    else
+      adc_meas_data_rack <= adc_meas_data_rreq;
+  end
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, cal_ctrl_wack, i2c_master_wack)
+  begin
+    cal_ctrl_wreq = 1'b0;
+    i2c_master_we = 1'b0;
+    case (wr_adr_d0[15:14])
+    2'b00:
+      case (wr_adr_d0[13:5])
+      9'b000000000:
+        case (wr_adr_d0[4:3])
+        2'b00:
+          case (wr_adr_d0[2:2])
+          1'b0:
+            // Reg ident
+            wr_ack_int = wr_req_d0;
+          1'b1:
+            // Reg ident
+            wr_ack_int = wr_req_d0;
+          default:
+            wr_ack_int = wr_req_d0;
+          endcase
+        2'b01:
+          case (wr_adr_d0[2:2])
+          1'b0:
+            // Reg version
+            wr_ack_int = wr_req_d0;
+          1'b1:
+            begin
+              // Reg cal_ctrl
+              cal_ctrl_wreq = wr_req_d0;
+              wr_ack_int = cal_ctrl_wack;
+            end
+          default:
+            wr_ack_int = wr_req_d0;
+          endcase
+        default:
+          wr_ack_int = wr_req_d0;
+        endcase
+      9'b000000001:
+        begin
+          // Submap i2c_master
+          i2c_master_we = wr_req_d0;
+          wr_ack_int = i2c_master_wack;
+        end
+      default:
+        wr_ack_int = wr_req_d0;
+      endcase
+    2'b01:
+      // Memory adc_offs
+      wr_ack_int = wr_req_d0;
+    2'b10:
+      // Memory adc_meas
+      wr_ack_int = wr_req_d0;
+    default:
+      wr_ack_int = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always @(wb_adr_i, rd_req_int, ident_i, version_i, cal_ctrl_cal_sel_reg, i2c_master_dat_i, i2c_master_rack, adc_offs_data_int_dato, adc_offs_data_rack, adc_meas_data_int_dato, adc_meas_data_rack)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    i2c_master_re = 1'b0;
+    adc_offs_data_rreq = 1'b0;
+    adc_meas_data_rreq = 1'b0;
+    case (wb_adr_i[15:14])
+    2'b00:
+      case (wb_adr_i[13:5])
+      9'b000000000:
+        case (wb_adr_i[4:3])
+        2'b00:
+          case (wb_adr_i[2:2])
+          1'b0:
+            begin
+              // Reg ident
+              rd_ack_d0 = rd_req_int;
+              rd_dat_d0 = ident_i[63:32];
+            end
+          1'b1:
+            begin
+              // Reg ident
+              rd_ack_d0 = rd_req_int;
+              rd_dat_d0 = ident_i[31:0];
+            end
+          default:
+            rd_ack_d0 = rd_req_int;
+          endcase
+        2'b01:
+          case (wb_adr_i[2:2])
+          1'b0:
+            begin
+              // Reg version
+              rd_ack_d0 = rd_req_int;
+              rd_dat_d0 = version_i;
+            end
+          1'b1:
+            begin
+              // Reg cal_ctrl
+              rd_ack_d0 = rd_req_int;
+              rd_dat_d0[1:0] = cal_ctrl_cal_sel_reg;
+              rd_dat_d0[31:2] = 30'b0;
+            end
+          default:
+            rd_ack_d0 = rd_req_int;
+          endcase
+        default:
+          rd_ack_d0 = rd_req_int;
+        endcase
+      9'b000000001:
+        begin
+          // Submap i2c_master
+          i2c_master_re = rd_req_int;
+          rd_dat_d0 = i2c_master_dat_i;
+          rd_ack_d0 = i2c_master_rack;
+        end
+      default:
+        rd_ack_d0 = rd_req_int;
+      endcase
+    2'b01:
+      begin
+        // Memory adc_offs
+        rd_dat_d0 = adc_offs_data_int_dato;
+        adc_offs_data_rreq = rd_req_int;
+        rd_ack_d0 = adc_offs_data_rack;
+      end
+    2'b10:
+      begin
+        // Memory adc_meas
+        rd_dat_d0 = adc_meas_data_int_dato;
+        adc_meas_data_rreq = rd_req_int;
+        rd_ack_d0 = adc_meas_data_rack;
+      end
+    default:
+      rd_ack_d0 = rd_req_int;
+    endcase
+  end
+endmodule

--- a/testfiles/issue8/simpleMap_bug.sv
+++ b/testfiles/issue8/simpleMap_bug.sv
@@ -29,7 +29,7 @@ module exemple
   assign VMEWrDone = wr_ack_int;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(Clk))
+  always_ff @(posedge(Clk))
   begin
     if (!rst_n)
       begin
@@ -52,65 +52,65 @@ module exemple
   // Register largeReg
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0)
+  always_comb
   case (wr_adr_d0[19:1])
   19'b0000000000000000000:
     // Reg smallReg
-    wr_ack_int <= wr_req_d0;
+    wr_ack_int = wr_req_d0;
   19'b0000000000000000001:
     // Reg largeReg
-    wr_ack_int <= wr_req_d0;
+    wr_ack_int = wr_req_d0;
   19'b0000000000000000010:
     // Reg largeReg
-    wr_ack_int <= wr_req_d0;
+    wr_ack_int = wr_req_d0;
   19'b0000000000000000011:
     // Reg largeReg
-    wr_ack_int <= wr_req_d0;
+    wr_ack_int = wr_req_d0;
   19'b0000000000000000100:
     // Reg largeReg
-    wr_ack_int <= wr_req_d0;
+    wr_ack_int = wr_req_d0;
   default:
-    wr_ack_int <= wr_req_d0;
+    wr_ack_int = wr_req_d0;
   endcase
 
   // Process for read requests.
-  always @(VMEAddr, VMERdMem, smallReg_i, largeReg_i)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {16{1'bx}};
+    rd_dat_d0 = {16{1'bx}};
     case (VMEAddr[19:1])
     19'b0000000000000000000:
       begin
         // Reg smallReg
-        rd_ack_d0 <= VMERdMem;
-        rd_dat_d0 <= smallReg_i;
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = smallReg_i;
       end
     19'b0000000000000000001:
       begin
         // Reg largeReg
-        rd_ack_d0 <= VMERdMem;
-        rd_dat_d0 <= largeReg_i[63:48];
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = largeReg_i[63:48];
       end
     19'b0000000000000000010:
       begin
         // Reg largeReg
-        rd_ack_d0 <= VMERdMem;
-        rd_dat_d0 <= largeReg_i[47:32];
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = largeReg_i[47:32];
       end
     19'b0000000000000000011:
       begin
         // Reg largeReg
-        rd_ack_d0 <= VMERdMem;
-        rd_dat_d0 <= largeReg_i[31:16];
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = largeReg_i[31:16];
       end
     19'b0000000000000000100:
       begin
         // Reg largeReg
-        rd_ack_d0 <= VMERdMem;
-        rd_dat_d0 <= largeReg_i[15:0];
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = largeReg_i[15:0];
       end
     default:
-      rd_ack_d0 <= VMERdMem;
+      rd_ack_d0 = VMERdMem;
     endcase
   end
 endmodule

--- a/testfiles/issue8/simpleMap_bug.v
+++ b/testfiles/issue8/simpleMap_bug.v
@@ -1,0 +1,116 @@
+
+module exemple
+  (
+    input   wire Clk,
+    input   wire Rst,
+    input   wire [19:1] VMEAddr,
+    output  reg [15:0] VMERdData,
+    input   wire [15:0] VMEWrData,
+    input   wire VMERdMem,
+    input   wire VMEWrMem,
+    output  wire VMERdDone,
+    output  wire VMEWrDone,
+
+    // REG smallReg
+    input   wire [15:0] smallReg_i,
+
+    // REG largeReg
+    input   wire [63:0] largeReg_i
+  );
+  wire rst_n;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  reg rd_ack_d0;
+  reg [15:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [19:1] wr_adr_d0;
+  assign rst_n = ~Rst;
+  assign VMERdDone = rd_ack_int;
+  assign VMEWrDone = wr_ack_int;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(Clk))
+  begin
+    if (!rst_n)
+      begin
+        rd_ack_int <= 1'b0;
+        VMERdData <= 16'b0000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 19'b0000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        VMERdData <= rd_dat_d0;
+        wr_req_d0 <= VMEWrMem;
+        wr_adr_d0 <= VMEAddr;
+      end
+  end
+
+  // Register smallReg
+
+  // Register largeReg
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0)
+  case (wr_adr_d0[19:1])
+  19'b0000000000000000000:
+    // Reg smallReg
+    wr_ack_int = wr_req_d0;
+  19'b0000000000000000001:
+    // Reg largeReg
+    wr_ack_int = wr_req_d0;
+  19'b0000000000000000010:
+    // Reg largeReg
+    wr_ack_int = wr_req_d0;
+  19'b0000000000000000011:
+    // Reg largeReg
+    wr_ack_int = wr_req_d0;
+  19'b0000000000000000100:
+    // Reg largeReg
+    wr_ack_int = wr_req_d0;
+  default:
+    wr_ack_int = wr_req_d0;
+  endcase
+
+  // Process for read requests.
+  always @(VMEAddr, VMERdMem, smallReg_i, largeReg_i)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {16{1'bx}};
+    case (VMEAddr[19:1])
+    19'b0000000000000000000:
+      begin
+        // Reg smallReg
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = smallReg_i;
+      end
+    19'b0000000000000000001:
+      begin
+        // Reg largeReg
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = largeReg_i[63:48];
+      end
+    19'b0000000000000000010:
+      begin
+        // Reg largeReg
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = largeReg_i[47:32];
+      end
+    19'b0000000000000000011:
+      begin
+        // Reg largeReg
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = largeReg_i[31:16];
+      end
+    19'b0000000000000000100:
+      begin
+        // Reg largeReg
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = largeReg_i[15:0];
+      end
+    default:
+      rd_ack_d0 = VMERdMem;
+    endcase
+  end
+endmodule

--- a/testfiles/issue8/simpleMap_noBug.sv
+++ b/testfiles/issue8/simpleMap_noBug.sv
@@ -29,7 +29,7 @@ module exemple
   assign VMEWrDone = wr_ack_int;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(Clk))
+  always_ff @(posedge(Clk))
   begin
     if (!rst_n)
       begin
@@ -52,65 +52,65 @@ module exemple
   // Register smallReg
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0)
+  always_comb
   case (wr_adr_d0[19:1])
   19'b0000000000000000000:
     // Reg largeReg
-    wr_ack_int <= wr_req_d0;
+    wr_ack_int = wr_req_d0;
   19'b0000000000000000001:
     // Reg largeReg
-    wr_ack_int <= wr_req_d0;
+    wr_ack_int = wr_req_d0;
   19'b0000000000000000010:
     // Reg largeReg
-    wr_ack_int <= wr_req_d0;
+    wr_ack_int = wr_req_d0;
   19'b0000000000000000011:
     // Reg largeReg
-    wr_ack_int <= wr_req_d0;
+    wr_ack_int = wr_req_d0;
   19'b0000000000000000100:
     // Reg smallReg
-    wr_ack_int <= wr_req_d0;
+    wr_ack_int = wr_req_d0;
   default:
-    wr_ack_int <= wr_req_d0;
+    wr_ack_int = wr_req_d0;
   endcase
 
   // Process for read requests.
-  always @(VMEAddr, VMERdMem, largeReg_i, smallReg_i)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {16{1'bx}};
+    rd_dat_d0 = {16{1'bx}};
     case (VMEAddr[19:1])
     19'b0000000000000000000:
       begin
         // Reg largeReg
-        rd_ack_d0 <= VMERdMem;
-        rd_dat_d0 <= largeReg_i[63:48];
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = largeReg_i[63:48];
       end
     19'b0000000000000000001:
       begin
         // Reg largeReg
-        rd_ack_d0 <= VMERdMem;
-        rd_dat_d0 <= largeReg_i[47:32];
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = largeReg_i[47:32];
       end
     19'b0000000000000000010:
       begin
         // Reg largeReg
-        rd_ack_d0 <= VMERdMem;
-        rd_dat_d0 <= largeReg_i[31:16];
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = largeReg_i[31:16];
       end
     19'b0000000000000000011:
       begin
         // Reg largeReg
-        rd_ack_d0 <= VMERdMem;
-        rd_dat_d0 <= largeReg_i[15:0];
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = largeReg_i[15:0];
       end
     19'b0000000000000000100:
       begin
         // Reg smallReg
-        rd_ack_d0 <= VMERdMem;
-        rd_dat_d0 <= smallReg_i;
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = smallReg_i;
       end
     default:
-      rd_ack_d0 <= VMERdMem;
+      rd_ack_d0 = VMERdMem;
     endcase
   end
 endmodule

--- a/testfiles/issue8/simpleMap_noBug.v
+++ b/testfiles/issue8/simpleMap_noBug.v
@@ -1,0 +1,116 @@
+
+module exemple
+  (
+    input   wire Clk,
+    input   wire Rst,
+    input   wire [19:1] VMEAddr,
+    output  reg [15:0] VMERdData,
+    input   wire [15:0] VMEWrData,
+    input   wire VMERdMem,
+    input   wire VMEWrMem,
+    output  wire VMERdDone,
+    output  wire VMEWrDone,
+
+    // REG largeReg
+    input   wire [63:0] largeReg_i,
+
+    // REG smallReg
+    input   wire [15:0] smallReg_i
+  );
+  wire rst_n;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  reg rd_ack_d0;
+  reg [15:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [19:1] wr_adr_d0;
+  assign rst_n = ~Rst;
+  assign VMERdDone = rd_ack_int;
+  assign VMEWrDone = wr_ack_int;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(Clk))
+  begin
+    if (!rst_n)
+      begin
+        rd_ack_int <= 1'b0;
+        VMERdData <= 16'b0000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 19'b0000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        VMERdData <= rd_dat_d0;
+        wr_req_d0 <= VMEWrMem;
+        wr_adr_d0 <= VMEAddr;
+      end
+  end
+
+  // Register largeReg
+
+  // Register smallReg
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0)
+  case (wr_adr_d0[19:1])
+  19'b0000000000000000000:
+    // Reg largeReg
+    wr_ack_int = wr_req_d0;
+  19'b0000000000000000001:
+    // Reg largeReg
+    wr_ack_int = wr_req_d0;
+  19'b0000000000000000010:
+    // Reg largeReg
+    wr_ack_int = wr_req_d0;
+  19'b0000000000000000011:
+    // Reg largeReg
+    wr_ack_int = wr_req_d0;
+  19'b0000000000000000100:
+    // Reg smallReg
+    wr_ack_int = wr_req_d0;
+  default:
+    wr_ack_int = wr_req_d0;
+  endcase
+
+  // Process for read requests.
+  always @(VMEAddr, VMERdMem, largeReg_i, smallReg_i)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {16{1'bx}};
+    case (VMEAddr[19:1])
+    19'b0000000000000000000:
+      begin
+        // Reg largeReg
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = largeReg_i[63:48];
+      end
+    19'b0000000000000000001:
+      begin
+        // Reg largeReg
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = largeReg_i[47:32];
+      end
+    19'b0000000000000000010:
+      begin
+        // Reg largeReg
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = largeReg_i[31:16];
+      end
+    19'b0000000000000000011:
+      begin
+        // Reg largeReg
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = largeReg_i[15:0];
+      end
+    19'b0000000000000000100:
+      begin
+        // Reg smallReg
+        rd_ack_d0 = VMERdMem;
+        rd_dat_d0 = smallReg_i;
+      end
+    default:
+      rd_ack_d0 = VMERdMem;
+    endcase
+  end
+endmodule

--- a/testfiles/issue84/sps200CavityControl_as.sv
+++ b/testfiles/issue84/sps200CavityControl_as.sv
@@ -206,15 +206,15 @@ module sps200CavityControl_regs
   assign hwInfo_wdata_o = wr_dat_d0;
   always @(wr_sel_d0)
   begin
-    hwInfo_wstrb_o <= 4'b0;
+    hwInfo_wstrb_o = 4'b0;
     if (~(wr_sel_d0[7:0] == 8'b0))
-      hwInfo_wstrb_o[0] <= 1'b1;
+      hwInfo_wstrb_o[0] = 1'b1;
     if (~(wr_sel_d0[15:8] == 8'b0))
-      hwInfo_wstrb_o[1] <= 1'b1;
+      hwInfo_wstrb_o[1] = 1'b1;
     if (~(wr_sel_d0[23:16] == 8'b0))
-      hwInfo_wstrb_o[2] <= 1'b1;
+      hwInfo_wstrb_o[2] = 1'b1;
     if (~(wr_sel_d0[31:24] == 8'b0))
-      hwInfo_wstrb_o[3] <= 1'b1;
+      hwInfo_wstrb_o[3] = 1'b1;
   end
   assign hwInfo_bready_o = 1'b1;
   assign hwInfo_arvalid_o = hwInfo_ar_val;
@@ -245,15 +245,15 @@ module sps200CavityControl_regs
   assign app_wdata_o = wr_dat_d0;
   always @(wr_sel_d0)
   begin
-    app_wstrb_o <= 4'b0;
+    app_wstrb_o = 4'b0;
     if (~(wr_sel_d0[7:0] == 8'b0))
-      app_wstrb_o[0] <= 1'b1;
+      app_wstrb_o[0] = 1'b1;
     if (~(wr_sel_d0[15:8] == 8'b0))
-      app_wstrb_o[1] <= 1'b1;
+      app_wstrb_o[1] = 1'b1;
     if (~(wr_sel_d0[23:16] == 8'b0))
-      app_wstrb_o[2] <= 1'b1;
+      app_wstrb_o[2] = 1'b1;
     if (~(wr_sel_d0[31:24] == 8'b0))
-      app_wstrb_o[3] <= 1'b1;
+      app_wstrb_o[3] = 1'b1;
   end
   assign app_bready_o = 1'b1;
   assign app_arvalid_o = app_ar_val;
@@ -279,23 +279,23 @@ module sps200CavityControl_regs
   // Process for write requests.
   always @(wr_adr_d0, wr_req_d0, hwInfo_bvalid_i, app_bvalid_i)
   begin
-    hwInfo_wr <= 1'b0;
-    app_wr <= 1'b0;
+    hwInfo_wr = 1'b0;
+    app_wr = 1'b0;
     case (wr_adr_d0[20:19])
     2'b00:
       begin
         // Submap hwInfo
-        hwInfo_wr <= wr_req_d0;
-        wr_ack <= hwInfo_bvalid_i;
+        hwInfo_wr = wr_req_d0;
+        wr_ack = hwInfo_bvalid_i;
       end
     2'b10:
       begin
         // Submap app
-        app_wr <= wr_req_d0;
-        wr_ack <= app_bvalid_i;
+        app_wr = wr_req_d0;
+        wr_ack = app_bvalid_i;
       end
     default:
-      wr_ack <= wr_req_d0;
+      wr_ack = wr_req_d0;
     endcase
   end
 
@@ -303,26 +303,26 @@ module sps200CavityControl_regs
   always @(rd_addr, rd_req, hwInfo_rdata_i, hwInfo_rvalid_i, app_rdata_i, app_rvalid_i)
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
-    hwInfo_rd <= 1'b0;
-    app_rd <= 1'b0;
+    rd_dat_d0 = {32{1'bx}};
+    hwInfo_rd = 1'b0;
+    app_rd = 1'b0;
     case (rd_addr[20:19])
     2'b00:
       begin
         // Submap hwInfo
-        hwInfo_rd <= rd_req;
-        rd_dat_d0 <= hwInfo_rdata_i;
-        rd_ack_d0 <= hwInfo_rvalid_i;
+        hwInfo_rd = rd_req;
+        rd_dat_d0 = hwInfo_rdata_i;
+        rd_ack_d0 = hwInfo_rvalid_i;
       end
     2'b10:
       begin
         // Submap app
-        app_rd <= rd_req;
-        rd_dat_d0 <= app_rdata_i;
-        rd_ack_d0 <= app_rvalid_i;
+        app_rd = rd_req;
+        rd_dat_d0 = app_rdata_i;
+        rd_ack_d0 = app_rvalid_i;
       end
     default:
-      rd_ack_d0 <= rd_req;
+      rd_ack_d0 = rd_req;
     endcase
   end
 endmodule

--- a/testfiles/issue87/qsm_regs.sv
+++ b/testfiles/issue87/qsm_regs.sv
@@ -93,12 +93,12 @@ module qsm_regs
   reg [31:0] wr_dat_d0;
 
   // WB decode signals
-  always @(wb.sel)
+  always_comb
   ;
   assign adr_int = wb.adr[10:2];
   assign wb_en = wb.cyc & wb.stb;
 
-  always @(posedge(wb.clk))
+  always_ff @(posedge(wb.clk))
   begin
     if (!wb.rst_n)
       wb_rip <= 1'b0;
@@ -107,7 +107,7 @@ module qsm_regs
   end
   assign rd_req_int = (wb_en & ~wb.we) & ~wb_rip;
 
-  always @(posedge(wb.clk))
+  always_ff @(posedge(wb.clk))
   begin
     if (!wb.rst_n)
       wb_wip <= 1'b0;
@@ -123,7 +123,7 @@ module qsm_regs
   assign wb.err = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(wb.clk))
+  always_ff @(posedge(wb.clk))
   begin
     if (!wb.rst_n)
       begin
@@ -149,7 +149,7 @@ module qsm_regs
   assign regs_0_control_last_reg_adr_o = regs_0_control_last_reg_adr_reg;
   assign regs_0_control_max_dim_no_o = regs_0_control_max_dim_no_reg;
   assign regs_0_control_read_delay_o = regs_0_control_read_delay_reg;
-  always @(posedge(wb.clk))
+  always_ff @(posedge(wb.clk))
   begin
     if (!wb.rst_n)
       begin
@@ -187,7 +187,7 @@ module qsm_regs
   assign regs_1_control_last_reg_adr_o = regs_1_control_last_reg_adr_reg;
   assign regs_1_control_max_dim_no_o = regs_1_control_max_dim_no_reg;
   assign regs_1_control_read_delay_o = regs_1_control_read_delay_reg;
-  always @(posedge(wb.clk))
+  always_ff @(posedge(wb.clk))
   begin
     if (!wb.rst_n)
       begin
@@ -220,7 +220,7 @@ module qsm_regs
   // Register regs_1_status
 
   // Interface memory_0_mem_readout
-  always @(posedge(wb.clk))
+  always_ff @(posedge(wb.clk))
   begin
     if (!wb.rst_n)
       memory_0_mem_readout_rack <= 1'b0;
@@ -230,7 +230,7 @@ module qsm_regs
   assign memory_0_mem_readout_addr_o = adr_int[8:2];
 
   // Interface memory_1_mem_readout
-  always @(posedge(wb.clk))
+  always_ff @(posedge(wb.clk))
   begin
     if (!wb.rst_n)
       memory_1_mem_readout_rack <= 1'b0;
@@ -240,118 +240,118 @@ module qsm_regs
   assign memory_1_mem_readout_addr_o = adr_int[8:2];
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0, regs_0_control_wack, regs_1_control_wack)
+  always_comb
   begin
-    regs_0_control_wreq <= 1'b0;
-    regs_1_control_wreq <= 1'b0;
+    regs_0_control_wreq = 1'b0;
+    regs_1_control_wreq = 1'b0;
     case (wr_adr_d0[10:9])
     2'b00:
       case (wr_adr_d0[8:2])
       7'b0000000:
         begin
           // Reg regs_0_control
-          regs_0_control_wreq <= wr_req_d0;
-          wr_ack_int <= regs_0_control_wack;
+          regs_0_control_wreq = wr_req_d0;
+          wr_ack_int = regs_0_control_wack;
         end
       7'b0000001:
         // Reg regs_0_status
-        wr_ack_int <= wr_req_d0;
+        wr_ack_int = wr_req_d0;
       7'b0000010:
         begin
           // Reg regs_1_control
-          regs_1_control_wreq <= wr_req_d0;
-          wr_ack_int <= regs_1_control_wack;
+          regs_1_control_wreq = wr_req_d0;
+          wr_ack_int = regs_1_control_wack;
         end
       7'b0000011:
         // Reg regs_1_status
-        wr_ack_int <= wr_req_d0;
+        wr_ack_int = wr_req_d0;
       default:
-        wr_ack_int <= wr_req_d0;
+        wr_ack_int = wr_req_d0;
       endcase
     2'b10:
       // Memory memory_0_mem_readout
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     2'b11:
       // Memory memory_1_mem_readout
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     default:
-      wr_ack_int <= wr_req_d0;
+      wr_ack_int = wr_req_d0;
     endcase
   end
 
   // Process for read requests.
-  always @(adr_int, rd_req_int, regs_0_control_last_reg_adr_reg, regs_0_control_max_dim_no_reg, regs_0_control_read_delay_reg, regs_0_status_busy_i, regs_0_status_done_i, regs_0_status_err_many_i, regs_0_status_err_fb_i, regs_0_status_dim_count_i, regs_1_control_last_reg_adr_reg, regs_1_control_max_dim_no_reg, regs_1_control_read_delay_reg, regs_1_status_busy_i, regs_1_status_done_i, regs_1_status_err_many_i, regs_1_status_err_fb_i, regs_1_status_dim_count_i, memory_0_mem_readout_data_i, memory_0_mem_readout_rack, memory_1_mem_readout_data_i, memory_1_mem_readout_rack)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
-    memory_0_mem_readout_re <= 1'b0;
-    memory_1_mem_readout_re <= 1'b0;
+    rd_dat_d0 = {32{1'bx}};
+    memory_0_mem_readout_re = 1'b0;
+    memory_1_mem_readout_re = 1'b0;
     case (adr_int[10:9])
     2'b00:
       case (adr_int[8:2])
       7'b0000000:
         begin
           // Reg regs_0_control
-          rd_ack_d0 <= rd_req_int;
-          rd_dat_d0[0] <= 1'b0;
-          rd_dat_d0[1] <= 1'b0;
-          rd_dat_d0[5:2] <= regs_0_control_last_reg_adr_reg;
-          rd_dat_d0[9:6] <= regs_0_control_max_dim_no_reg;
-          rd_dat_d0[19:10] <= regs_0_control_read_delay_reg;
-          rd_dat_d0[31:20] <= 12'b0;
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0[0] = 1'b0;
+          rd_dat_d0[1] = 1'b0;
+          rd_dat_d0[5:2] = regs_0_control_last_reg_adr_reg;
+          rd_dat_d0[9:6] = regs_0_control_max_dim_no_reg;
+          rd_dat_d0[19:10] = regs_0_control_read_delay_reg;
+          rd_dat_d0[31:20] = 12'b0;
         end
       7'b0000001:
         begin
           // Reg regs_0_status
-          rd_ack_d0 <= rd_req_int;
-          rd_dat_d0[0] <= regs_0_status_busy_i;
-          rd_dat_d0[1] <= regs_0_status_done_i;
-          rd_dat_d0[2] <= regs_0_status_err_many_i;
-          rd_dat_d0[3] <= regs_0_status_err_fb_i;
-          rd_dat_d0[7:4] <= regs_0_status_dim_count_i;
-          rd_dat_d0[31:8] <= 24'b0;
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0[0] = regs_0_status_busy_i;
+          rd_dat_d0[1] = regs_0_status_done_i;
+          rd_dat_d0[2] = regs_0_status_err_many_i;
+          rd_dat_d0[3] = regs_0_status_err_fb_i;
+          rd_dat_d0[7:4] = regs_0_status_dim_count_i;
+          rd_dat_d0[31:8] = 24'b0;
         end
       7'b0000010:
         begin
           // Reg regs_1_control
-          rd_ack_d0 <= rd_req_int;
-          rd_dat_d0[0] <= 1'b0;
-          rd_dat_d0[1] <= 1'b0;
-          rd_dat_d0[5:2] <= regs_1_control_last_reg_adr_reg;
-          rd_dat_d0[9:6] <= regs_1_control_max_dim_no_reg;
-          rd_dat_d0[19:10] <= regs_1_control_read_delay_reg;
-          rd_dat_d0[31:20] <= 12'b0;
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0[0] = 1'b0;
+          rd_dat_d0[1] = 1'b0;
+          rd_dat_d0[5:2] = regs_1_control_last_reg_adr_reg;
+          rd_dat_d0[9:6] = regs_1_control_max_dim_no_reg;
+          rd_dat_d0[19:10] = regs_1_control_read_delay_reg;
+          rd_dat_d0[31:20] = 12'b0;
         end
       7'b0000011:
         begin
           // Reg regs_1_status
-          rd_ack_d0 <= rd_req_int;
-          rd_dat_d0[0] <= regs_1_status_busy_i;
-          rd_dat_d0[1] <= regs_1_status_done_i;
-          rd_dat_d0[2] <= regs_1_status_err_many_i;
-          rd_dat_d0[3] <= regs_1_status_err_fb_i;
-          rd_dat_d0[7:4] <= regs_1_status_dim_count_i;
-          rd_dat_d0[31:8] <= 24'b0;
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0[0] = regs_1_status_busy_i;
+          rd_dat_d0[1] = regs_1_status_done_i;
+          rd_dat_d0[2] = regs_1_status_err_many_i;
+          rd_dat_d0[3] = regs_1_status_err_fb_i;
+          rd_dat_d0[7:4] = regs_1_status_dim_count_i;
+          rd_dat_d0[31:8] = 24'b0;
         end
       default:
-        rd_ack_d0 <= rd_req_int;
+        rd_ack_d0 = rd_req_int;
       endcase
     2'b10:
       begin
         // Memory memory_0_mem_readout
-        rd_dat_d0[15:0] <= memory_0_mem_readout_data_i;
-        rd_ack_d0 <= memory_0_mem_readout_rack;
-        memory_0_mem_readout_re <= rd_req_int;
+        rd_dat_d0[15:0] = memory_0_mem_readout_data_i;
+        rd_ack_d0 = memory_0_mem_readout_rack;
+        memory_0_mem_readout_re = rd_req_int;
       end
     2'b11:
       begin
         // Memory memory_1_mem_readout
-        rd_dat_d0[15:0] <= memory_1_mem_readout_data_i;
-        rd_ack_d0 <= memory_1_mem_readout_rack;
-        memory_1_mem_readout_re <= rd_req_int;
+        rd_dat_d0[15:0] = memory_1_mem_readout_data_i;
+        rd_ack_d0 = memory_1_mem_readout_rack;
+        memory_1_mem_readout_re = rd_req_int;
       end
     default:
-      rd_ack_d0 <= rd_req_int;
+      rd_ack_d0 = rd_req_int;
     endcase
   end
 endmodule

--- a/testfiles/issue87/qsm_regs.v
+++ b/testfiles/issue87/qsm_regs.v
@@ -1,0 +1,357 @@
+
+module qsm_regs
+  (
+    t_wishbone.slave wb,
+
+    // Control register
+    // Send the Reset state to DIM
+    output  wire regs_0_control_reset_o,
+    // Trigger DIM readout
+    output  wire regs_0_control_trig_o,
+    // Address of last DIM register (number of registers - 1)
+    output  wire [3:0] regs_0_control_last_reg_adr_o,
+    // Maximum number of devices present on line
+    output  wire [3:0] regs_0_control_max_dim_no_o,
+    // Delay between consecutive register reads in microseconds (usually 512 us)
+    output  wire [9:0] regs_0_control_read_delay_o,
+
+    // Status register
+    // QSPI master is busy (either in RESET or READOUT)
+    input   wire regs_0_status_busy_i,
+    // QSPI master has finished DIM readout
+    input   wire regs_0_status_done_i,
+    // Too many devices on DIM line (more than set by 'max_dim_no' register)
+    input   wire regs_0_status_err_many_i,
+    // Detected error on QSPI fb line
+    input   wire regs_0_status_err_fb_i,
+    // Detected number of DIM devices (can be lower than 'max_dim_no')
+    input   wire [3:0] regs_0_status_dim_count_i,
+
+    // Control register
+    // Send the Reset state to DIM
+    output  wire regs_1_control_reset_o,
+    // Trigger DIM readout
+    output  wire regs_1_control_trig_o,
+    // Address of last DIM register (number of registers - 1)
+    output  wire [3:0] regs_1_control_last_reg_adr_o,
+    // Maximum number of devices present on line
+    output  wire [3:0] regs_1_control_max_dim_no_o,
+    // Delay between consecutive register reads in microseconds (usually 512 us)
+    output  wire [9:0] regs_1_control_read_delay_o,
+
+    // Status register
+    // QSPI master is busy (either in RESET or READOUT)
+    input   wire regs_1_status_busy_i,
+    // QSPI master has finished DIM readout
+    input   wire regs_1_status_done_i,
+    // Too many devices on DIM line (more than set by 'max_dim_no' register)
+    input   wire regs_1_status_err_many_i,
+    // Detected error on QSPI fb line
+    input   wire regs_1_status_err_fb_i,
+    // Detected number of DIM devices (can be lower than 'max_dim_no')
+    input   wire [3:0] regs_1_status_dim_count_i,
+
+    // SRAM bus memory_0_mem_readout
+    output  wire [8:2] memory_0_mem_readout_addr_o,
+    input   wire [15:0] memory_0_mem_readout_data_i,
+
+    // SRAM bus memory_1_mem_readout
+    output  wire [8:2] memory_1_mem_readout_addr_o,
+    input   wire [15:0] memory_1_mem_readout_data_i
+  );
+  wire [10:2] adr_int;
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg regs_0_control_reset_reg;
+  reg regs_0_control_trig_reg;
+  reg [3:0] regs_0_control_last_reg_adr_reg;
+  reg [3:0] regs_0_control_max_dim_no_reg;
+  reg [9:0] regs_0_control_read_delay_reg;
+  reg regs_0_control_wreq;
+  reg regs_0_control_wack;
+  reg regs_1_control_reset_reg;
+  reg regs_1_control_trig_reg;
+  reg [3:0] regs_1_control_last_reg_adr_reg;
+  reg [3:0] regs_1_control_max_dim_no_reg;
+  reg [9:0] regs_1_control_read_delay_reg;
+  reg regs_1_control_wreq;
+  reg regs_1_control_wack;
+  reg memory_0_mem_readout_rack;
+  reg memory_0_mem_readout_re;
+  reg memory_1_mem_readout_rack;
+  reg memory_1_mem_readout_re;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [10:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+
+  // WB decode signals
+  always @(wb.sel)
+  ;
+  assign adr_int = wb.adr[10:2];
+  assign wb_en = wb.cyc & wb.stb;
+
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb.we)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb.we) & ~wb_rip;
+
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb.we)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb.we) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb.ack = ack_int;
+  assign wb.stall = ~ack_int & wb_en;
+  assign wb.rty = 1'b0;
+  assign wb.err = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      begin
+        rd_ack_int <= 1'b0;
+        wb.dati <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 9'b000000000;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb.dati <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_adr_d0 <= adr_int;
+        wr_dat_d0 <= wb.dato;
+      end
+  end
+
+  // Register regs_0_control
+  assign regs_0_control_reset_o = regs_0_control_reset_reg;
+  assign regs_0_control_trig_o = regs_0_control_trig_reg;
+  assign regs_0_control_last_reg_adr_o = regs_0_control_last_reg_adr_reg;
+  assign regs_0_control_max_dim_no_o = regs_0_control_max_dim_no_reg;
+  assign regs_0_control_read_delay_o = regs_0_control_read_delay_reg;
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      begin
+        regs_0_control_reset_reg <= 1'b0;
+        regs_0_control_trig_reg <= 1'b0;
+        regs_0_control_last_reg_adr_reg <= 4'b0000;
+        regs_0_control_max_dim_no_reg <= 4'b0000;
+        regs_0_control_read_delay_reg <= 10'b0000000000;
+        regs_0_control_wack <= 1'b0;
+      end
+    else
+      begin
+        if (regs_0_control_wreq == 1'b1)
+          begin
+            regs_0_control_reset_reg <= wr_dat_d0[0];
+            regs_0_control_trig_reg <= wr_dat_d0[1];
+            regs_0_control_last_reg_adr_reg <= wr_dat_d0[5:2];
+            regs_0_control_max_dim_no_reg <= wr_dat_d0[9:6];
+            regs_0_control_read_delay_reg <= wr_dat_d0[19:10];
+          end
+        else
+          begin
+            regs_0_control_reset_reg <= 1'b0;
+            regs_0_control_trig_reg <= 1'b0;
+          end
+        regs_0_control_wack <= regs_0_control_wreq;
+      end
+  end
+
+  // Register regs_0_status
+
+  // Register regs_1_control
+  assign regs_1_control_reset_o = regs_1_control_reset_reg;
+  assign regs_1_control_trig_o = regs_1_control_trig_reg;
+  assign regs_1_control_last_reg_adr_o = regs_1_control_last_reg_adr_reg;
+  assign regs_1_control_max_dim_no_o = regs_1_control_max_dim_no_reg;
+  assign regs_1_control_read_delay_o = regs_1_control_read_delay_reg;
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      begin
+        regs_1_control_reset_reg <= 1'b0;
+        regs_1_control_trig_reg <= 1'b0;
+        regs_1_control_last_reg_adr_reg <= 4'b0000;
+        regs_1_control_max_dim_no_reg <= 4'b0000;
+        regs_1_control_read_delay_reg <= 10'b0000000000;
+        regs_1_control_wack <= 1'b0;
+      end
+    else
+      begin
+        if (regs_1_control_wreq == 1'b1)
+          begin
+            regs_1_control_reset_reg <= wr_dat_d0[0];
+            regs_1_control_trig_reg <= wr_dat_d0[1];
+            regs_1_control_last_reg_adr_reg <= wr_dat_d0[5:2];
+            regs_1_control_max_dim_no_reg <= wr_dat_d0[9:6];
+            regs_1_control_read_delay_reg <= wr_dat_d0[19:10];
+          end
+        else
+          begin
+            regs_1_control_reset_reg <= 1'b0;
+            regs_1_control_trig_reg <= 1'b0;
+          end
+        regs_1_control_wack <= regs_1_control_wreq;
+      end
+  end
+
+  // Register regs_1_status
+
+  // Interface memory_0_mem_readout
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      memory_0_mem_readout_rack <= 1'b0;
+    else
+      memory_0_mem_readout_rack <= memory_0_mem_readout_re & ~memory_0_mem_readout_rack;
+  end
+  assign memory_0_mem_readout_addr_o = adr_int[8:2];
+
+  // Interface memory_1_mem_readout
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      memory_1_mem_readout_rack <= 1'b0;
+    else
+      memory_1_mem_readout_rack <= memory_1_mem_readout_re & ~memory_1_mem_readout_rack;
+  end
+  assign memory_1_mem_readout_addr_o = adr_int[8:2];
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, regs_0_control_wack, regs_1_control_wack)
+  begin
+    regs_0_control_wreq = 1'b0;
+    regs_1_control_wreq = 1'b0;
+    case (wr_adr_d0[10:9])
+    2'b00:
+      case (wr_adr_d0[8:2])
+      7'b0000000:
+        begin
+          // Reg regs_0_control
+          regs_0_control_wreq = wr_req_d0;
+          wr_ack_int = regs_0_control_wack;
+        end
+      7'b0000001:
+        // Reg regs_0_status
+        wr_ack_int = wr_req_d0;
+      7'b0000010:
+        begin
+          // Reg regs_1_control
+          regs_1_control_wreq = wr_req_d0;
+          wr_ack_int = regs_1_control_wack;
+        end
+      7'b0000011:
+        // Reg regs_1_status
+        wr_ack_int = wr_req_d0;
+      default:
+        wr_ack_int = wr_req_d0;
+      endcase
+    2'b10:
+      // Memory memory_0_mem_readout
+      wr_ack_int = wr_req_d0;
+    2'b11:
+      // Memory memory_1_mem_readout
+      wr_ack_int = wr_req_d0;
+    default:
+      wr_ack_int = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always @(adr_int, rd_req_int, regs_0_control_last_reg_adr_reg, regs_0_control_max_dim_no_reg, regs_0_control_read_delay_reg, regs_0_status_busy_i, regs_0_status_done_i, regs_0_status_err_many_i, regs_0_status_err_fb_i, regs_0_status_dim_count_i, regs_1_control_last_reg_adr_reg, regs_1_control_max_dim_no_reg, regs_1_control_read_delay_reg, regs_1_status_busy_i, regs_1_status_done_i, regs_1_status_err_many_i, regs_1_status_err_fb_i, regs_1_status_dim_count_i, memory_0_mem_readout_data_i, memory_0_mem_readout_rack, memory_1_mem_readout_data_i, memory_1_mem_readout_rack)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    memory_0_mem_readout_re = 1'b0;
+    memory_1_mem_readout_re = 1'b0;
+    case (adr_int[10:9])
+    2'b00:
+      case (adr_int[8:2])
+      7'b0000000:
+        begin
+          // Reg regs_0_control
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0[0] = 1'b0;
+          rd_dat_d0[1] = 1'b0;
+          rd_dat_d0[5:2] = regs_0_control_last_reg_adr_reg;
+          rd_dat_d0[9:6] = regs_0_control_max_dim_no_reg;
+          rd_dat_d0[19:10] = regs_0_control_read_delay_reg;
+          rd_dat_d0[31:20] = 12'b0;
+        end
+      7'b0000001:
+        begin
+          // Reg regs_0_status
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0[0] = regs_0_status_busy_i;
+          rd_dat_d0[1] = regs_0_status_done_i;
+          rd_dat_d0[2] = regs_0_status_err_many_i;
+          rd_dat_d0[3] = regs_0_status_err_fb_i;
+          rd_dat_d0[7:4] = regs_0_status_dim_count_i;
+          rd_dat_d0[31:8] = 24'b0;
+        end
+      7'b0000010:
+        begin
+          // Reg regs_1_control
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0[0] = 1'b0;
+          rd_dat_d0[1] = 1'b0;
+          rd_dat_d0[5:2] = regs_1_control_last_reg_adr_reg;
+          rd_dat_d0[9:6] = regs_1_control_max_dim_no_reg;
+          rd_dat_d0[19:10] = regs_1_control_read_delay_reg;
+          rd_dat_d0[31:20] = 12'b0;
+        end
+      7'b0000011:
+        begin
+          // Reg regs_1_status
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0[0] = regs_1_status_busy_i;
+          rd_dat_d0[1] = regs_1_status_done_i;
+          rd_dat_d0[2] = regs_1_status_err_many_i;
+          rd_dat_d0[3] = regs_1_status_err_fb_i;
+          rd_dat_d0[7:4] = regs_1_status_dim_count_i;
+          rd_dat_d0[31:8] = 24'b0;
+        end
+      default:
+        rd_ack_d0 = rd_req_int;
+      endcase
+    2'b10:
+      begin
+        // Memory memory_0_mem_readout
+        rd_dat_d0[15:0] = memory_0_mem_readout_data_i;
+        rd_ack_d0 = memory_0_mem_readout_rack;
+        memory_0_mem_readout_re = rd_req_int;
+      end
+    2'b11:
+      begin
+        // Memory memory_1_mem_readout
+        rd_dat_d0[15:0] = memory_1_mem_readout_data_i;
+        rd_ack_d0 = memory_1_mem_readout_rack;
+        memory_1_mem_readout_re = rd_req_int;
+      end
+    default:
+      rd_ack_d0 = rd_req_int;
+    endcase
+  end
+endmodule

--- a/testfiles/issue89/map.sv
+++ b/testfiles/issue89/map.sv
@@ -37,7 +37,7 @@ module map1
   assign VMEWrDone = wr_ack_int;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(Clk))
+  always_ff @(posedge(Clk))
   begin
     if (!rst_n)
       begin
@@ -58,11 +58,11 @@ module map1
   end
 
   // Memory m1
-  always @(VMEAddr, wr_adr_d0, m1_wr)
+  always_comb
   if (m1_wr == 1'b1)
-    m1_adr_int <= wr_adr_d0[7:2];
+    m1_adr_int = wr_adr_d0[7:2];
   else
-    m1_adr_int <= VMEAddr[7:2];
+    m1_adr_int = VMEAddr[7:2];
   assign m1_wreq = m1_r1_int_wr;
   assign m1_wr = m1_wreq;
   cheby_dpssram #(
@@ -89,7 +89,7 @@ module map1
       .wr_b_i(1'b0)
     );
   
-  always @(posedge(Clk))
+  always_ff @(posedge(Clk))
   begin
     if (!rst_n)
       m1_r1_rack <= 1'b0;
@@ -98,23 +98,23 @@ module map1
   end
 
   // Process for write requests.
-  always @(wr_req_d0)
+  always_comb
   begin
-    m1_r1_int_wr <= 1'b0;
+    m1_r1_int_wr = 1'b0;
     // Memory m1
-    m1_r1_int_wr <= wr_req_d0;
-    wr_ack_int <= wr_req_d0;
+    m1_r1_int_wr = wr_req_d0;
+    wr_ack_int = wr_req_d0;
   end
 
   // Process for read requests.
-  always @(m1_r1_int_dato, VMERdMem, m1_r1_rack)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
-    m1_r1_rreq <= 1'b0;
+    rd_dat_d0 = {32{1'bx}};
+    m1_r1_rreq = 1'b0;
     // Memory m1
-    rd_dat_d0 <= {16'b0000000000000000, m1_r1_int_dato};
-    m1_r1_rreq <= VMERdMem;
-    rd_ack_d0 <= m1_r1_rack;
+    rd_dat_d0 = {16'b0000000000000000, m1_r1_int_dato};
+    m1_r1_rreq = VMERdMem;
+    rd_ack_d0 = m1_r1_rack;
   end
 endmodule

--- a/testfiles/issue89/map.v
+++ b/testfiles/issue89/map.v
@@ -1,0 +1,120 @@
+
+module map1
+  (
+    input   wire Clk,
+    input   wire Rst,
+    input   wire [7:2] VMEAddr,
+    output  reg [31:0] VMERdData,
+    input   wire [31:0] VMEWrData,
+    input   wire VMERdMem,
+    input   wire VMEWrMem,
+    output  wire VMERdDone,
+    output  wire VMEWrDone,
+
+    // RAM port for m1
+    input   wire [5:0] m1_adr_i,
+    input   wire m1_r1_rd_i,
+    output  wire [15:0] m1_r1_dat_o
+  );
+  wire rst_n;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire [15:0] m1_r1_int_dato;
+  wire [15:0] m1_r1_ext_dat;
+  reg m1_r1_rreq;
+  reg m1_r1_rack;
+  reg m1_r1_int_wr;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [7:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+  wire m1_wr;
+  wire m1_wreq;
+  reg [5:0] m1_adr_int;
+  assign rst_n = ~Rst;
+  assign VMERdDone = rd_ack_int;
+  assign VMEWrDone = wr_ack_int;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(Clk))
+  begin
+    if (!rst_n)
+      begin
+        rd_ack_int <= 1'b0;
+        VMERdData <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 6'b000000;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        VMERdData <= rd_dat_d0;
+        wr_req_d0 <= VMEWrMem;
+        wr_adr_d0 <= VMEAddr;
+        wr_dat_d0 <= VMEWrData;
+      end
+  end
+
+  // Memory m1
+  always @(VMEAddr, wr_adr_d0, m1_wr)
+  if (m1_wr == 1'b1)
+    m1_adr_int = wr_adr_d0[7:2];
+  else
+    m1_adr_int = VMEAddr[7:2];
+  assign m1_wreq = m1_r1_int_wr;
+  assign m1_wr = m1_wreq;
+  cheby_dpssram #(
+      .g_data_width(16),
+      .g_size(64),
+      .g_addr_width(6),
+      .g_dual_clock(1'b0),
+      .g_use_bwsel(1'b0)
+    )
+  m1_r1_raminst (
+      .clk_a_i(Clk),
+      .clk_b_i(Clk),
+      .addr_a_i(m1_adr_int),
+      .bwsel_a_i({2{1'b1}}),
+      .data_a_i(wr_dat_d0[15:0]),
+      .data_a_o(m1_r1_int_dato),
+      .rd_a_i(m1_r1_rreq),
+      .wr_a_i(m1_r1_int_wr),
+      .addr_b_i(m1_adr_i),
+      .bwsel_b_i({2{1'b1}}),
+      .data_b_i(m1_r1_ext_dat),
+      .data_b_o(m1_r1_dat_o),
+      .rd_b_i(m1_r1_rd_i),
+      .wr_b_i(1'b0)
+    );
+  
+  always @(posedge(Clk))
+  begin
+    if (!rst_n)
+      m1_r1_rack <= 1'b0;
+    else
+      m1_r1_rack <= m1_r1_rreq;
+  end
+
+  // Process for write requests.
+  always @(wr_req_d0)
+  begin
+    m1_r1_int_wr = 1'b0;
+    // Memory m1
+    m1_r1_int_wr = wr_req_d0;
+    wr_ack_int = wr_req_d0;
+  end
+
+  // Process for read requests.
+  always @(m1_r1_int_dato, VMERdMem, m1_r1_rack)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    m1_r1_rreq = 1'b0;
+    // Memory m1
+    rd_dat_d0 = {16'b0000000000000000, m1_r1_int_dato};
+    m1_r1_rreq = VMERdMem;
+    rd_ack_d0 = m1_r1_rack;
+  end
+endmodule

--- a/testfiles/issue9/test.sv
+++ b/testfiles/issue9/test.sv
@@ -70,7 +70,7 @@ module test
   assign awready = ~axi_awset;
   assign wready = ~axi_wset;
   assign bvalid = axi_wdone;
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -109,7 +109,7 @@ module test
   // AR and R channels
   assign arready = ~axi_arset;
   assign rvalid = axi_rdone;
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -142,7 +142,7 @@ module test
   assign rresp = 2'b00;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -164,7 +164,7 @@ module test
 
   // Register register1
   assign register1_o = register1_reg;
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -183,7 +183,7 @@ module test
 
   // Register block1_register3
   assign block1_register3_o = block1_register3_reg;
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -201,67 +201,67 @@ module test
   // Register block1_block2_register4
 
   // Process for write requests.
-  always @(wr_adr_d0, wr_req_d0, register1_wack, block1_register3_wack)
+  always_comb
   begin
-    register1_wreq <= 1'b0;
-    block1_register3_wreq <= 1'b0;
+    register1_wreq = 1'b0;
+    block1_register3_wreq = 1'b0;
     case (wr_adr_d0[4:2])
     3'b000:
       begin
         // Reg register1
-        register1_wreq <= wr_req_d0;
-        wr_ack <= register1_wack;
+        register1_wreq = wr_req_d0;
+        wr_ack = register1_wack;
       end
     3'b100:
       // Reg block1_register2
-      wr_ack <= wr_req_d0;
+      wr_ack = wr_req_d0;
     3'b101:
       begin
         // Reg block1_register3
-        block1_register3_wreq <= wr_req_d0;
-        wr_ack <= block1_register3_wack;
+        block1_register3_wreq = wr_req_d0;
+        wr_ack = block1_register3_wack;
       end
     3'b110:
       // Reg block1_block2_register4
-      wr_ack <= wr_req_d0;
+      wr_ack = wr_req_d0;
     default:
-      wr_ack <= wr_req_d0;
+      wr_ack = wr_req_d0;
     endcase
   end
 
   // Process for read requests.
-  always @(rd_addr, rd_req, block1_register2_field1_i, block1_register2_field2_i, block1_register3_reg, block1_block2_register4_field3_i, block1_block2_register4_field4_i)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     case (rd_addr[4:2])
     3'b000:
       // Reg register1
-      rd_ack_d0 <= rd_req;
+      rd_ack_d0 = rd_req;
     3'b100:
       begin
         // Reg block1_register2
-        rd_ack_d0 <= rd_req;
-        rd_dat_d0[0] <= block1_register2_field1_i;
-        rd_dat_d0[3:1] <= block1_register2_field2_i;
-        rd_dat_d0[31:4] <= 28'b0;
+        rd_ack_d0 = rd_req;
+        rd_dat_d0[0] = block1_register2_field1_i;
+        rd_dat_d0[3:1] = block1_register2_field2_i;
+        rd_dat_d0[31:4] = 28'b0;
       end
     3'b101:
       begin
         // Reg block1_register3
-        rd_ack_d0 <= rd_req;
-        rd_dat_d0 <= block1_register3_reg;
+        rd_ack_d0 = rd_req;
+        rd_dat_d0 = block1_register3_reg;
       end
     3'b110:
       begin
         // Reg block1_block2_register4
-        rd_ack_d0 <= rd_req;
-        rd_dat_d0[0] <= block1_block2_register4_field3_i;
-        rd_dat_d0[3:1] <= block1_block2_register4_field4_i;
-        rd_dat_d0[31:4] <= 28'b0;
+        rd_ack_d0 = rd_req;
+        rd_dat_d0[0] = block1_block2_register4_field3_i;
+        rd_dat_d0[3:1] = block1_block2_register4_field4_i;
+        rd_dat_d0[31:4] = 28'b0;
       end
     default:
-      rd_ack_d0 <= rd_req;
+      rd_ack_d0 = rd_req;
     endcase
   end
 endmodule

--- a/testfiles/issue9/test.v
+++ b/testfiles/issue9/test.v
@@ -1,0 +1,267 @@
+
+module test
+  (
+    input   wire aclk,
+    input   wire areset_n,
+    input   wire awvalid,
+    output  wire awready,
+    input   wire [4:2] awaddr,
+    input   wire [2:0] awprot,
+    input   wire wvalid,
+    output  wire wready,
+    input   wire [31:0] wdata,
+    input   wire [3:0] wstrb,
+    output  wire bvalid,
+    input   wire bready,
+    output  wire [1:0] bresp,
+    input   wire arvalid,
+    output  wire arready,
+    input   wire [4:2] araddr,
+    input   wire [2:0] arprot,
+    output  wire rvalid,
+    input   wire rready,
+    output  reg [31:0] rdata,
+    output  wire [1:0] rresp,
+
+    // Test register 1
+    output  wire [31:0] register1_o,
+
+    // Test register 2
+    // Test field 1
+    input   wire block1_register2_field1_i,
+    // Test field 2
+    input   wire [2:0] block1_register2_field2_i,
+
+    // Test register 3
+    output  wire [31:0] block1_register3_o,
+
+    // Test register 4
+    // Test field 3
+    input   wire block1_block2_register4_field3_i,
+    // Test field 4
+    input   wire [2:0] block1_block2_register4_field4_i
+  );
+  reg wr_req;
+  reg wr_ack;
+  reg [4:2] wr_addr;
+  reg [31:0] wr_data;
+  reg axi_awset;
+  reg axi_wset;
+  reg axi_wdone;
+  reg rd_req;
+  reg rd_ack;
+  reg [4:2] rd_addr;
+  reg [31:0] rd_data;
+  reg axi_arset;
+  reg axi_rdone;
+  reg [31:0] register1_reg;
+  reg register1_wreq;
+  reg register1_wack;
+  reg [31:0] block1_register3_reg;
+  reg block1_register3_wreq;
+  reg block1_register3_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [4:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+
+  // AW, W and B channels
+  assign awready = ~axi_awset;
+  assign wready = ~axi_wset;
+  assign bvalid = axi_wdone;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        wr_req <= 1'b0;
+        axi_awset <= 1'b0;
+        axi_wset <= 1'b0;
+        axi_wdone <= 1'b0;
+      end
+    else
+      begin
+        wr_req <= 1'b0;
+        if (awvalid == 1'b1 & axi_awset == 1'b0)
+          begin
+            wr_addr <= awaddr;
+            axi_awset <= 1'b1;
+            wr_req <= axi_wset;
+          end
+        if (wvalid == 1'b1 & axi_wset == 1'b0)
+          begin
+            wr_data <= wdata;
+            axi_wset <= 1'b1;
+            wr_req <= axi_awset | awvalid;
+          end
+        if ((axi_wdone & bready) == 1'b1)
+          begin
+            axi_wset <= 1'b0;
+            axi_awset <= 1'b0;
+            axi_wdone <= 1'b0;
+          end
+        if (wr_ack == 1'b1)
+          axi_wdone <= 1'b1;
+      end
+  end
+  assign bresp = 2'b00;
+
+  // AR and R channels
+  assign arready = ~axi_arset;
+  assign rvalid = axi_rdone;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        rd_req <= 1'b0;
+        axi_arset <= 1'b0;
+        axi_rdone <= 1'b0;
+        rdata <= 32'b0;
+      end
+    else
+      begin
+        rd_req <= 1'b0;
+        if (arvalid == 1'b1 & axi_arset == 1'b0)
+          begin
+            rd_addr <= araddr;
+            axi_arset <= 1'b1;
+            rd_req <= 1'b1;
+          end
+        if ((axi_rdone & rready) == 1'b1)
+          begin
+            axi_arset <= 1'b0;
+            axi_rdone <= 1'b0;
+          end
+        if (rd_ack == 1'b1)
+          begin
+            axi_rdone <= 1'b1;
+            rdata <= rd_data;
+          end
+      end
+  end
+  assign rresp = 2'b00;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        rd_ack <= 1'b0;
+        rd_data <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 3'b000;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack <= rd_ack_d0;
+        rd_data <= rd_dat_d0;
+        wr_req_d0 <= wr_req;
+        wr_adr_d0 <= wr_addr;
+        wr_dat_d0 <= wr_data;
+      end
+  end
+
+  // Register register1
+  assign register1_o = register1_reg;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        register1_reg <= 32'b00000000000000000000000000000000;
+        register1_wack <= 1'b0;
+      end
+    else
+      begin
+        if (register1_wreq == 1'b1)
+          register1_reg <= wr_dat_d0;
+        register1_wack <= register1_wreq;
+      end
+  end
+
+  // Register block1_register2
+
+  // Register block1_register3
+  assign block1_register3_o = block1_register3_reg;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        block1_register3_reg <= 32'b00000000000000000000000000000000;
+        block1_register3_wack <= 1'b0;
+      end
+    else
+      begin
+        if (block1_register3_wreq == 1'b1)
+          block1_register3_reg <= wr_dat_d0;
+        block1_register3_wack <= block1_register3_wreq;
+      end
+  end
+
+  // Register block1_block2_register4
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, register1_wack, block1_register3_wack)
+  begin
+    register1_wreq = 1'b0;
+    block1_register3_wreq = 1'b0;
+    case (wr_adr_d0[4:2])
+    3'b000:
+      begin
+        // Reg register1
+        register1_wreq = wr_req_d0;
+        wr_ack = register1_wack;
+      end
+    3'b100:
+      // Reg block1_register2
+      wr_ack = wr_req_d0;
+    3'b101:
+      begin
+        // Reg block1_register3
+        block1_register3_wreq = wr_req_d0;
+        wr_ack = block1_register3_wack;
+      end
+    3'b110:
+      // Reg block1_block2_register4
+      wr_ack = wr_req_d0;
+    default:
+      wr_ack = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always @(rd_addr, rd_req, block1_register2_field1_i, block1_register2_field2_i, block1_register3_reg, block1_block2_register4_field3_i, block1_block2_register4_field4_i)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    case (rd_addr[4:2])
+    3'b000:
+      // Reg register1
+      rd_ack_d0 = rd_req;
+    3'b100:
+      begin
+        // Reg block1_register2
+        rd_ack_d0 = rd_req;
+        rd_dat_d0[0] = block1_register2_field1_i;
+        rd_dat_d0[3:1] = block1_register2_field2_i;
+        rd_dat_d0[31:4] = 28'b0;
+      end
+    3'b101:
+      begin
+        // Reg block1_register3
+        rd_ack_d0 = rd_req;
+        rd_dat_d0 = block1_register3_reg;
+      end
+    3'b110:
+      begin
+        // Reg block1_block2_register4
+        rd_ack_d0 = rd_req;
+        rd_dat_d0[0] = block1_block2_register4_field3_i;
+        rd_dat_d0[3:1] = block1_block2_register4_field4_i;
+        rd_dat_d0[31:4] = 28'b0;
+      end
+    default:
+      rd_ack_d0 = rd_req;
+    endcase
+  end
+endmodule

--- a/testfiles/issue90/bugDPSSRAMbwSel.sv
+++ b/testfiles/issue90/bugDPSSRAMbwSel.sv
@@ -62,7 +62,7 @@ module bugDPSSRAMbwSel
   assign awready = ~axi_awset;
   assign wready = ~axi_wset;
   assign bvalid = axi_wdone;
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -105,7 +105,7 @@ module bugDPSSRAMbwSel
   // AR and R channels
   assign arready = ~axi_arset;
   assign rvalid = axi_rdone;
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -138,7 +138,7 @@ module bugDPSSRAMbwSel
   assign rresp = 2'b00;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       begin
@@ -161,11 +161,11 @@ module bugDPSSRAMbwSel
   end
 
   // Memory mem
-  always @(rd_addr, wr_adr_d0, mem_wr)
+  always_comb
   if (mem_wr == 1'b1)
-    mem_adr_int <= wr_adr_d0[11:2];
+    mem_adr_int = wr_adr_d0[11:2];
   else
-    mem_adr_int <= rd_addr[11:2];
+    mem_adr_int = rd_addr[11:2];
   assign mem_wreq = mem_r1_int_wr;
   assign mem_wr = mem_wreq;
   cheby_dpssram #(
@@ -192,19 +192,19 @@ module bugDPSSRAMbwSel
       .wr_b_i(1'b0)
     );
   
-  always @(wr_sel_d0)
+  always_comb
   begin
-    mem_sel_int <= 4'b0;
+    mem_sel_int = 4'b0;
     if (~(wr_sel_d0[7:0] == 8'b0))
-      mem_sel_int[0] <= 1'b1;
+      mem_sel_int[0] = 1'b1;
     if (~(wr_sel_d0[15:8] == 8'b0))
-      mem_sel_int[1] <= 1'b1;
+      mem_sel_int[1] = 1'b1;
     if (~(wr_sel_d0[23:16] == 8'b0))
-      mem_sel_int[2] <= 1'b1;
+      mem_sel_int[2] = 1'b1;
     if (~(wr_sel_d0[31:24] == 8'b0))
-      mem_sel_int[3] <= 1'b1;
+      mem_sel_int[3] = 1'b1;
   end
-  always @(posedge(aclk))
+  always_ff @(posedge(aclk))
   begin
     if (!areset_n)
       mem_r1_rack <= 1'b0;
@@ -213,23 +213,23 @@ module bugDPSSRAMbwSel
   end
 
   // Process for write requests.
-  always @(wr_req_d0)
+  always_comb
   begin
-    mem_r1_int_wr <= 1'b0;
+    mem_r1_int_wr = 1'b0;
     // Memory mem
-    mem_r1_int_wr <= wr_req_d0;
-    wr_ack <= wr_req_d0;
+    mem_r1_int_wr = wr_req_d0;
+    wr_ack = wr_req_d0;
   end
 
   // Process for read requests.
-  always @(mem_r1_int_dato, rd_req, mem_wreq, mem_r1_rack)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
-    mem_r1_rreq <= 1'b0;
+    rd_dat_d0 = {32{1'bx}};
+    mem_r1_rreq = 1'b0;
     // Memory mem
-    rd_dat_d0 <= {24'b000000000000000000000000, mem_r1_int_dato};
-    mem_r1_rreq <= rd_req & ~mem_wreq;
-    rd_ack_d0 <= mem_r1_rack;
+    rd_dat_d0 = {24'b000000000000000000000000, mem_r1_int_dato};
+    mem_r1_rreq = rd_req & ~mem_wreq;
+    rd_ack_d0 = mem_r1_rack;
   end
 endmodule

--- a/testfiles/issue90/bugDPSSRAMbwSel.v
+++ b/testfiles/issue90/bugDPSSRAMbwSel.v
@@ -1,0 +1,235 @@
+
+module bugDPSSRAMbwSel
+  (
+    input   wire aclk,
+    input   wire areset_n,
+    input   wire awvalid,
+    output  wire awready,
+    input   wire [19:2] awaddr,
+    input   wire [2:0] awprot,
+    input   wire wvalid,
+    output  wire wready,
+    input   wire [31:0] wdata,
+    input   wire [3:0] wstrb,
+    output  wire bvalid,
+    input   wire bready,
+    output  wire [1:0] bresp,
+    input   wire arvalid,
+    output  wire arready,
+    input   wire [19:2] araddr,
+    input   wire [2:0] arprot,
+    output  wire rvalid,
+    input   wire rready,
+    output  reg [31:0] rdata,
+    output  wire [1:0] rresp,
+
+    // RAM port for mem
+    input   wire [9:0] mem_adr_i,
+    input   wire mem_r1_rd_i,
+    output  wire [7:0] mem_r1_dat_o
+  );
+  reg wr_req;
+  reg wr_ack;
+  reg [19:2] wr_addr;
+  reg [31:0] wr_data;
+  reg [31:0] wr_sel;
+  reg axi_awset;
+  reg axi_wset;
+  reg axi_wdone;
+  reg rd_req;
+  reg rd_ack;
+  reg [19:2] rd_addr;
+  reg [31:0] rd_data;
+  reg axi_arset;
+  reg axi_rdone;
+  wire [7:0] mem_r1_int_dato;
+  wire [7:0] mem_r1_ext_dat;
+  reg mem_r1_rreq;
+  reg mem_r1_rack;
+  reg mem_r1_int_wr;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [19:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+  reg [31:0] wr_sel_d0;
+  wire mem_wr;
+  wire mem_wreq;
+  reg [9:0] mem_adr_int;
+  reg [3:0] mem_sel_int;
+
+  // AW, W and B channels
+  assign awready = ~axi_awset;
+  assign wready = ~axi_wset;
+  assign bvalid = axi_wdone;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        wr_req <= 1'b0;
+        axi_awset <= 1'b0;
+        axi_wset <= 1'b0;
+        axi_wdone <= 1'b0;
+      end
+    else
+      begin
+        wr_req <= 1'b0;
+        if (awvalid == 1'b1 & axi_awset == 1'b0)
+          begin
+            wr_addr <= awaddr;
+            axi_awset <= 1'b1;
+            wr_req <= axi_wset;
+          end
+        if (wvalid == 1'b1 & axi_wset == 1'b0)
+          begin
+            wr_data <= wdata;
+            wr_sel[7:0] <= {8{wstrb[0]}};
+            wr_sel[15:8] <= {8{wstrb[1]}};
+            wr_sel[23:16] <= {8{wstrb[2]}};
+            wr_sel[31:24] <= {8{wstrb[3]}};
+            axi_wset <= 1'b1;
+            wr_req <= axi_awset | awvalid;
+          end
+        if ((axi_wdone & bready) == 1'b1)
+          begin
+            axi_wset <= 1'b0;
+            axi_awset <= 1'b0;
+            axi_wdone <= 1'b0;
+          end
+        if (wr_ack == 1'b1)
+          axi_wdone <= 1'b1;
+      end
+  end
+  assign bresp = 2'b00;
+
+  // AR and R channels
+  assign arready = ~axi_arset;
+  assign rvalid = axi_rdone;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        rd_req <= 1'b0;
+        axi_arset <= 1'b0;
+        axi_rdone <= 1'b0;
+        rdata <= 32'b0;
+      end
+    else
+      begin
+        rd_req <= 1'b0;
+        if (arvalid == 1'b1 & axi_arset == 1'b0)
+          begin
+            rd_addr <= araddr;
+            axi_arset <= 1'b1;
+            rd_req <= 1'b1;
+          end
+        if ((axi_rdone & rready) == 1'b1)
+          begin
+            axi_arset <= 1'b0;
+            axi_rdone <= 1'b0;
+          end
+        if (rd_ack == 1'b1)
+          begin
+            axi_rdone <= 1'b1;
+            rdata <= rd_data;
+          end
+      end
+  end
+  assign rresp = 2'b00;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        rd_ack <= 1'b0;
+        rd_data <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 18'b000000000000000000;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+        wr_sel_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack <= rd_ack_d0;
+        rd_data <= rd_dat_d0;
+        wr_req_d0 <= wr_req;
+        wr_adr_d0 <= wr_addr;
+        wr_dat_d0 <= wr_data;
+        wr_sel_d0 <= wr_sel;
+      end
+  end
+
+  // Memory mem
+  always @(rd_addr, wr_adr_d0, mem_wr)
+  if (mem_wr == 1'b1)
+    mem_adr_int = wr_adr_d0[11:2];
+  else
+    mem_adr_int = rd_addr[11:2];
+  assign mem_wreq = mem_r1_int_wr;
+  assign mem_wr = mem_wreq;
+  cheby_dpssram #(
+      .g_data_width(8),
+      .g_size(1024),
+      .g_addr_width(10),
+      .g_dual_clock(1'b0),
+      .g_use_bwsel(1'b1)
+    )
+  mem_r1_raminst (
+      .clk_a_i(aclk),
+      .clk_b_i(aclk),
+      .addr_a_i(mem_adr_int),
+      .bwsel_a_i(mem_sel_int[0:0]),
+      .data_a_i(wr_dat_d0[7:0]),
+      .data_a_o(mem_r1_int_dato),
+      .rd_a_i(mem_r1_rreq),
+      .wr_a_i(mem_r1_int_wr),
+      .addr_b_i(mem_adr_i),
+      .bwsel_b_i({1{1'b1}}),
+      .data_b_i(mem_r1_ext_dat),
+      .data_b_o(mem_r1_dat_o),
+      .rd_b_i(mem_r1_rd_i),
+      .wr_b_i(1'b0)
+    );
+  
+  always @(wr_sel_d0)
+  begin
+    mem_sel_int = 4'b0;
+    if (~(wr_sel_d0[7:0] == 8'b0))
+      mem_sel_int[0] = 1'b1;
+    if (~(wr_sel_d0[15:8] == 8'b0))
+      mem_sel_int[1] = 1'b1;
+    if (~(wr_sel_d0[23:16] == 8'b0))
+      mem_sel_int[2] = 1'b1;
+    if (~(wr_sel_d0[31:24] == 8'b0))
+      mem_sel_int[3] = 1'b1;
+  end
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      mem_r1_rack <= 1'b0;
+    else
+      mem_r1_rack <= (mem_r1_rreq & ~mem_wreq) & ~mem_r1_rack;
+  end
+
+  // Process for write requests.
+  always @(wr_req_d0)
+  begin
+    mem_r1_int_wr = 1'b0;
+    // Memory mem
+    mem_r1_int_wr = wr_req_d0;
+    wr_ack = wr_req_d0;
+  end
+
+  // Process for read requests.
+  always @(mem_r1_int_dato, rd_req, mem_wreq, mem_r1_rack)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    mem_r1_rreq = 1'b0;
+    // Memory mem
+    rd_dat_d0 = {24'b000000000000000000000000, mem_r1_int_dato};
+    mem_r1_rreq = rd_req & ~mem_wreq;
+    rd_ack_d0 = mem_r1_rack;
+  end
+endmodule

--- a/testfiles/issue92/blockInMap.sv
+++ b/testfiles/issue92/blockInMap.sv
@@ -22,7 +22,7 @@ module blockInMap
   assign VMEWrDone = wr_ack_int;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(Clk))
+  always_ff @(posedge(Clk))
   begin
     if (!rst_n)
       begin
@@ -39,14 +39,14 @@ module blockInMap
   end
 
   // Process for write requests.
-  always @(wr_req_d0)
-  wr_ack_int <= wr_req_d0;
+  always_comb
+  wr_ack_int = wr_req_d0;
 
   // Process for read requests.
-  always @(VMERdMem)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
-    rd_ack_d0 <= VMERdMem;
+    rd_dat_d0 = {32{1'bx}};
+    rd_ack_d0 = VMERdMem;
   end
 endmodule

--- a/testfiles/issue92/blockInMap.v
+++ b/testfiles/issue92/blockInMap.v
@@ -1,0 +1,52 @@
+
+module blockInMap
+  (
+    input   wire Clk,
+    input   wire Rst,
+    input   wire [13:2] VMEAddr,
+    output  reg [31:0] VMERdData,
+    input   wire [31:0] VMEWrData,
+    input   wire VMERdMem,
+    input   wire VMEWrMem,
+    output  wire VMERdDone,
+    output  wire VMEWrDone
+  );
+  wire rst_n;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  assign rst_n = ~Rst;
+  assign VMERdDone = rd_ack_int;
+  assign VMEWrDone = wr_ack_int;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(Clk))
+  begin
+    if (!rst_n)
+      begin
+        rd_ack_int <= 1'b0;
+        VMERdData <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        VMERdData <= rd_dat_d0;
+        wr_req_d0 <= VMEWrMem;
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_req_d0)
+  wr_ack_int = wr_req_d0;
+
+  // Process for read requests.
+  always @(VMERdMem)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    rd_ack_d0 = VMERdMem;
+  end
+endmodule

--- a/testfiles/memory01/mainMap.sv
+++ b/testfiles/memory01/mainMap.sv
@@ -31,7 +31,7 @@ module mainMap
   assign VMEWrDone = wr_ack_int;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(Clk))
+  always_ff @(posedge(Clk))
   begin
     if (!rst_n)
       begin
@@ -72,7 +72,7 @@ module mainMap
       .wr_b_i(acqVP_value_we_i)
     );
   
-  always @(posedge(Clk))
+  always_ff @(posedge(Clk))
   begin
     if (!rst_n)
       acqVP_value_rack <= 1'b0;
@@ -81,19 +81,19 @@ module mainMap
   end
 
   // Process for write requests.
-  always @(wr_req_d0)
+  always_comb
   // Memory acqVP
-  wr_ack_int <= wr_req_d0;
+  wr_ack_int = wr_req_d0;
 
   // Process for read requests.
-  always @(acqVP_value_int_dato, VMERdMem, acqVP_value_rack)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
-    acqVP_value_rreq <= 1'b0;
+    rd_dat_d0 = {32{1'bx}};
+    acqVP_value_rreq = 1'b0;
     // Memory acqVP
-    rd_dat_d0 <= {16'b0000000000000000, acqVP_value_int_dato};
-    acqVP_value_rreq <= VMERdMem;
-    rd_ack_d0 <= acqVP_value_rack;
+    rd_dat_d0 = {16'b0000000000000000, acqVP_value_int_dato};
+    acqVP_value_rreq = VMERdMem;
+    rd_ack_d0 = acqVP_value_rack;
   end
 endmodule

--- a/testfiles/memory01/mainMap.v
+++ b/testfiles/memory01/mainMap.v
@@ -1,0 +1,99 @@
+
+module mainMap
+  (
+    input   wire Clk,
+    input   wire Rst,
+    input   wire [19:2] VMEAddr,
+    output  reg [31:0] VMERdData,
+    input   wire [31:0] VMEWrData,
+    input   wire VMERdMem,
+    input   wire VMEWrMem,
+    output  wire VMERdDone,
+    output  wire VMEWrDone,
+
+    // RAM port for acqVP
+    input   wire [8:0] acqVP_adr_i,
+    input   wire acqVP_value_we_i,
+    input   wire [15:0] acqVP_value_dat_i
+  );
+  wire rst_n;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire [15:0] acqVP_value_int_dato;
+  wire [15:0] acqVP_value_ext_dat;
+  reg acqVP_value_rreq;
+  reg acqVP_value_rack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  assign rst_n = ~Rst;
+  assign VMERdDone = rd_ack_int;
+  assign VMEWrDone = wr_ack_int;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(Clk))
+  begin
+    if (!rst_n)
+      begin
+        rd_ack_int <= 1'b0;
+        VMERdData <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        VMERdData <= rd_dat_d0;
+        wr_req_d0 <= VMEWrMem;
+      end
+  end
+
+  // Memory acqVP
+  cheby_dpssram #(
+      .g_data_width(16),
+      .g_size(512),
+      .g_addr_width(9),
+      .g_dual_clock(1'b0),
+      .g_use_bwsel(1'b0)
+    )
+  acqVP_value_raminst (
+      .clk_a_i(Clk),
+      .clk_b_i(Clk),
+      .addr_a_i(VMEAddr[10:2]),
+      .bwsel_a_i({2{1'b1}}),
+      .data_a_i({16{1'bx}}),
+      .data_a_o(acqVP_value_int_dato),
+      .rd_a_i(acqVP_value_rreq),
+      .wr_a_i(1'b0),
+      .addr_b_i(acqVP_adr_i),
+      .bwsel_b_i({2{1'b1}}),
+      .data_b_i(acqVP_value_dat_i),
+      .data_b_o(acqVP_value_ext_dat),
+      .rd_b_i(1'b0),
+      .wr_b_i(acqVP_value_we_i)
+    );
+  
+  always @(posedge(Clk))
+  begin
+    if (!rst_n)
+      acqVP_value_rack <= 1'b0;
+    else
+      acqVP_value_rack <= acqVP_value_rreq;
+  end
+
+  // Process for write requests.
+  always @(wr_req_d0)
+  // Memory acqVP
+  wr_ack_int = wr_req_d0;
+
+  // Process for read requests.
+  always @(acqVP_value_int_dato, VMERdMem, acqVP_value_rack)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    acqVP_value_rreq = 1'b0;
+    // Memory acqVP
+    rd_dat_d0 = {16'b0000000000000000, acqVP_value_int_dato};
+    acqVP_value_rreq = VMERdMem;
+    rd_ack_d0 = acqVP_value_rack;
+  end
+endmodule

--- a/testfiles/memory01/sramro.sv
+++ b/testfiles/memory01/sramro.sv
@@ -23,12 +23,12 @@ module sramro
   reg wr_req_d0;
 
   // WB decode signals
-  always @(wb.sel)
+  always_comb
   ;
   assign adr_int = wb.adr[7:2];
   assign wb_en = wb.cyc & wb.stb;
 
-  always @(posedge(wb.clk))
+  always_ff @(posedge(wb.clk))
   begin
     if (!wb.rst_n)
       wb_rip <= 1'b0;
@@ -37,7 +37,7 @@ module sramro
   end
   assign rd_req_int = (wb_en & ~wb.we) & ~wb_rip;
 
-  always @(posedge(wb.clk))
+  always_ff @(posedge(wb.clk))
   begin
     if (!wb.rst_n)
       wb_wip <= 1'b0;
@@ -53,7 +53,7 @@ module sramro
   assign wb.err = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(wb.clk))
+  always_ff @(posedge(wb.clk))
   begin
     if (!wb.rst_n)
       begin
@@ -70,7 +70,7 @@ module sramro
   end
 
   // Interface mymem
-  always @(posedge(wb.clk))
+  always_ff @(posedge(wb.clk))
   begin
     if (!wb.rst_n)
       mymem_rack <= 1'b0;
@@ -80,19 +80,19 @@ module sramro
   assign mymem_addr_o = adr_int[7:2];
 
   // Process for write requests.
-  always @(wr_req_d0)
+  always_comb
   // Memory mymem
-  wr_ack_int <= wr_req_d0;
+  wr_ack_int = wr_req_d0;
 
   // Process for read requests.
-  always @(mymem_data_i, mymem_rack, rd_req_int)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
-    mymem_re <= 1'b0;
+    rd_dat_d0 = {32{1'bx}};
+    mymem_re = 1'b0;
     // Memory mymem
-    rd_dat_d0 <= mymem_data_i;
-    rd_ack_d0 <= mymem_rack;
-    mymem_re <= rd_req_int;
+    rd_dat_d0 = mymem_data_i;
+    rd_ack_d0 = mymem_rack;
+    mymem_re = rd_req_int;
   end
 endmodule

--- a/testfiles/memory01/sramro.v
+++ b/testfiles/memory01/sramro.v
@@ -1,0 +1,98 @@
+
+module sramro
+  (
+    t_wishbone.slave wb,
+
+    // SRAM bus mymem
+    output  wire [7:2] mymem_addr_o,
+    input   wire [31:0] mymem_data_i
+  );
+  wire [7:2] adr_int;
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg mymem_rack;
+  reg mymem_re;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+
+  // WB decode signals
+  always @(wb.sel)
+  ;
+  assign adr_int = wb.adr[7:2];
+  assign wb_en = wb.cyc & wb.stb;
+
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb.we)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb.we) & ~wb_rip;
+
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb.we)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb.we) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb.ack = ack_int;
+  assign wb.stall = ~ack_int & wb_en;
+  assign wb.rty = 1'b0;
+  assign wb.err = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      begin
+        rd_ack_int <= 1'b0;
+        wb.dati <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb.dati <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+      end
+  end
+
+  // Interface mymem
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      mymem_rack <= 1'b0;
+    else
+      mymem_rack <= mymem_re & ~mymem_rack;
+  end
+  assign mymem_addr_o = adr_int[7:2];
+
+  // Process for write requests.
+  always @(wr_req_d0)
+  // Memory mymem
+  wr_ack_int = wr_req_d0;
+
+  // Process for read requests.
+  always @(mymem_data_i, mymem_rack, rd_req_int)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    mymem_re = 1'b0;
+    // Memory mymem
+    rd_dat_d0 = mymem_data_i;
+    rd_ack_d0 = mymem_rack;
+    mymem_re = rd_req_int;
+  end
+endmodule

--- a/testfiles/memory01/sramrw.v
+++ b/testfiles/memory01/sramrw.v
@@ -1,0 +1,125 @@
+
+module sramrw
+  (
+    t_wishbone.slave wb,
+
+    // SRAM bus mymem
+    output  reg [7:2] mymem_addr_o,
+    input   wire [31:0] mymem_data_i,
+    output  wire [31:0] mymem_data_o,
+    output  reg mymem_wr_o
+  );
+  wire [7:2] adr_int;
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg mymem_rack;
+  reg mymem_re;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [7:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+  reg mymem_wp;
+  wire mymem_we;
+
+  // WB decode signals
+  always @(wb.sel)
+  ;
+  assign adr_int = wb.adr[7:2];
+  assign wb_en = wb.cyc & wb.stb;
+
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb.we)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb.we) & ~wb_rip;
+
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb.we)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb.we) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb.ack = ack_int;
+  assign wb.stall = ~ack_int & wb_en;
+  assign wb.rty = 1'b0;
+  assign wb.err = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      begin
+        rd_ack_int <= 1'b0;
+        wb.dati <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 6'b000000;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb.dati <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_adr_d0 <= adr_int;
+        wr_dat_d0 <= wb.dato;
+      end
+  end
+
+  // Interface mymem
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      mymem_rack <= 1'b0;
+    else
+      mymem_rack <= mymem_re & ~mymem_rack;
+  end
+  assign mymem_data_o = wr_dat_d0;
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      mymem_wp <= 1'b0;
+    else
+      mymem_wp <= (wr_req_d0 | mymem_wp) & rd_req_int;
+  end
+  assign mymem_we = (wr_req_d0 | mymem_wp) & ~rd_req_int;
+  always @(adr_int, wr_adr_d0, mymem_re)
+  if (mymem_re == 1'b1)
+    mymem_addr_o = adr_int[7:2];
+  else
+    mymem_addr_o = wr_adr_d0[7:2];
+
+  // Process for write requests.
+  always @(mymem_we)
+  begin
+    mymem_wr_o = 1'b0;
+    // Memory mymem
+    mymem_wr_o = mymem_we;
+    wr_ack_int = mymem_we;
+  end
+
+  // Process for read requests.
+  always @(mymem_data_i, mymem_rack, rd_req_int)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    mymem_re = 1'b0;
+    // Memory mymem
+    rd_dat_d0 = mymem_data_i;
+    rd_ack_d0 = mymem_rack;
+    mymem_re = rd_req_int;
+  end
+endmodule

--- a/testfiles/memory01/sramwo.sv
+++ b/testfiles/memory01/sramwo.sv
@@ -24,12 +24,12 @@ module sramwo
   reg [31:0] wr_dat_d0;
 
   // WB decode signals
-  always @(wb.sel)
+  always_comb
   ;
   assign adr_int = wb.adr[7:2];
   assign wb_en = wb.cyc & wb.stb;
 
-  always @(posedge(wb.clk))
+  always_ff @(posedge(wb.clk))
   begin
     if (!wb.rst_n)
       wb_rip <= 1'b0;
@@ -38,7 +38,7 @@ module sramwo
   end
   assign rd_req_int = (wb_en & ~wb.we) & ~wb_rip;
 
-  always @(posedge(wb.clk))
+  always_ff @(posedge(wb.clk))
   begin
     if (!wb.rst_n)
       wb_wip <= 1'b0;
@@ -54,7 +54,7 @@ module sramwo
   assign wb.err = 1'b0;
 
   // pipelining for wr-in+rd-out
-  always @(posedge(wb.clk))
+  always_ff @(posedge(wb.clk))
   begin
     if (!wb.rst_n)
       begin
@@ -79,20 +79,20 @@ module sramwo
   assign mymem_addr_o = wr_adr_d0[7:2];
 
   // Process for write requests.
-  always @(wr_req_d0)
+  always_comb
   begin
-    mymem_wr_o <= 1'b0;
+    mymem_wr_o = 1'b0;
     // Memory mymem
-    mymem_wr_o <= wr_req_d0;
-    wr_ack_int <= wr_req_d0;
+    mymem_wr_o = wr_req_d0;
+    wr_ack_int = wr_req_d0;
   end
 
   // Process for read requests.
-  always @(rd_req_int)
+  always_comb
   begin
     // By default ack read requests
-    rd_dat_d0 <= {32{1'bx}};
+    rd_dat_d0 = {32{1'bx}};
     // Memory mymem
-    rd_ack_d0 <= rd_req_int;
+    rd_ack_d0 = rd_req_int;
   end
 endmodule

--- a/testfiles/memory01/sramwo.v
+++ b/testfiles/memory01/sramwo.v
@@ -1,0 +1,98 @@
+
+module sramwo
+  (
+    t_wishbone.slave wb,
+
+    // SRAM bus mymem
+    output  wire [7:2] mymem_addr_o,
+    output  wire [31:0] mymem_data_o,
+    output  reg mymem_wr_o
+  );
+  wire [7:2] adr_int;
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [7:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+
+  // WB decode signals
+  always @(wb.sel)
+  ;
+  assign adr_int = wb.adr[7:2];
+  assign wb_en = wb.cyc & wb.stb;
+
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb.we)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb.we) & ~wb_rip;
+
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb.we)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb.we) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb.ack = ack_int;
+  assign wb.stall = ~ack_int & wb_en;
+  assign wb.rty = 1'b0;
+  assign wb.err = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(wb.clk))
+  begin
+    if (!wb.rst_n)
+      begin
+        rd_ack_int <= 1'b0;
+        wb.dati <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 6'b000000;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb.dati <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_adr_d0 <= adr_int;
+        wr_dat_d0 <= wb.dato;
+      end
+  end
+
+  // Interface mymem
+  assign mymem_data_o = wr_dat_d0;
+  assign mymem_addr_o = wr_adr_d0[7:2];
+
+  // Process for write requests.
+  always @(wr_req_d0)
+  begin
+    mymem_wr_o = 1'b0;
+    // Memory mymem
+    mymem_wr_o = wr_req_d0;
+    wr_ack_int = wr_req_d0;
+  end
+
+  // Process for read requests.
+  always @(rd_req_int)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    // Memory mymem
+    rd_ack_d0 = rd_req_int;
+  end
+endmodule


### PR DESCRIPTION
Follow-up from https://github.com/tgingold-cern/cheby/pull/31

Given that the intent is to support both SystemVerilog and Verilog (at least partially), I think we should test the generation of both in CI. This PR implements that and fixes one issue that was detected using the new elboration test.

### Functional changes

- Use blocking '=' for comb, non-blocking '<=' for sync (sequential) logic. 
  * This is one of the 'Golden Rules of Verilog', see C. E. Cummings, "Nonblocking Assignments in Verilog Synthesis, Coding Styles That Kill!" (http://www.sunburst-design.com/papers/CummingsSNUG2000SJ_NBA_rev1_2.pdf). Not following this rule can lead to weird behaviour in Simulation. Using `<=` in an `always_comb` also results in a Verilator warning (https://verilator.org/guide/latest/warnings.html#cmdoption-arg-COMBDLY).

### Testing changes

 - Generate and elaborate both SV and Verilog RTL files separately. 
 - Update the golden test files.