### PR TITLE
Fix constants generation with same c_name between register and field

### DIFF
--- a/proto/cheby/print_consts.py
+++ b/proto/cheby/print_consts.py
@@ -51,6 +51,7 @@ class ConstsPrinter(object):
                     return "{}{}{}".format(self.pr_name(n.parent), self.sep, n.name)
             else:
                 # Return c_name with prefix
+                # (see also comment in pr_field() calling pr_field_address())
                 return "{}_{}".format(self.pfx, n.c_name.upper())
 
     def pr_address(self, n):
@@ -112,7 +113,16 @@ class ConstsPrinter(object):
         self.pr_hex_data(self.pr_name(f), self.compute_mask(f), f._parent.width)
 
     def pr_field(self, f):
-        self.pr_field_address(f)
+        if self.sep != "_" or f.parent.c_name != f.c_name:
+            # If there is a register containing a single field and both share the same
+            # name, both of their c_name s will be equal. Hence, when the default
+            # separator "_" is selected, pr_name() will return the same name for the
+            # register as well as for the field. Printing the address for the register
+            # and the field will therefore lead to the same constant printed twice.
+            # In that case, this condition blocks the field address constant to be
+            # printed here.
+            self.pr_field_address(f)
+
         self.pr_field_offset(f)
         self.pr_field_mask(f)
 


### PR DESCRIPTION
Bug introduced in #43:

If there is a register containing a single field and both share the same name, both of their `c_name`s will be equal. Hence, when the default separator `_` is selected, `pr_name()` will return the same name for the register as well as for the field. Printing the address for the register and the field will therefore lead to the same constant printed twice.

E.g.
```yaml
    - reg:
        name: foo_bar
        description: 'Foo Bar'
        width: 32
        access: rw
        children:
            - field:
                name: foo_bar
                description: 'Foo Bar'
                range: 31-0
    - reg:
        ...
```
will lead to the following VHDL constant generation (`ADDR_REG_SET_FOO_BAR` declared twice):
```vhdl
  constant ADDR_REG_SET_FOO_BAR : Natural := 16#c#;
  constant ADDR_REG_SET_FOO_BAR : Natural := 16#c#;
  constant REG_SET_FOO_BAR_OFFSET : Natural := 0;
```
Since before #43, the address constant was only printed for the register (but not for the field), the constant was previously printed only once.

This fix blocks the printing of the constant if a field and its register share the same `c_name`.