### PR TITLE
Latex - Fix escaping of special chars (tilde, circumflex)

### DIFF
--- a/proto/cheby/print_latex.py
+++ b/proto/cheby/print_latex.py
@@ -23,9 +23,12 @@ def escape_printable(text):
         if idx % 2 == 0:
 
             # Escape special characters
-            SPECIAL_CHARS = ['\\', '&', '%', '#', '_', '{', '}', '~', '^']  # '$'
+            SPECIAL_CHARS = ['\\', '&', '%', '#', '_', '{', '}']
             for char in SPECIAL_CHARS:
                 text_part = text_part.replace(char, '\\' + char)
+
+            text_part.replace('~', '\\textasciitilde')
+            text_part.replace('^', '\\textasciicircum')
 
             # Allow line breaks after '_' and '.' in long strings
             ALLOW_BREAK_CHARS = ['.', '_']


### PR DESCRIPTION
Hey Tristan :)

This PR just fixes some small bugs with the Latex escaping (`\~`, `\^` are not valid).