### PR TITLE
Do not OR autoclear fields with previous value

### DIFF
--- a/proto/cheby/hdl/genreg.py
+++ b/proto/cheby/hdl/genreg.py
@@ -285,14 +285,8 @@ class GenFieldAutoclear(GenFieldBase):
             off, self.field.h_reg, ibus.wr_dat, ibus.wr_sel
         )
         if hasattr(self.root, "hdl_wmask") and self.root.hdl_wmask and mask is not None:
-            then_stmts.append(
-                HDLAssign(
-                    reg,
-                    HDLOr(
-                        HDLParen(HDLAnd(reg, HDLNot(mask))), HDLParen(HDLAnd(dat, mask))
-                    ),
-                )
-            )
+            # Do not OR with previous value as its an autoclear field
+            then_stmts.append(HDLAssign(reg, HDLAnd(dat, mask)))
         else:
             then_stmts.append(HDLAssign(reg, dat))
         else_stmts.append(HDLAssign(reg, HDLConst(0, w if w != 1 else None)))


### PR DESCRIPTION
When using a write mask, fields are normally updated like following
```
new_data = (old_data and !write_mask) or (write_data and write_mask)
```
Since in the case of the autoclear field, the previous data is irrelevant it should not be ORed:
```
new_data = write_data and write_mask
```
 Otherwise, two consecutive write requests to the same register with different masks might keep the field asserted.