### PR TITLE
C - Omit struct in hierarchy for blocks with block-prefix: False

### DIFF
--- a/proto/cheby/gen_c.py
+++ b/proto/cheby/gen_c.py
@@ -125,9 +125,11 @@ def cprint_reg(cp, n):
 @CPrinter.register(tree.Block)
 def cprint_block(cp, n):
     cp.cp_txt('/* [0x{:x}]: BLOCK {} */'.format(n.c_address, comment(n)))
-    cp.start_struct(n)
+    if n.hdl_blk_prefix:
+        cp.start_struct(n)
     cprint_children(cp, n, n.c_size, n.c_address)
-    cp.end_struct(n.name)
+    if n.hdl_blk_prefix:
+        cp.end_struct(n.name)
 
 
 @CPrinter.register(tree.Memory)

--- a/proto/tests.py
+++ b/proto/tests.py
@@ -273,7 +273,8 @@ def test_genc_ref():
     for f in ['issue103/top',
               'bug-gen-c-02/mbox_regs', 'bug-gen-c-02/fip_urv_regs',
               'issue67/repeatInRepeat', 'issue67/repeatInRepeatC',
-              'bug-same-label/same_label']:
+              'bug-same-label/same_label',
+              'features/blkprefix3']:
         h_file = srcdir + f + '.h'
         cheby_file = srcdir + f + '.cheby'
         t = parse_ok(cheby_file)

--- a/testfiles/features/blkprefix3.h
+++ b/testfiles/features/blkprefix3.h
@@ -1,0 +1,51 @@
+#ifndef __CHEBY__BLKPREFIX3__H__
+#define __CHEBY__BLKPREFIX3__H__
+
+#include <stdint.h>
+
+#define BLKPREFIX3_SIZE 12 /* 0xc */
+
+/* (comment missing) */
+#define BLKPREFIX3_B1 0x0UL
+#define BLKPREFIX3_B1_SIZE 8 /* 0x8 */
+
+/* (comment missing) */
+#define BLKPREFIX3_B1_R2 0x0UL
+#define BLKPREFIX3_B1_R2_F1_MASK 0x7UL
+#define BLKPREFIX3_B1_R2_F1_SHIFT 0
+#define BLKPREFIX3_B1_R2_F2 0x10UL
+
+/* (comment missing) */
+#define BLKPREFIX3_B1_R3 0x4UL
+#define BLKPREFIX3_B1_R3_F1_MASK 0x7UL
+#define BLKPREFIX3_B1_R3_F1_SHIFT 0
+#define BLKPREFIX3_B1_R3_F2 0x10UL
+
+/* (comment missing) */
+#define BLKPREFIX3_B2 0x8UL
+#define BLKPREFIX3_B2_SIZE 4 /* 0x4 */
+
+/* (comment missing) */
+#define BLKPREFIX3_B2_R3 0x8UL
+#define BLKPREFIX3_B2_R3_F1_MASK 0x7UL
+#define BLKPREFIX3_B2_R3_F1_SHIFT 0
+
+#ifndef __ASSEMBLER__
+struct blkprefix3 {
+  /* [0x0]: BLOCK (comment missing) */
+  /* [0x0]: REG (rw) (comment missing) */
+  uint32_t r2;
+
+  /* [0x4]: BLOCK (comment missing) */
+  /* [0x0]: REG (rw) (comment missing) */
+  uint32_t r3;
+
+  /* [0x8]: BLOCK (comment missing) */
+  struct b2 {
+    /* [0x0]: REG (rw) (comment missing) */
+    uint32_t r3;
+  } b2;
+};
+#endif /* !__ASSEMBLER__*/
+
+#endif /* __CHEBY__BLKPREFIX3__H__ */


### PR DESCRIPTION
:wave: 

This is a small change to adapt the C struct output to match the other outputs more closely in case `block-prefix: False` is defined for a block. E.g. The C defines for the register address already omit the name of the block in this case.

It turns this output

```c
#ifndef __ASSEMBLER__
struct my_reg {

  /* [0x4]: BLOCK Interrupt registers */
  struct irq_regs {
    /* [0x0]: REG (ro) Interrupt status. */
    uint32_t irq_status;

    /* [0x4]: REG (rw) Interrupt enable. */
    uint32_t irq_enable;
  } irq_regs;
```

into this:

```c
#ifndef __ASSEMBLER__
struct my_reg {
  /* [0x4]: BLOCK Interrupt registers */
  /* [0x0]: REG (ro) Interrupt status. */
  uint32_t irq_status;

  /* [0x4]: REG (rw) Interrupt enable. */
  uint32_t irq_enable;
```

Let me know if I should add a testcase for this.