### PR TITLE
Add separate write mask port for (read-)write wire fields

### DIFF
--- a/proto/cheby/hdl/genreg.py
+++ b/proto/cheby/hdl/genreg.py
@@ -227,44 +227,23 @@ class GenFieldWire(GenFieldBase):
     def connect_output(self, stmts, ibus):
         # Handle wire fields: create connections between the bus and the outputs.
         for off in self.get_offset_range():
-            lo, w = self.extract_reg_bounds(off)
+            reg, dat, mask = self.extract_reg_dat(
+                off, self.field.h_oport, ibus.wr_dat, ibus.wr_sel
+            )
 
-            wire_out = self.extract_reg2(self.field.h_oport, lo, w)
-            wire_in = self.extract_reg2(self.field.h_iport, lo, w)
-            w_data = self.extract_dat2(ibus.wr_dat, self.field.lo + lo - off, w)
-            w_mask = self.extract_mask2(ibus.wr_sel, self.field.lo + lo - off, w)
-
-            # Regular assignment
-            field_assign = HDLAssign(wire_out, w_data)
-            field_depend = [w_data]
-
-            # Apply mask to assignment (only for rw, i.e. if wire_in exists)
-            if (
-                hasattr(self.root, "hdl_wmask")
-                and self.root.hdl_wmask
-                and w_mask is not None
-                and wire_in
-            ):
-                field_assign = HDLAssign(
-                    wire_out,
-                    HDLOr(
-                        HDLParen(HDLAnd(wire_in, HDLNot(w_mask))),
-                        HDLParen(HDLAnd(w_data, w_mask)),
-                    ),
-                )
-                field_depend = [wire_in, w_data, w_mask]
+            field_assign = HDLAssign(reg, dat)
 
             # Apply lock-value signal
             if self.field.hdl_lock_value and (
                 hasattr(self.root, "h_lock_port") and self.root.h_lock_port
             ):
                 proc = HDLComb()
-                proc.sensitivity.extend([self.root.h_lock_port] + field_depend)
+                proc.sensitivity.extend([self.root.h_lock_port, dat])
                 proc.stmts.append(HDLComment("Overwrite output with lock value"))
                 proc_if = HDLIfElse(HDLEq(self.root.h_lock_port, bit_1))
                 proc_if.then_stmts.append(
                     HDLAssign(
-                        wire_out,
+                        reg,
                         HDLConst(
                             self.field.hdl_lock_value,
                             self.field.c_rwidth if self.field.c_rwidth != 1 else None,
@@ -276,6 +255,10 @@ class GenFieldWire(GenFieldBase):
                 field_assign = proc
 
             stmts.append(field_assign)
+
+            # Output mask on separate port if available (and wmask active)
+            if mask is not None and self.field.h_wmask_port is not None:
+                stmts.append(HDLAssign(self.field.h_wmask_port, mask))
 
 
 class GenFieldConst(GenFieldBase):
@@ -474,14 +457,15 @@ class GenReg(ElGen):
 
     def gen_ports(self):
         """Add ports and wires for register or fields of :param n:
-           :field h_reg: the register.
-           :field h_wreq: the internal write request signal.
-           :field h_iport: the input port.
-           :field h_oport: the output port.
-           :field h_wreq_port: the write strobe port.
-           :field h_rreq_port: the read strobe port.
-           :field h_rack_port: the read ack port.
-           :field h_wack_port: the write ack port.
+        :field h_reg: the register.
+        :field h_wreq: the internal write request signal.
+        :field h_iport: the input port.
+        :field h_oport: the output port.
+        :field h_wreq_port: the write strobe port.
+        :field h_rreq_port: the read strobe port.
+        :field h_rack_port: the read ack port.
+        :field h_wack_port: the write ack port.
+        :field h_wmask_port: the write mask output port.
         """
         n = self.n
         # Single port when 'port: reg' is set.
@@ -526,21 +510,59 @@ class GenReg(ElGen):
                 f.h_iport = None
 
             # Output
+            f.h_wmask_port = None
+
             if need_oport:
-                if n.hdl_port == 'reg':
+                if n.hdl_port == "reg":
                     # One port used for all fields.
                     if oport is None:
-                        name = self.get_port_name(n, '', 'o', need_iport)
-                        oport = self.add_module_port(name, n.width, dir='OUT')
+                        oport_name = self.get_port_name(n, "", "o", need_iport)
+                        oport = self.add_module_port(oport_name, n.width, dir="OUT")
                         oport.comment = comment
                         comment = None
+
+                        # Write mask port
+                        # (only used by wo/rw wire fields with active wmask)
+                        if (
+                            f.hdl_type == "wire"
+                            and hasattr(self.root, "hdl_wmask")
+                            and self.root.hdl_wmask
+                        ):
+                            wmask_port_name = self.get_port_name(
+                                n, "_wmask", "o", need_iport
+                            )
+                            wmask_port = self.add_module_port(
+                                wmask_port_name, n.width, dir="OUT"
+                            )
+
                     f.h_oport = Slice_or_Index(oport, f.lo, w)
+
+                    if (
+                        f.hdl_type == "wire"
+                        and hasattr(self.root, "hdl_wmask")
+                        and self.root.hdl_wmask
+                    ):
+                        f.h_wmask_port = Slice_or_Index(wmask_port, f.lo, w)
+
                 else:
                     # One port per field.
-                    name = self.get_port_name(f, '', 'o', need_iport)
-                    f.h_oport = self.add_module_port(name, w, dir='OUT')
+                    oport_name = self.get_port_name(f, "", "o", need_iport)
+                    f.h_oport = self.add_module_port(oport_name, w, dir="OUT")
                     f.h_oport.comment = comment
                     comment = None
+
+                    # Write mask port (only used by wo/rw wire fields with active wmask)
+                    if (
+                        f.hdl_type == "wire"
+                        and hasattr(self.root, "hdl_wmask")
+                        and self.root.hdl_wmask
+                    ):
+                        wmask_port_name = self.get_port_name(
+                            f, "_wmask", "o", need_iport
+                        )
+                        f.h_wmask_port = self.add_module_port(
+                            wmask_port_name, w, dir="OUT"
+                        )
             else:
                 f.h_oport = None
 

--- a/testfiles/tb/golden_files/wmask_apb.vhdl
+++ b/testfiles/tb/golden_files/wmask_apb.vhdl
@@ -29,12 +29,14 @@ entity wmask_apb is
     -- REG wire_rw
     wire_rw_i            : in    std_logic_vector(31 downto 0);
     wire_rw_o            : out   std_logic_vector(31 downto 0);
+    wire_rw_wmask_o      : out   std_logic_vector(31 downto 0);
 
     -- REG wire_ro
     wire_ro_i            : in    std_logic_vector(31 downto 0);
 
     -- REG wire_wo
     wire_wo_o            : out   std_logic_vector(31 downto 0);
+    wire_wo_wmask_o      : out   std_logic_vector(31 downto 0);
 
     -- RAM port for ram1
     ram1_adr_i           : in    std_logic_vector(2 downto 0);
@@ -150,12 +152,14 @@ begin
   end process;
 
   -- Register wire_rw
-  wire_rw_o <= (wire_rw_i and not wr_sel_d0) or (wr_dat_d0 and wr_sel_d0);
+  wire_rw_o <= wr_dat_d0;
+  wire_rw_wmask_o <= wr_sel_d0;
 
   -- Register wire_ro
 
   -- Register wire_wo
   wire_wo_o <= wr_dat_d0;
+  wire_wo_wmask_o <= wr_sel_d0;
 
   -- Memory ram1
   process (rd_addr, wr_adr_d0, ram1_wr) begin

--- a/testfiles/tb/golden_files/wmask_apb.vhdl
+++ b/testfiles/tb/golden_files/wmask_apb.vhdl
@@ -17,8 +17,24 @@ entity wmask_apb is
     prdata               : out   std_logic_vector(31 downto 0);
     pslverr              : out   std_logic;
 
-    -- REG reg1
-    reg1_o               : out   std_logic_vector(31 downto 0);
+    -- REG reg_rw
+    reg_rw_o             : out   std_logic_vector(31 downto 0);
+
+    -- REG reg_ro
+    reg_ro_i             : in    std_logic_vector(31 downto 0);
+
+    -- REG reg_wo
+    reg_wo_o             : out   std_logic_vector(31 downto 0);
+
+    -- REG wire_rw
+    wire_rw_i            : in    std_logic_vector(31 downto 0);
+    wire_rw_o            : out   std_logic_vector(31 downto 0);
+
+    -- REG wire_ro
+    wire_ro_i            : in    std_logic_vector(31 downto 0);
+
+    -- REG wire_wo
+    wire_wo_o            : out   std_logic_vector(31 downto 0);
 
     -- RAM port for ram1
     ram1_adr_i           : in    std_logic_vector(2 downto 0);
@@ -37,9 +53,12 @@ architecture syn of wmask_apb is
   signal rd_data                        : std_logic_vector(31 downto 0);
   signal wr_ack                         : std_logic;
   signal rd_ack                         : std_logic;
-  signal reg1_reg                       : std_logic_vector(31 downto 0);
-  signal reg1_wreq                      : std_logic;
-  signal reg1_wack                      : std_logic;
+  signal reg_rw_reg                     : std_logic_vector(31 downto 0);
+  signal reg_rw_wreq                    : std_logic;
+  signal reg_rw_wack                    : std_logic;
+  signal reg_wo_reg                     : std_logic_vector(31 downto 0);
+  signal reg_wo_wreq                    : std_logic;
+  signal reg_wo_wack                    : std_logic;
   signal ram1_row1_int_dato             : std_logic_vector(31 downto 0);
   signal ram1_row1_ext_dat              : std_logic_vector(31 downto 0);
   signal ram1_row1_rreq                 : std_logic;
@@ -96,21 +115,47 @@ begin
     end if;
   end process;
 
-  -- Register reg1
-  reg1_o <= reg1_reg;
+  -- Register reg_rw
+  reg_rw_o <= reg_rw_reg;
   process (pclk) begin
     if rising_edge(pclk) then
       if presetn = '0' then
-        reg1_reg <= "00000000000000000000000000000000";
-        reg1_wack <= '0';
+        reg_rw_reg <= "00000000000000000000000000000000";
+        reg_rw_wack <= '0';
       else
-        if reg1_wreq = '1' then
-          reg1_reg <= (reg1_reg and not wr_sel_d0) or (wr_dat_d0 and wr_sel_d0);
+        if reg_rw_wreq = '1' then
+          reg_rw_reg <= (reg_rw_reg and not wr_sel_d0) or (wr_dat_d0 and wr_sel_d0);
         end if;
-        reg1_wack <= reg1_wreq;
+        reg_rw_wack <= reg_rw_wreq;
       end if;
     end if;
   end process;
+
+  -- Register reg_ro
+
+  -- Register reg_wo
+  reg_wo_o <= reg_wo_reg;
+  process (pclk) begin
+    if rising_edge(pclk) then
+      if presetn = '0' then
+        reg_wo_reg <= "00000000000000000000000000000000";
+        reg_wo_wack <= '0';
+      else
+        if reg_wo_wreq = '1' then
+          reg_wo_reg <= (reg_wo_reg and not wr_sel_d0) or (wr_dat_d0 and wr_sel_d0);
+        end if;
+        reg_wo_wack <= reg_wo_wreq;
+      end if;
+    end if;
+  end process;
+
+  -- Register wire_rw
+  wire_rw_o <= (wire_rw_i and not wr_sel_d0) or (wr_dat_d0 and wr_sel_d0);
+
+  -- Register wire_ro
+
+  -- Register wire_wo
+  wire_wo_o <= wr_dat_d0;
 
   -- Memory ram1
   process (rd_addr, wr_adr_d0, ram1_wr) begin
@@ -173,16 +218,33 @@ begin
   end process;
 
   -- Process for write requests.
-  process (wr_adr_d0, wr_req_d0, reg1_wack) begin
-    reg1_wreq <= '0';
+  process (wr_adr_d0, wr_req_d0, reg_rw_wack, reg_wo_wack) begin
+    reg_rw_wreq <= '0';
+    reg_wo_wreq <= '0';
     ram1_row1_int_wr <= '0';
     case wr_adr_d0(5 downto 5) is
     when "0" =>
       case wr_adr_d0(4 downto 2) is
       when "000" =>
-        -- Reg reg1
-        reg1_wreq <= wr_req_d0;
-        wr_ack <= reg1_wack;
+        -- Reg reg_rw
+        reg_rw_wreq <= wr_req_d0;
+        wr_ack <= reg_rw_wack;
+      when "001" =>
+        -- Reg reg_ro
+        wr_ack <= wr_req_d0;
+      when "010" =>
+        -- Reg reg_wo
+        reg_wo_wreq <= wr_req_d0;
+        wr_ack <= reg_wo_wack;
+      when "011" =>
+        -- Reg wire_rw
+        wr_ack <= wr_req_d0;
+      when "100" =>
+        -- Reg wire_ro
+        wr_ack <= wr_req_d0;
+      when "101" =>
+        -- Reg wire_wo
+        wr_ack <= wr_req_d0;
       when others =>
         wr_ack <= wr_req_d0;
       end case;
@@ -196,7 +258,8 @@ begin
   end process;
 
   -- Process for read requests.
-  process (rd_addr, rd_req, reg1_reg, ram1_row1_int_dato, ram1_wreq, ram1_row1_rack) begin
+  process (rd_addr, rd_req, reg_rw_reg, reg_ro_i, wire_rw_i, wire_ro_i,
+           ram1_row1_int_dato, ram1_wreq, ram1_row1_rack) begin
     -- By default ack read requests
     rd_dat_d0 <= (others => 'X');
     ram1_row1_rreq <= '0';
@@ -204,9 +267,27 @@ begin
     when "0" =>
       case rd_addr(4 downto 2) is
       when "000" =>
-        -- Reg reg1
+        -- Reg reg_rw
         rd_ack_d0 <= rd_req;
-        rd_dat_d0 <= reg1_reg;
+        rd_dat_d0 <= reg_rw_reg;
+      when "001" =>
+        -- Reg reg_ro
+        rd_ack_d0 <= rd_req;
+        rd_dat_d0 <= reg_ro_i;
+      when "010" =>
+        -- Reg reg_wo
+        rd_ack_d0 <= rd_req;
+      when "011" =>
+        -- Reg wire_rw
+        rd_ack_d0 <= rd_req;
+        rd_dat_d0 <= wire_rw_i;
+      when "100" =>
+        -- Reg wire_ro
+        rd_ack_d0 <= rd_req;
+        rd_dat_d0 <= wire_ro_i;
+      when "101" =>
+        -- Reg wire_wo
+        rd_ack_d0 <= rd_req;
       when others =>
         rd_ack_d0 <= rd_req;
       end case;

--- a/testfiles/tb/golden_files/wmask_avalon.vhdl
+++ b/testfiles/tb/golden_files/wmask_avalon.vhdl
@@ -28,12 +28,14 @@ entity wmask_avalon is
     -- REG wire_rw
     wire_rw_i            : in    std_logic_vector(31 downto 0);
     wire_rw_o            : out   std_logic_vector(31 downto 0);
+    wire_rw_wmask_o      : out   std_logic_vector(31 downto 0);
 
     -- REG wire_ro
     wire_ro_i            : in    std_logic_vector(31 downto 0);
 
     -- REG wire_wo
     wire_wo_o            : out   std_logic_vector(31 downto 0);
+    wire_wo_wmask_o      : out   std_logic_vector(31 downto 0);
 
     -- RAM port for ram1
     ram1_adr_i           : in    std_logic_vector(2 downto 0);
@@ -140,12 +142,14 @@ begin
   end process;
 
   -- Register wire_rw
-  wire_rw_o <= (wire_rw_i and not wr_sel) or (wr_dat and wr_sel);
+  wire_rw_o <= wr_dat;
+  wire_rw_wmask_o <= wr_sel;
 
   -- Register wire_ro
 
   -- Register wire_wo
   wire_wo_o <= wr_dat;
+  wire_wo_wmask_o <= wr_sel;
 
   -- Memory ram1
   ram1_row1_raminst: cheby_dpssram

--- a/testfiles/tb/golden_files/wmask_axi4.vhdl
+++ b/testfiles/tb/golden_files/wmask_axi4.vhdl
@@ -27,8 +27,24 @@ entity wmask_axi4 is
     rdata                : out   std_logic_vector(31 downto 0);
     rresp                : out   std_logic_vector(1 downto 0);
 
-    -- REG reg1
-    reg1_o               : out   std_logic_vector(31 downto 0);
+    -- REG reg_rw
+    reg_rw_o             : out   std_logic_vector(31 downto 0);
+
+    -- REG reg_ro
+    reg_ro_i             : in    std_logic_vector(31 downto 0);
+
+    -- REG reg_wo
+    reg_wo_o             : out   std_logic_vector(31 downto 0);
+
+    -- REG wire_rw
+    wire_rw_i            : in    std_logic_vector(31 downto 0);
+    wire_rw_o            : out   std_logic_vector(31 downto 0);
+
+    -- REG wire_ro
+    wire_ro_i            : in    std_logic_vector(31 downto 0);
+
+    -- REG wire_wo
+    wire_wo_o            : out   std_logic_vector(31 downto 0);
 
     -- RAM port for ram1
     ram1_adr_i           : in    std_logic_vector(2 downto 0);
@@ -52,9 +68,12 @@ architecture syn of wmask_axi4 is
   signal rd_data                        : std_logic_vector(31 downto 0);
   signal axi_arset                      : std_logic;
   signal axi_rdone                      : std_logic;
-  signal reg1_reg                       : std_logic_vector(31 downto 0);
-  signal reg1_wreq                      : std_logic;
-  signal reg1_wack                      : std_logic;
+  signal reg_rw_reg                     : std_logic_vector(31 downto 0);
+  signal reg_rw_wreq                    : std_logic;
+  signal reg_rw_wack                    : std_logic;
+  signal reg_wo_reg                     : std_logic_vector(31 downto 0);
+  signal reg_wo_wreq                    : std_logic;
+  signal reg_wo_wack                    : std_logic;
   signal ram1_row1_int_dato             : std_logic_vector(31 downto 0);
   signal ram1_row1_ext_dat              : std_logic_vector(31 downto 0);
   signal ram1_row1_rreq                 : std_logic;
@@ -163,21 +182,47 @@ begin
     end if;
   end process;
 
-  -- Register reg1
-  reg1_o <= reg1_reg;
+  -- Register reg_rw
+  reg_rw_o <= reg_rw_reg;
   process (aclk) begin
     if rising_edge(aclk) then
       if areset_n = '0' then
-        reg1_reg <= "00000000000000000000000000000000";
-        reg1_wack <= '0';
+        reg_rw_reg <= "00000000000000000000000000000000";
+        reg_rw_wack <= '0';
       else
-        if reg1_wreq = '1' then
-          reg1_reg <= (reg1_reg and not wr_sel_d0) or (wr_dat_d0 and wr_sel_d0);
+        if reg_rw_wreq = '1' then
+          reg_rw_reg <= (reg_rw_reg and not wr_sel_d0) or (wr_dat_d0 and wr_sel_d0);
         end if;
-        reg1_wack <= reg1_wreq;
+        reg_rw_wack <= reg_rw_wreq;
       end if;
     end if;
   end process;
+
+  -- Register reg_ro
+
+  -- Register reg_wo
+  reg_wo_o <= reg_wo_reg;
+  process (aclk) begin
+    if rising_edge(aclk) then
+      if areset_n = '0' then
+        reg_wo_reg <= "00000000000000000000000000000000";
+        reg_wo_wack <= '0';
+      else
+        if reg_wo_wreq = '1' then
+          reg_wo_reg <= (reg_wo_reg and not wr_sel_d0) or (wr_dat_d0 and wr_sel_d0);
+        end if;
+        reg_wo_wack <= reg_wo_wreq;
+      end if;
+    end if;
+  end process;
+
+  -- Register wire_rw
+  wire_rw_o <= (wire_rw_i and not wr_sel_d0) or (wr_dat_d0 and wr_sel_d0);
+
+  -- Register wire_ro
+
+  -- Register wire_wo
+  wire_wo_o <= wr_dat_d0;
 
   -- Memory ram1
   process (rd_addr, wr_adr_d0, ram1_wr) begin
@@ -240,16 +285,33 @@ begin
   end process;
 
   -- Process for write requests.
-  process (wr_adr_d0, wr_req_d0, reg1_wack) begin
-    reg1_wreq <= '0';
+  process (wr_adr_d0, wr_req_d0, reg_rw_wack, reg_wo_wack) begin
+    reg_rw_wreq <= '0';
+    reg_wo_wreq <= '0';
     ram1_row1_int_wr <= '0';
     case wr_adr_d0(5 downto 5) is
     when "0" =>
       case wr_adr_d0(4 downto 2) is
       when "000" =>
-        -- Reg reg1
-        reg1_wreq <= wr_req_d0;
-        wr_ack <= reg1_wack;
+        -- Reg reg_rw
+        reg_rw_wreq <= wr_req_d0;
+        wr_ack <= reg_rw_wack;
+      when "001" =>
+        -- Reg reg_ro
+        wr_ack <= wr_req_d0;
+      when "010" =>
+        -- Reg reg_wo
+        reg_wo_wreq <= wr_req_d0;
+        wr_ack <= reg_wo_wack;
+      when "011" =>
+        -- Reg wire_rw
+        wr_ack <= wr_req_d0;
+      when "100" =>
+        -- Reg wire_ro
+        wr_ack <= wr_req_d0;
+      when "101" =>
+        -- Reg wire_wo
+        wr_ack <= wr_req_d0;
       when others =>
         wr_ack <= wr_req_d0;
       end case;
@@ -263,7 +325,8 @@ begin
   end process;
 
   -- Process for read requests.
-  process (rd_addr, rd_req, reg1_reg, ram1_row1_int_dato, ram1_wreq, ram1_row1_rack) begin
+  process (rd_addr, rd_req, reg_rw_reg, reg_ro_i, wire_rw_i, wire_ro_i,
+           ram1_row1_int_dato, ram1_wreq, ram1_row1_rack) begin
     -- By default ack read requests
     rd_dat_d0 <= (others => 'X');
     ram1_row1_rreq <= '0';
@@ -271,9 +334,27 @@ begin
     when "0" =>
       case rd_addr(4 downto 2) is
       when "000" =>
-        -- Reg reg1
+        -- Reg reg_rw
         rd_ack_d0 <= rd_req;
-        rd_dat_d0 <= reg1_reg;
+        rd_dat_d0 <= reg_rw_reg;
+      when "001" =>
+        -- Reg reg_ro
+        rd_ack_d0 <= rd_req;
+        rd_dat_d0 <= reg_ro_i;
+      when "010" =>
+        -- Reg reg_wo
+        rd_ack_d0 <= rd_req;
+      when "011" =>
+        -- Reg wire_rw
+        rd_ack_d0 <= rd_req;
+        rd_dat_d0 <= wire_rw_i;
+      when "100" =>
+        -- Reg wire_ro
+        rd_ack_d0 <= rd_req;
+        rd_dat_d0 <= wire_ro_i;
+      when "101" =>
+        -- Reg wire_wo
+        rd_ack_d0 <= rd_req;
       when others =>
         rd_ack_d0 <= rd_req;
       end case;

--- a/testfiles/tb/golden_files/wmask_axi4.vhdl
+++ b/testfiles/tb/golden_files/wmask_axi4.vhdl
@@ -39,12 +39,14 @@ entity wmask_axi4 is
     -- REG wire_rw
     wire_rw_i            : in    std_logic_vector(31 downto 0);
     wire_rw_o            : out   std_logic_vector(31 downto 0);
+    wire_rw_wmask_o      : out   std_logic_vector(31 downto 0);
 
     -- REG wire_ro
     wire_ro_i            : in    std_logic_vector(31 downto 0);
 
     -- REG wire_wo
     wire_wo_o            : out   std_logic_vector(31 downto 0);
+    wire_wo_wmask_o      : out   std_logic_vector(31 downto 0);
 
     -- RAM port for ram1
     ram1_adr_i           : in    std_logic_vector(2 downto 0);
@@ -217,12 +219,14 @@ begin
   end process;
 
   -- Register wire_rw
-  wire_rw_o <= (wire_rw_i and not wr_sel_d0) or (wr_dat_d0 and wr_sel_d0);
+  wire_rw_o <= wr_dat_d0;
+  wire_rw_wmask_o <= wr_sel_d0;
 
   -- Register wire_ro
 
   -- Register wire_wo
   wire_wo_o <= wr_dat_d0;
+  wire_wo_wmask_o <= wr_sel_d0;
 
   -- Memory ram1
   process (rd_addr, wr_adr_d0, ram1_wr) begin

--- a/testfiles/tb/golden_files/wmask_wb.vhdl
+++ b/testfiles/tb/golden_files/wmask_wb.vhdl
@@ -31,12 +31,14 @@ entity wmask_wb is
     -- REG wire_rw
     wire_rw_i            : in    std_logic_vector(31 downto 0);
     wire_rw_o            : out   std_logic_vector(31 downto 0);
+    wire_rw_wmask_o      : out   std_logic_vector(31 downto 0);
 
     -- REG wire_ro
     wire_ro_i            : in    std_logic_vector(31 downto 0);
 
     -- REG wire_wo
     wire_wo_o            : out   std_logic_vector(31 downto 0);
+    wire_wo_wmask_o      : out   std_logic_vector(31 downto 0);
 
     -- RAM port for ram1
     ram1_adr_i           : in    std_logic_vector(2 downto 0);
@@ -171,12 +173,14 @@ begin
   end process;
 
   -- Register wire_rw
-  wire_rw_o <= (wire_rw_i and not wr_sel_d0) or (wr_dat_d0 and wr_sel_d0);
+  wire_rw_o <= wr_dat_d0;
+  wire_rw_wmask_o <= wr_sel_d0;
 
   -- Register wire_ro
 
   -- Register wire_wo
   wire_wo_o <= wr_dat_d0;
+  wire_wo_wmask_o <= wr_sel_d0;
 
   -- Memory ram1
   process (wb_adr_i, wr_adr_d0, ram1_wr) begin

--- a/testfiles/tb/wmask.cheby
+++ b/testfiles/tb/wmask.cheby
@@ -5,11 +5,45 @@ memory-map:
     wmask: True
   children:
   - reg:
-      name: reg1
+      name: reg_rw
       type: unsigned
       width: 32
       access: rw
       preset: 0x00000000
+  - reg:
+      name: reg_ro
+      type: unsigned
+      width: 32
+      access: ro
+      preset: 0x00000000
+  - reg:
+      name: reg_wo
+      type: unsigned
+      width: 32
+      access: wo
+  - reg:
+      name: wire_rw
+      type: unsigned
+      width: 32
+      access: rw
+      preset: 0x00000000
+      x-hdl:
+        type: wire
+  - reg:
+      name: wire_ro
+      type: unsigned
+      width: 32
+      access: ro
+      preset: 0x00000000
+      x-hdl:
+        type: wire
+  - reg:
+      name: wire_wo
+      type: unsigned
+      width: 32
+      access: wo
+      x-hdl:
+        type: wire
   - memory:
       name: ram1
       memsize: 32

--- a/testfiles/tb/wmask_apb_tb.vhdl
+++ b/testfiles/tb/wmask_apb_tb.vhdl
@@ -15,8 +15,10 @@ architecture tb of wmask_apb_tb is
   signal apb_in  : t_apb_master_in;
   signal apb_out : t_apb_master_out;
 
-  signal reg_rw  : std_logic_vector(31 downto 0);
-  signal wire_rw : std_logic_vector(31 downto 0);
+  signal reg_rw       : std_logic_vector(31 downto 0);
+  signal wire_rw_in   : std_logic_vector(31 downto 0);
+  signal wire_rw_out  : std_logic_vector(31 downto 0);
+  signal wire_rw_mask : std_logic_vector(31 downto 0);
 
   signal end_of_test : boolean := False;
 begin
@@ -52,14 +54,18 @@ begin
       reg_rw_o        => reg_rw,
       reg_ro_i        => (others => '0'),
       reg_wo_o        => open,
-      wire_rw_i       => wire_rw,
-      wire_rw_o       => wire_rw,
+      wire_rw_i       => wire_rw_in,
+      wire_rw_o       => wire_rw_out,
+      wire_rw_wmask_o => wire_rw_mask,
       wire_ro_i       => (others => '0'),
       wire_wo_o       => open,
+      wire_wo_wmask_o => open,
       ram1_adr_i      => (others => '0'),
       ram1_row1_rd_i  => '0',
       ram1_row1_dat_o => open
     );
+
+  wire_rw_in <= wire_rw_out;
 
   main : process is
     variable v : std_logic_vector(31 downto 0);
@@ -89,6 +95,18 @@ begin
     assert reg_rw = x"9a34_de78" severity error;
     apb_read(clk, apb_out, apb_in, x"0000_0000", v);
     assert v = x"9a34_de78" severity error;
+
+    -- Wire
+    -- Testing regular write write
+    report "Testing regular wire write" severity note;
+    apb_write(clk, apb_out, apb_in, x"0000_0008", x"3456_789a", "1111");
+    assert wire_rw_out = x"3456_789a" severity error;
+    assert wire_rw_mask = x"ffff_ffff" severity error;
+
+    report "Testing wire write with mask" severity note;
+    apb_write(clk, apb_out, apb_in, x"0000_0008", x"bcde_f012", "0101");
+    assert wire_rw_out = x"bcde_f012" severity error;
+    assert wire_rw_mask = x"00ff_00ff" severity error;
 
     -- Memory
     -- Testing regular memory write

--- a/testfiles/tb/wmask_apb_tb.vhdl
+++ b/testfiles/tb/wmask_apb_tb.vhdl
@@ -15,7 +15,8 @@ architecture tb of wmask_apb_tb is
   signal apb_in  : t_apb_master_in;
   signal apb_out : t_apb_master_out;
 
-  signal reg1   : std_logic_vector(31 downto 0);
+  signal reg_rw  : std_logic_vector(31 downto 0);
+  signal wire_rw : std_logic_vector(31 downto 0);
 
   signal end_of_test : boolean := False;
 begin
@@ -48,7 +49,13 @@ begin
       prdata          => apb_in.prdata,
       pslverr         => apb_in.pslverr,
 
-      reg1_o          => reg1,
+      reg_rw_o        => reg_rw,
+      reg_ro_i        => (others => '0'),
+      reg_wo_o        => open,
+      wire_rw_i       => wire_rw,
+      wire_rw_o       => wire_rw,
+      wire_ro_i       => (others => '0'),
+      wire_wo_o       => open,
       ram1_adr_i      => (others => '0'),
       ram1_row1_rd_i  => '0',
       ram1_row1_dat_o => open
@@ -66,20 +73,20 @@ begin
     -- Testing regular register read
     report "Testing regular register read" severity note;
     apb_read(clk, apb_out, apb_in, x"0000_0000", v);
-    assert reg1 = x"0000_0000" severity error;
+    assert reg_rw = x"0000_0000" severity error;
     assert v = x"0000_0000" severity error;
 
     -- Testing regular register write
     report "Testing regular register write" severity note;
     apb_write(clk, apb_out, apb_in, x"0000_0000", x"1234_5678", "1111");
-    assert reg1 = x"1234_5678" severity error;
+    assert reg_rw = x"1234_5678" severity error;
     apb_read(clk, apb_out, apb_in, x"0000_0000", v);
     assert v = x"1234_5678" severity error;
 
     --  Testing register write with mask
     report "Testing register write with mask" severity note;
     apb_write(clk, apb_out, apb_in, x"0000_0000", x"9abc_def0", "1010");
-    assert reg1 = x"9a34_de78" severity error;
+    assert reg_rw = x"9a34_de78" severity error;
     apb_read(clk, apb_out, apb_in, x"0000_0000", v);
     assert v = x"9a34_de78" severity error;
 
@@ -87,14 +94,14 @@ begin
     -- Testing regular memory write
     report "Testing regular memory write" severity note;
     apb_write(clk, apb_out, apb_in, x"0010_0000", x"1234_5678", "1111");
-    assert reg1 = x"1234_5678" severity error;
+    assert reg_rw = x"1234_5678" severity error;
     apb_read(clk, apb_out, apb_in, x"0010_0000", v);
     assert v = x"1234_5678" severity error;
 
     -- Testing memory write with mask
     report "Testing memory write with mask" severity note;
     apb_write(clk, apb_out, apb_in, x"0010_0000", x"9abc_def0", "1010");
-    assert reg1 = x"9a34_de78" severity error;
+    assert reg_rw = x"9a34_de78" severity error;
     apb_read(clk, apb_out, apb_in, x"0010_0000", v);
     assert v = x"9a34_de78" severity error;
 

--- a/testfiles/tb/wmask_avalon_tb.vhdl
+++ b/testfiles/tb/wmask_avalon_tb.vhdl
@@ -15,7 +15,8 @@ architecture tb of wmask_avalon_tb is
   signal avalon_in  : t_avmm_master_in;
   signal avalon_out : t_avmm_master_out;
 
-  signal reg1   : std_logic_vector(31 downto 0);
+  signal reg_rw  : std_logic_vector(31 downto 0);
+  signal wire_rw : std_logic_vector(31 downto 0);
 
   signal end_of_test : boolean := False;
 begin
@@ -47,7 +48,13 @@ begin
       readdatavalid   => avalon_in.readdatavalid,
       waitrequest     => avalon_in.waitrequest,
 
-      reg1_o          => reg1,
+      reg_rw_o        => reg_rw,
+      reg_ro_i        => (others => '0'),
+      reg_wo_o        => open,
+      wire_rw_i       => wire_rw,
+      wire_rw_o       => wire_rw,
+      wire_ro_i       => (others => '0'),
+      wire_wo_o       => open,
       ram1_adr_i      => (others => '0'),
       ram1_row1_rd_i  => '0',
       ram1_row1_dat_o => open
@@ -65,20 +72,20 @@ begin
     -- Testing regular register read
     report "Testing regular register read" severity note;
     avmm_readl(clk, avalon_in, avalon_out, x"0000_0000", v);
-    assert reg1 = x"0000_0000" severity error;
+    assert reg_rw = x"0000_0000" severity error;
     assert v = x"0000_0000" severity error;
 
     -- Testing regular register write
     report "Testing regular register write" severity note;
     avmm_writel(clk, avalon_in, avalon_out, x"0000_0000", x"1234_5678", "1111");
-    assert reg1 = x"1234_5678" severity error;
+    assert reg_rw = x"1234_5678" severity error;
     avmm_readl(clk, avalon_in, avalon_out, x"0000_0000", v);
     assert v = x"1234_5678" severity error;
 
     --  Testing register write with mask
     report "Testing register write with mask" severity note;
     avmm_writel(clk, avalon_in, avalon_out, x"0000_0000", x"9abc_def0", "1010");
-    assert reg1 = x"9a34_de78" severity error;
+    assert reg_rw = x"9a34_de78" severity error;
     avmm_readl(clk, avalon_in, avalon_out, x"0000_0000", v);
     assert v = x"9a34_de78" severity error;
 
@@ -86,14 +93,14 @@ begin
     -- Testing regular memory write
     report "Testing regular memory write" severity note;
     avmm_writel(clk, avalon_in, avalon_out, x"0010_0000", x"1234_5678", "1111");
-    assert reg1 = x"1234_5678" severity error;
+    assert reg_rw = x"1234_5678" severity error;
     avmm_readl(clk, avalon_in, avalon_out, x"0010_0000", v);
     assert v = x"1234_5678" severity error;
 
     -- Testing memory write with mask
     report "Testing memory write with mask" severity note;
     avmm_writel(clk, avalon_in, avalon_out, x"0010_0000", x"9abc_def0", "1010");
-    assert reg1 = x"9a34_de78" severity error;
+    assert reg_rw = x"9a34_de78" severity error;
     avmm_readl(clk, avalon_in, avalon_out, x"0010_0000", v);
     assert v = x"9a34_de78" severity error;
 

--- a/testfiles/tb/wmask_axi4_tb.vhdl
+++ b/testfiles/tb/wmask_axi4_tb.vhdl
@@ -17,8 +17,10 @@ architecture tb of wmask_axi4_tb is
   signal rd_in  : t_axi4lite_read_master_in;
   signal rd_out : t_axi4lite_read_master_out;
 
-  signal reg_rw  : std_logic_vector(31 downto 0);
-  signal wire_rw : std_logic_vector(31 downto 0);
+  signal reg_rw       : std_logic_vector(31 downto 0);
+  signal wire_rw_in   : std_logic_vector(31 downto 0);
+  signal wire_rw_out  : std_logic_vector(31 downto 0);
+  signal wire_rw_mask : std_logic_vector(31 downto 0);
 
   signal end_of_test : boolean := False;
 begin
@@ -64,14 +66,18 @@ begin
       reg_rw_o        => reg_rw,
       reg_ro_i        => (others => '0'),
       reg_wo_o        => open,
-      wire_rw_i       => wire_rw,
-      wire_rw_o       => wire_rw,
+      wire_rw_i       => wire_rw_in,
+      wire_rw_o       => wire_rw_out,
+      wire_rw_wmask_o => wire_rw_mask,
       wire_ro_i       => (others => '0'),
       wire_wo_o       => open,
+      wire_wo_wmask_o => open,
       ram1_adr_i      => (others => '0'),
       ram1_row1_rd_i  => '0',
       ram1_row1_dat_o => open
     );
+
+  wire_rw_in <= wire_rw_out;
 
   main : process is
     variable v : std_logic_vector(31 downto 0);
@@ -102,6 +108,18 @@ begin
     assert reg_rw = x"9a34_de78" severity error;
     axi4lite_read(clk, rd_out, rd_in, x"0000_0000", v);
     assert v = x"9a34_de78" severity error;
+
+    -- Wire
+    -- Testing regular write write
+    report "Testing regular wire write" severity note;
+    axi4lite_write(clk, wr_out, wr_in, x"0000_0008", x"3456_789a", "1111", C_AXI4_RESP_OK);
+    assert wire_rw_out = x"3456_789a" severity error;
+    assert wire_rw_mask = x"ffff_ffff" severity error;
+
+    report "Testing wire write with mask" severity note;
+    axi4lite_write(clk, wr_out, wr_in, x"0000_0008", x"bcde_f012", "0101", C_AXI4_RESP_OK);
+    assert wire_rw_out = x"bcde_f012" severity error;
+    assert wire_rw_mask = x"00ff_00ff" severity error;
 
     -- Memory
     -- Testing regular memory write

--- a/testfiles/tb/wmask_axi4_tb.vhdl
+++ b/testfiles/tb/wmask_axi4_tb.vhdl
@@ -17,7 +17,8 @@ architecture tb of wmask_axi4_tb is
   signal rd_in  : t_axi4lite_read_master_in;
   signal rd_out : t_axi4lite_read_master_out;
 
-  signal reg1   : std_logic_vector(31 downto 0);
+  signal reg_rw  : std_logic_vector(31 downto 0);
+  signal wire_rw : std_logic_vector(31 downto 0);
 
   signal end_of_test : boolean := False;
 begin
@@ -60,7 +61,13 @@ begin
       rdata           => rd_in.rdata,
       rresp           => rd_in.rresp,
 
-      reg1_o          => reg1,
+      reg_rw_o        => reg_rw,
+      reg_ro_i        => (others => '0'),
+      reg_wo_o        => open,
+      wire_rw_i       => wire_rw,
+      wire_rw_o       => wire_rw,
+      wire_ro_i       => (others => '0'),
+      wire_wo_o       => open,
       ram1_adr_i      => (others => '0'),
       ram1_row1_rd_i  => '0',
       ram1_row1_dat_o => open
@@ -79,20 +86,20 @@ begin
     -- Testing regular register read
     report "Testing regular register read" severity note;
     axi4lite_read(clk, rd_out, rd_in, x"0000_0000", v);
-    assert reg1 = x"0000_0000" severity error;
+    assert reg_rw = x"0000_0000" severity error;
     assert v = x"0000_0000" severity error;
 
     -- Testing regular register write
     report "Testing regular register write" severity note;
     axi4lite_write(clk, wr_out, wr_in, x"0000_0000", x"1234_5678", "1111", C_AXI4_RESP_OK);
-    assert reg1 = x"1234_5678" severity error;
+    assert reg_rw = x"1234_5678" severity error;
     axi4lite_read(clk, rd_out, rd_in, x"0000_0000", v);
     assert v = x"1234_5678" severity error;
 
     --  Testing register write with mask
     report "Testing register write with mask" severity note;
     axi4lite_write(clk, wr_out, wr_in, x"0000_0000", x"9abc_def0", "1010", C_AXI4_RESP_OK);
-    assert reg1 = x"9a34_de78" severity error;
+    assert reg_rw = x"9a34_de78" severity error;
     axi4lite_read(clk, rd_out, rd_in, x"0000_0000", v);
     assert v = x"9a34_de78" severity error;
 
@@ -100,14 +107,14 @@ begin
     -- Testing regular memory write
     report "Testing regular memory write" severity note;
     axi4lite_write(clk, wr_out, wr_in, x"0010_0000", x"1234_5678", "1111", C_AXI4_RESP_OK);
-    assert reg1 = x"1234_5678" severity error;
+    assert reg_rw = x"1234_5678" severity error;
     axi4lite_read(clk, rd_out, rd_in, x"0010_0000", v);
     assert v = x"1234_5678" severity error;
 
     -- Testing memory write with mask
     report "Testing memory write with mask" severity note;
     axi4lite_write(clk, wr_out, wr_in, x"0010_0000", x"9abc_def0", "1010", C_AXI4_RESP_OK);
-    assert reg1 = x"9a34_de78" severity error;
+    assert reg_rw = x"9a34_de78" severity error;
     axi4lite_read(clk, rd_out, rd_in, x"0010_0000", v);
     assert v = x"9a34_de78" severity error;
 

--- a/testfiles/tb/wmask_wb_tb.vhdl
+++ b/testfiles/tb/wmask_wb_tb.vhdl
@@ -16,7 +16,8 @@ architecture tb of wmask_wb_tb is
   signal wb_in  : t_wishbone_slave_in;
   signal wb_out : t_wishbone_slave_out;
 
-  signal reg1   : std_logic_vector(31 downto 0);
+  signal reg_rw  : std_logic_vector(31 downto 0);
+  signal wire_rw : std_logic_vector(31 downto 0);
 
   signal end_of_test : boolean := False;
 begin
@@ -51,7 +52,13 @@ begin
       wb_stall_o      => wb_out.stall,
       wb_dat_o        => wb_out.dat,
 
-      reg1_o          => reg1,
+      reg_rw_o        => reg_rw,
+      reg_ro_i        => (others => '0'),
+      reg_wo_o        => open,
+      wire_rw_i       => wire_rw,
+      wire_rw_o       => wire_rw,
+      wire_ro_i       => (others => '0'),
+      wire_wo_o       => open,
       ram1_adr_i      => (others => '0'),
       ram1_row1_rd_i  => '0',
       ram1_row1_dat_o => open
@@ -69,20 +76,20 @@ begin
     -- Testing regular register read
     report "Testing regular register read" severity note;
     wb_readl(clk, wb_out, wb_in, x"0000_0000", v);
-    assert reg1 = x"0000_0000" severity error;
+    assert reg_rw = x"0000_0000" severity error;
     assert v = x"0000_0000" severity error;
 
     -- Testing regular register write
     report "Testing regular register write" severity note;
     wb_writel(clk, wb_out, wb_in, x"0000_0000", x"1234_5678", "1111");
-    assert reg1 = x"1234_5678" severity error;
+    assert reg_rw = x"1234_5678" severity error;
     wb_readl(clk, wb_out, wb_in, x"0000_0000", v);
     assert v = x"1234_5678" severity error;
 
     --  Testing register write with mask
     report "Testing register write with mask" severity note;
     wb_writel(clk, wb_out, wb_in, x"0000_0000", x"9abc_def0", "1010");
-    assert reg1 = x"9a34_de78" severity error;
+    assert reg_rw = x"9a34_de78" severity error;
     wb_readl(clk, wb_out, wb_in, x"0000_0000", v);
     assert v = x"9a34_de78" severity error;
 
@@ -90,14 +97,14 @@ begin
     -- Testing regular memory write
     report "Testing regular memory write" severity note;
     wb_writel(clk, wb_out, wb_in, x"0010_0000", x"1234_5678", "1111");
-    assert reg1 = x"1234_5678" severity error;
+    assert reg_rw = x"1234_5678" severity error;
     wb_readl(clk, wb_out, wb_in, x"0010_0000", v);
     assert v = x"1234_5678" severity error;
 
     -- Testing memory write with mask
     report "Testing memory write with mask" severity note;
     wb_writel(clk, wb_out, wb_in, x"0010_0000", x"9abc_def0", "1010");
-    assert reg1 = x"9a34_de78" severity error;
+    assert reg_rw = x"9a34_de78" severity error;
     wb_readl(clk, wb_out, wb_in, x"0010_0000", v);
     assert v = x"9a34_de78" severity error;
 

--- a/testfiles/tb/wmask_wb_tb.vhdl
+++ b/testfiles/tb/wmask_wb_tb.vhdl
@@ -16,8 +16,10 @@ architecture tb of wmask_wb_tb is
   signal wb_in  : t_wishbone_slave_in;
   signal wb_out : t_wishbone_slave_out;
 
-  signal reg_rw  : std_logic_vector(31 downto 0);
-  signal wire_rw : std_logic_vector(31 downto 0);
+  signal reg_rw       : std_logic_vector(31 downto 0);
+  signal wire_rw_in   : std_logic_vector(31 downto 0);
+  signal wire_rw_out  : std_logic_vector(31 downto 0);
+  signal wire_rw_mask : std_logic_vector(31 downto 0);
 
   signal end_of_test : boolean := False;
 begin
@@ -55,14 +57,18 @@ begin
       reg_rw_o        => reg_rw,
       reg_ro_i        => (others => '0'),
       reg_wo_o        => open,
-      wire_rw_i       => wire_rw,
-      wire_rw_o       => wire_rw,
+      wire_rw_i       => wire_rw_in,
+      wire_rw_o       => wire_rw_out,
+      wire_rw_wmask_o => wire_rw_mask,
       wire_ro_i       => (others => '0'),
       wire_wo_o       => open,
+      wire_wo_wmask_o => open,
       ram1_adr_i      => (others => '0'),
       ram1_row1_rd_i  => '0',
       ram1_row1_dat_o => open
     );
+
+  wire_rw_in <= wire_rw_out;
 
   main : process is
     variable v : std_logic_vector(31 downto 0);
@@ -92,6 +98,18 @@ begin
     assert reg_rw = x"9a34_de78" severity error;
     wb_readl(clk, wb_out, wb_in, x"0000_0000", v);
     assert v = x"9a34_de78" severity error;
+
+    -- Wire
+    -- Testing regular write write
+    report "Testing regular wire write" severity note;
+    wb_writel(clk, wb_out, wb_in, x"0000_0008", x"3456_789a", "1111");
+    assert wire_rw_out = x"3456_789a" severity error;
+    assert wire_rw_mask = x"ffff_ffff" severity error;
+
+    report "Testing wire write with mask" severity note;
+    wb_writel(clk, wb_out, wb_in, x"0000_0008", x"bcde_f012", "0101");
+    assert wire_rw_out = x"bcde_f012" severity error;
+    assert wire_rw_mask = x"00ff_00ff" severity error;
 
     -- Memory
     -- Testing regular memory write


### PR DESCRIPTION
Write masks were added in #16. Similar code between register fields and wire fields was used. Since register fields are assigned in a sequential process, using the same signal name on the right side of the assignment (i.e., the current value) and on the left side (i.e. the new value) is permitted. This is not valid for wires where such a code creates an infinite loop. Instead, when using write masks with read-write wire fields, the input wire value has to be used on the right side of the assignment (i.e., the current value), while the output wire value has to be used on the left side (i.e. the new value).

I.e., having the following cheby file:
```yaml
memory-map:
  ...
  x-hdl:
    wmask: True
  children:
  ...
  - reg:
      name: wire_rw
      type: unsigned
      width: 32
      access: rw
      preset: 0x00000000
      x-hdl:
        type: wire
```

Previously, the following VHDL code was generated:
```vhdl
wire_rw_o <= (wire_rw_o and not wr_sel_d0) or (wr_dat_d0 and wr_sel_d0);
```
As one can see, both sides of the assignment contain the `wire_rw_o` (`_o` suffix) signal while the actual input of the wire field, `wire_rw_i` (`_i` suffix), is not used. Hence, one has an infinite loop and the input wire signal is erroneously not used to apply the mask.

Originally, a fix proposed here corrected this behavior and generates the following VHDL code:
```vhdl
wire_rw_o <= (wire_rw_i and not wr_sel_d0) or (wr_dat_d0 and wr_sel_d0);
```

Finally, it was decided to add a dedicated write mask port for all wire fields to which one can write (and if the mask feature is enabled).