### PR TITLE
Align write strobe in case of register/field of type "wire"

### DIFF
--- a/proto/cheby/expand_hdl.py
+++ b/proto/cheby/expand_hdl.py
@@ -14,6 +14,7 @@ def expand_x_hdl_reg(n, dct):
     n.hdl_read_ack = False
     n.hdl_port = 'field'
     n.hdl_type = None
+    n.hdl_field_types = []
     n.hdl_port_name = None
 
     if not n.has_fields():
@@ -95,17 +96,25 @@ def expand_x_hdl_field_type(n, v):
 
 def expand_x_hdl_field_kv(f, n, k, v):
     "Decode one x-hdl attribute for a field"
-    if k == 'type':
+    if k == "type":
         f.hdl_type = expand_x_hdl_field_type(n, v)
-    elif k == 'port-name':
+
+        # Add all field types to register (parent)
+        if f.hdl_type not in n.hdl_field_types:
+            n.hdl_field_types.append(f.hdl_type)
+
+    elif k == "port-name":
         f.hdl_port_name = v
-    elif k == 'lock':
+
+    elif k == "lock":
         f.hdl_lock = parser.read_bool(n, k, v)
-    elif k == 'lock-value':
+
+    elif k == "lock-value":
         f.hdl_lock_value = parser.read_int(n, k, v)
+
     else:
-        parser.error("unhandled '{}' in x-hdl of field {}".format(
-            k, n.get_path()))
+        parser.error("unhandled '{}' in x-hdl of field {}".format(k, n.get_path()))
+
 
 def expand_x_hdl_field_validate(f):
     # Validate x-hdl attributes

--- a/testfiles/issue59/inherit.sv
+++ b/testfiles/issue59/inherit.sv
@@ -36,7 +36,7 @@ module inherit
   reg [3:0] reg0_field01_reg;
   reg reg0_wreq;
   wire reg0_wack;
-  reg reg0_wstrb;
+  wire reg0_wstrb;
   reg rd_ack_d0;
   reg [31:0] rd_dat_d0;
   reg wr_req_d0;
@@ -95,19 +95,14 @@ module inherit
   assign reg0_field01_o = reg0_field01_reg;
   assign reg0_field02_o = wr_dat_d0[10:8];
   assign reg0_wack = reg0_wreq;
+  assign reg0_wstrb = reg0_wreq;
   always_ff @(posedge(clk_i))
   begin
     if (!rst_n_i)
-      begin
-        reg0_field01_reg <= 4'b0000;
-        reg0_wstrb <= 1'b0;
-      end
+      reg0_field01_reg <= 4'b0000;
     else
-      begin
-        if (reg0_wreq == 1'b1)
-          reg0_field01_reg <= wr_dat_d0[7:4];
-        reg0_wstrb <= reg0_wreq;
-      end
+      if (reg0_wreq == 1'b1)
+        reg0_field01_reg <= wr_dat_d0[7:4];
   end
   assign reg0_wr_o = reg0_wstrb;
 

--- a/testfiles/issue59/inherit.v
+++ b/testfiles/issue59/inherit.v
@@ -36,7 +36,7 @@ module inherit
   reg [3:0] reg0_field01_reg;
   reg reg0_wreq;
   wire reg0_wack;
-  reg reg0_wstrb;
+  wire reg0_wstrb;
   reg rd_ack_d0;
   reg [31:0] rd_dat_d0;
   reg wr_req_d0;
@@ -95,19 +95,14 @@ module inherit
   assign reg0_field01_o = reg0_field01_reg;
   assign reg0_field02_o = wr_dat_d0[10:8];
   assign reg0_wack = reg0_wreq;
+  assign reg0_wstrb = reg0_wreq;
   always @(posedge(clk_i))
   begin
     if (!rst_n_i)
-      begin
-        reg0_field01_reg <= 4'b0000;
-        reg0_wstrb <= 1'b0;
-      end
+      reg0_field01_reg <= 4'b0000;
     else
-      begin
-        if (reg0_wreq == 1'b1)
-          reg0_field01_reg <= wr_dat_d0[7:4];
-        reg0_wstrb <= reg0_wreq;
-      end
+      if (reg0_wreq == 1'b1)
+        reg0_field01_reg <= wr_dat_d0[7:4];
   end
   assign reg0_wr_o = reg0_wstrb;
 

--- a/testfiles/issue59/inherit.vhdl
+++ b/testfiles/issue59/inherit.vhdl
@@ -102,16 +102,15 @@ begin
   reg0_field01_o <= reg0_field01_reg;
   reg0_field02_o <= wr_dat_d0(10 downto 8);
   reg0_wack <= reg0_wreq;
+  reg0_wstrb <= reg0_wreq;
   process (clk_i) begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
         reg0_field01_reg <= "0000";
-        reg0_wstrb <= '0';
       else
         if reg0_wreq = '1' then
           reg0_field01_reg <= wr_dat_d0(7 downto 4);
         end if;
-        reg0_wstrb <= reg0_wreq;
       end if;
     end if;
   end process;

--- a/testfiles/tb/golden_files/reg4wrw_wb.vhdl
+++ b/testfiles/tb/golden_files/reg4wrw_wb.vhdl
@@ -25,6 +25,7 @@ entity reg4wrw_wb is
     fwrw_rws_f3_i        : in    std_logic_vector(23 downto 0);
     fwrw_rws_f3_o        : out   std_logic_vector(23 downto 0);
     fwrw_rws_wr_o        : out   std_logic_vector(1 downto 0);
+    fwrw_rws_wire_wr_o   : out   std_logic_vector(1 downto 0);
     fwrw_rws_rd_o        : out   std_logic_vector(1 downto 0);
 
     -- REG fwrw_rws_rwa
@@ -34,6 +35,7 @@ entity reg4wrw_wb is
     fwrw_rws_rwa_f3_i    : in    std_logic_vector(23 downto 0);
     fwrw_rws_rwa_f3_o    : out   std_logic_vector(23 downto 0);
     fwrw_rws_rwa_wr_o    : out   std_logic_vector(1 downto 0);
+    fwrw_rws_rwa_wire_wr_o : out   std_logic_vector(1 downto 0);
     fwrw_rws_rwa_rd_o    : out   std_logic_vector(1 downto 0);
     fwrw_rws_rwa_wack_i  : in    std_logic_vector(1 downto 0);
     fwrw_rws_rwa_rack_i  : in    std_logic_vector(1 downto 0)
@@ -53,9 +55,11 @@ architecture syn of reg4wrw_wb is
   signal fwrw_rws_wreq                  : std_logic_vector(1 downto 0);
   signal fwrw_rws_wack                  : std_logic_vector(1 downto 0);
   signal fwrw_rws_wstrb                 : std_logic_vector(1 downto 0);
+  signal fwrw_rws_wstrb_wire            : std_logic_vector(1 downto 0);
   signal fwrw_rws_rwa_f2_reg            : std_logic_vector(15 downto 0);
   signal fwrw_rws_rwa_wreq              : std_logic_vector(1 downto 0);
   signal fwrw_rws_rwa_wstrb             : std_logic_vector(1 downto 0);
+  signal fwrw_rws_rwa_wstrb_wire        : std_logic_vector(1 downto 0);
   signal rd_ack_d0                      : std_logic;
   signal rd_dat_d0                      : std_logic_vector(31 downto 0);
   signal wr_req_d0                      : std_logic;
@@ -118,6 +122,7 @@ begin
   fwrw_rws_f2_o <= fwrw_rws_f2_reg;
   fwrw_rws_f3_o <= wr_dat_d0(31 downto 8);
   fwrw_rws_wack <= fwrw_rws_wreq;
+  fwrw_rws_wstrb_wire <= fwrw_rws_wreq;
   process (clk_i) begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
@@ -135,11 +140,13 @@ begin
     end if;
   end process;
   fwrw_rws_wr_o <= fwrw_rws_wstrb;
+  fwrw_rws_wire_wr_o <= fwrw_rws_wstrb_wire;
 
   -- Register fwrw_rws_rwa
   fwrw_rws_rwa_f1_o <= wr_dat_d0(11 downto 0);
   fwrw_rws_rwa_f2_o <= fwrw_rws_rwa_f2_reg;
   fwrw_rws_rwa_f3_o <= wr_dat_d0(31 downto 8);
+  fwrw_rws_rwa_wstrb_wire <= fwrw_rws_rwa_wreq;
   process (clk_i) begin
     if rising_edge(clk_i) then
       if rst_n_i = '0' then
@@ -157,6 +164,7 @@ begin
     end if;
   end process;
   fwrw_rws_rwa_wr_o <= fwrw_rws_rwa_wstrb;
+  fwrw_rws_rwa_wire_wr_o <= fwrw_rws_rwa_wstrb_wire;
 
   -- Process for write requests.
   process (wr_adr_d0, wr_req_d0, fwrw_rws_wack, fwrw_rws_rwa_wack_i) begin


### PR DESCRIPTION
The write strobe should be asserted synchronously with the update of the register/field in case of a write request. Since the register has to first sample the write data, the write strobe is a delay version of the write request.
In case of a register or field of type "wire" this is no longer true: There is no register and as such the write data is directly forwarded to the output ports. Hence, the write strobe also should be forwarded without prior sampling. In case where a register contains fields with multiple different types, two write strobes are generated: One delayed as before and a new one for the fields of type "wire" that is directly forwarded.