### PR TITLE
 C - Fix padding numbering when structs are omitted 

### DIFF
--- a/proto/tests.py
+++ b/proto/tests.py
@@ -274,7 +274,7 @@ def test_genc_ref():
               'bug-gen-c-02/mbox_regs', 'bug-gen-c-02/fip_urv_regs',
               'issue67/repeatInRepeat', 'issue67/repeatInRepeatC',
               'bug-same-label/same_label',
-              'features/blkprefix3']:
+              'features/blkprefix3', 'features/blkprefix5']:
         h_file = srcdir + f + '.h'
         cheby_file = srcdir + f + '.cheby'
         t = parse_ok(cheby_file)
@@ -411,7 +411,7 @@ def test_hdl_ref():
               'features/enums1', 'features/enums2',
               'features/orclrout_rw',
               'features/blkprefix1', 'features/blkprefix2', 'features/blkprefix3',
-              'features/blkprefix4',
+              'features/blkprefix4', 'features/blkprefix5',
               'features/regprefix1', 'features/regprefix2', 'features/regprefix3',
               'features/mem64ro', 'features/mem64rodual',
               'features/iogroup1', 'features/iogroup2', 'features/repeat-iogroup1',

--- a/testfiles/features/blkprefix5.cheby
+++ b/testfiles/features/blkprefix5.cheby
@@ -1,0 +1,57 @@
+memory-map:
+  bus: wb-32-be
+  name: blkprefix3
+  children:
+  - block:
+      name: b1
+      x-hdl:
+        block-prefix: False
+      children:
+      - reg:
+          name: r1
+          width: 32
+          access: rw
+          children:
+          - field:
+              name: f1
+              range: 2-0
+          - field:
+              name: f2
+              range: 4
+      - reg:
+          name: r2
+          width: 64
+          access: rw
+      - block:
+          name: b11
+          children:
+          - reg:
+              name: r3
+              width: 32
+              access: rw
+              children:
+              - field:
+                  name: f1
+                  range: 2-0
+              - field:
+                  name: f2
+                  range: 4
+          - reg:
+              name: r4
+              width: 64
+              access: rw
+  - block:
+      name: b2
+      children:
+      - reg:
+          name: r1
+          width: 32
+          access: rw
+          children:
+          - field:
+              name: f1
+              range: 2-0
+      - reg:
+          name: r2
+          width: 64
+          access: rw

--- a/testfiles/features/blkprefix5.h
+++ b/testfiles/features/blkprefix5.h
@@ -1,0 +1,78 @@
+#ifndef __CHEBY__BLKPREFIX3__H__
+#define __CHEBY__BLKPREFIX3__H__
+
+#include <stdint.h>
+
+#define BLKPREFIX3_SIZE 48 /* 0x30 */
+
+/* (comment missing) */
+#define BLKPREFIX3_B1 0x0UL
+#define BLKPREFIX3_B1_SIZE 32 /* 0x20 */
+
+/* (comment missing) */
+#define BLKPREFIX3_B1_R1 0x0UL
+#define BLKPREFIX3_B1_R1_F1_MASK 0x7UL
+#define BLKPREFIX3_B1_R1_F1_SHIFT 0
+#define BLKPREFIX3_B1_R1_F2 0x10UL
+
+/* (comment missing) */
+#define BLKPREFIX3_B1_R2 0x8UL
+
+/* (comment missing) */
+#define BLKPREFIX3_B1_R3 0x10UL
+#define BLKPREFIX3_B1_R3_F1_MASK 0x7UL
+#define BLKPREFIX3_B1_R3_F1_SHIFT 0
+#define BLKPREFIX3_B1_R3_F2 0x10UL
+
+/* (comment missing) */
+#define BLKPREFIX3_B1_R4 0x18UL
+
+/* (comment missing) */
+#define BLKPREFIX3_B2 0x20UL
+#define BLKPREFIX3_B2_SIZE 16 /* 0x10 */
+
+/* (comment missing) */
+#define BLKPREFIX3_B2_R1 0x20UL
+#define BLKPREFIX3_B2_R1_F1_MASK 0x7UL
+#define BLKPREFIX3_B2_R1_F1_SHIFT 0
+
+/* (comment missing) */
+#define BLKPREFIX3_B2_R2 0x28UL
+
+#ifndef __ASSEMBLER__
+struct blkprefix3 {
+  /* [0x0]: BLOCK (comment missing) */
+  /* [0x0]: REG (rw) (comment missing) */
+  uint32_t r1;
+
+  /* padding to: 8 Bytes */
+  uint32_t __padding_0[1];
+
+  /* [0x8]: REG (rw) (comment missing) */
+  uint64_t r2;
+
+  /* [0x10]: BLOCK (comment missing) */
+  /* [0x0]: REG (rw) (comment missing) */
+  uint32_t r3;
+
+  /* padding to: 8 Bytes */
+  uint32_t __padding_1[1];
+
+  /* [0x8]: REG (rw) (comment missing) */
+  uint64_t r4;
+
+  /* [0x20]: BLOCK (comment missing) */
+  struct b2 {
+    /* [0x0]: REG (rw) (comment missing) */
+    uint32_t r1;
+
+    /* padding to: 8 Bytes */
+    uint32_t __padding_0[1];
+
+    /* [0x8]: REG (rw) (comment missing) */
+    uint64_t r2;
+  } b2;
+};
+#endif /* !__ASSEMBLER__*/
+
+#endif /* __CHEBY__BLKPREFIX3__H__ */

--- a/testfiles/features/blkprefix5.sv
+++ b/testfiles/features/blkprefix5.sv
@@ -1,0 +1,420 @@
+
+module blkprefix3
+  (
+    input   wire rst_n_i,
+    input   wire clk_i,
+    input   wire wb_cyc_i,
+    input   wire wb_stb_i,
+    input   wire [5:2] wb_adr_i,
+    input   wire [3:0] wb_sel_i,
+    input   wire wb_we_i,
+    input   wire [31:0] wb_dat_i,
+    output  wire wb_ack_o,
+    output  wire wb_err_o,
+    output  wire wb_rty_o,
+    output  wire wb_stall_o,
+    output  reg [31:0] wb_dat_o,
+
+    // REG r1
+    output  wire [2:0] b1_r1_f1_o,
+    output  wire b1_r1_f2_o,
+
+    // REG r2
+    output  wire [63:0] b1_r2_o,
+
+    // REG r3
+    output  wire [2:0] b1_r3_f1_o,
+    output  wire b1_r3_f2_o,
+
+    // REG r4
+    output  wire [63:0] b1_r4_o,
+
+    // REG r1
+    output  wire [2:0] b2_r1_f1_o,
+
+    // REG r2
+    output  wire [63:0] b2_r2_o
+  );
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg [2:0] b1_r1_f1_reg;
+  reg b1_r1_f2_reg;
+  reg b1_r1_wreq;
+  wire b1_r1_wack;
+  reg [63:0] b1_r2_reg;
+  reg [1:0] b1_r2_wreq;
+  wire [1:0] b1_r2_wack;
+  reg [2:0] b1_b11_r3_f1_reg;
+  reg b1_b11_r3_f2_reg;
+  reg b1_r3_wreq;
+  wire b1_r3_wack;
+  reg [63:0] b1_b11_r4_reg;
+  reg [1:0] b1_r4_wreq;
+  wire [1:0] b1_r4_wack;
+  reg [2:0] b2_r1_f1_reg;
+  reg b2_r1_wreq;
+  wire b2_r1_wack;
+  reg [63:0] b2_r2_reg;
+  reg [1:0] b2_r2_wreq;
+  wire [1:0] b2_r2_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [5:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+
+  // WB decode signals
+  always_comb
+  ;
+  assign wb_en = wb_cyc_i & wb_stb_i;
+
+  always_ff @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb_we_i)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
+
+  always_ff @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb_we_i)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb_we_i) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb_ack_o = ack_int;
+  assign wb_stall_o = ~ack_int & wb_en;
+  assign wb_rty_o = 1'b0;
+  assign wb_err_o = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always_ff @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        rd_ack_int <= 1'b0;
+        wb_dat_o <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 4'b0000;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb_dat_o <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_adr_d0 <= wb_adr_i;
+        wr_dat_d0 <= wb_dat_i;
+      end
+  end
+
+  // Register b1_r1
+  assign b1_r1_f1_o = b1_r1_f1_reg;
+  assign b1_r1_f2_o = b1_r1_f2_reg;
+  assign b1_r1_wack = b1_r1_wreq;
+  always_ff @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        b1_r1_f1_reg <= 3'b000;
+        b1_r1_f2_reg <= 1'b0;
+      end
+    else
+      if (b1_r1_wreq == 1'b1)
+        begin
+          b1_r1_f1_reg <= wr_dat_d0[2:0];
+          b1_r1_f2_reg <= wr_dat_d0[4];
+        end
+  end
+
+  // Register b1_r2
+  assign b1_r2_o = b1_r2_reg;
+  assign b1_r2_wack = b1_r2_wreq;
+  always_ff @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      b1_r2_reg <= 64'b0000000000000000000000000000000000000000000000000000000000000000;
+    else
+      begin
+        if (b1_r2_wreq[0] == 1'b1)
+          b1_r2_reg[31:0] <= wr_dat_d0;
+        if (b1_r2_wreq[1] == 1'b1)
+          b1_r2_reg[63:32] <= wr_dat_d0;
+      end
+  end
+
+  // Register b1_r3
+  assign b1_r3_f1_o = b1_b11_r3_f1_reg;
+  assign b1_r3_f2_o = b1_b11_r3_f2_reg;
+  assign b1_r3_wack = b1_r3_wreq;
+  always_ff @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        b1_b11_r3_f1_reg <= 3'b000;
+        b1_b11_r3_f2_reg <= 1'b0;
+      end
+    else
+      if (b1_r3_wreq == 1'b1)
+        begin
+          b1_b11_r3_f1_reg <= wr_dat_d0[2:0];
+          b1_b11_r3_f2_reg <= wr_dat_d0[4];
+        end
+  end
+
+  // Register b1_r4
+  assign b1_r4_o = b1_b11_r4_reg;
+  assign b1_r4_wack = b1_r4_wreq;
+  always_ff @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      b1_b11_r4_reg <= 64'b0000000000000000000000000000000000000000000000000000000000000000;
+    else
+      begin
+        if (b1_r4_wreq[0] == 1'b1)
+          b1_b11_r4_reg[31:0] <= wr_dat_d0;
+        if (b1_r4_wreq[1] == 1'b1)
+          b1_b11_r4_reg[63:32] <= wr_dat_d0;
+      end
+  end
+
+  // Register b2_r1
+  assign b2_r1_f1_o = b2_r1_f1_reg;
+  assign b2_r1_wack = b2_r1_wreq;
+  always_ff @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      b2_r1_f1_reg <= 3'b000;
+    else
+      if (b2_r1_wreq == 1'b1)
+        b2_r1_f1_reg <= wr_dat_d0[2:0];
+  end
+
+  // Register b2_r2
+  assign b2_r2_o = b2_r2_reg;
+  assign b2_r2_wack = b2_r2_wreq;
+  always_ff @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      b2_r2_reg <= 64'b0000000000000000000000000000000000000000000000000000000000000000;
+    else
+      begin
+        if (b2_r2_wreq[0] == 1'b1)
+          b2_r2_reg[31:0] <= wr_dat_d0;
+        if (b2_r2_wreq[1] == 1'b1)
+          b2_r2_reg[63:32] <= wr_dat_d0;
+      end
+  end
+
+  // Process for write requests.
+  always_comb
+  begin
+    b1_r1_wreq = 1'b0;
+    b1_r2_wreq = 2'b0;
+    b1_r3_wreq = 1'b0;
+    b1_r4_wreq = 2'b0;
+    b2_r1_wreq = 1'b0;
+    b2_r2_wreq = 2'b0;
+    case (wr_adr_d0[5:3])
+    3'b000:
+      case (wr_adr_d0[2:2])
+      1'b0:
+        begin
+          // Reg b1_r1
+          b1_r1_wreq = wr_req_d0;
+          wr_ack_int = b1_r1_wack;
+        end
+      default:
+        wr_ack_int = wr_req_d0;
+      endcase
+    3'b001:
+      case (wr_adr_d0[2:2])
+      1'b0:
+        begin
+          // Reg b1_r2
+          b1_r2_wreq[1] = wr_req_d0;
+          wr_ack_int = b1_r2_wack[1];
+        end
+      1'b1:
+        begin
+          // Reg b1_r2
+          b1_r2_wreq[0] = wr_req_d0;
+          wr_ack_int = b1_r2_wack[0];
+        end
+      default:
+        wr_ack_int = wr_req_d0;
+      endcase
+    3'b010:
+      case (wr_adr_d0[2:2])
+      1'b0:
+        begin
+          // Reg b1_r3
+          b1_r3_wreq = wr_req_d0;
+          wr_ack_int = b1_r3_wack;
+        end
+      default:
+        wr_ack_int = wr_req_d0;
+      endcase
+    3'b011:
+      case (wr_adr_d0[2:2])
+      1'b0:
+        begin
+          // Reg b1_r4
+          b1_r4_wreq[1] = wr_req_d0;
+          wr_ack_int = b1_r4_wack[1];
+        end
+      1'b1:
+        begin
+          // Reg b1_r4
+          b1_r4_wreq[0] = wr_req_d0;
+          wr_ack_int = b1_r4_wack[0];
+        end
+      default:
+        wr_ack_int = wr_req_d0;
+      endcase
+    3'b100:
+      case (wr_adr_d0[2:2])
+      1'b0:
+        begin
+          // Reg b2_r1
+          b2_r1_wreq = wr_req_d0;
+          wr_ack_int = b2_r1_wack;
+        end
+      default:
+        wr_ack_int = wr_req_d0;
+      endcase
+    3'b101:
+      case (wr_adr_d0[2:2])
+      1'b0:
+        begin
+          // Reg b2_r2
+          b2_r2_wreq[1] = wr_req_d0;
+          wr_ack_int = b2_r2_wack[1];
+        end
+      1'b1:
+        begin
+          // Reg b2_r2
+          b2_r2_wreq[0] = wr_req_d0;
+          wr_ack_int = b2_r2_wack[0];
+        end
+      default:
+        wr_ack_int = wr_req_d0;
+      endcase
+    default:
+      wr_ack_int = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always_comb
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    case (wb_adr_i[5:3])
+    3'b000:
+      case (wb_adr_i[2:2])
+      1'b0:
+        begin
+          // Reg b1_r1
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0[2:0] = b1_r1_f1_reg;
+          rd_dat_d0[3] = 1'b0;
+          rd_dat_d0[4] = b1_r1_f2_reg;
+          rd_dat_d0[31:5] = 27'b0;
+        end
+      default:
+        rd_ack_d0 = rd_req_int;
+      endcase
+    3'b001:
+      case (wb_adr_i[2:2])
+      1'b0:
+        begin
+          // Reg b1_r2
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0 = b1_r2_reg[63:32];
+        end
+      1'b1:
+        begin
+          // Reg b1_r2
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0 = b1_r2_reg[31:0];
+        end
+      default:
+        rd_ack_d0 = rd_req_int;
+      endcase
+    3'b010:
+      case (wb_adr_i[2:2])
+      1'b0:
+        begin
+          // Reg b1_r3
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0[2:0] = b1_b11_r3_f1_reg;
+          rd_dat_d0[3] = 1'b0;
+          rd_dat_d0[4] = b1_b11_r3_f2_reg;
+          rd_dat_d0[31:5] = 27'b0;
+        end
+      default:
+        rd_ack_d0 = rd_req_int;
+      endcase
+    3'b011:
+      case (wb_adr_i[2:2])
+      1'b0:
+        begin
+          // Reg b1_r4
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0 = b1_b11_r4_reg[63:32];
+        end
+      1'b1:
+        begin
+          // Reg b1_r4
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0 = b1_b11_r4_reg[31:0];
+        end
+      default:
+        rd_ack_d0 = rd_req_int;
+      endcase
+    3'b100:
+      case (wb_adr_i[2:2])
+      1'b0:
+        begin
+          // Reg b2_r1
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0[2:0] = b2_r1_f1_reg;
+          rd_dat_d0[31:3] = 29'b0;
+        end
+      default:
+        rd_ack_d0 = rd_req_int;
+      endcase
+    3'b101:
+      case (wb_adr_i[2:2])
+      1'b0:
+        begin
+          // Reg b2_r2
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0 = b2_r2_reg[63:32];
+        end
+      1'b1:
+        begin
+          // Reg b2_r2
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0 = b2_r2_reg[31:0];
+        end
+      default:
+        rd_ack_d0 = rd_req_int;
+      endcase
+    default:
+      rd_ack_d0 = rd_req_int;
+    endcase
+  end
+endmodule

--- a/testfiles/features/blkprefix5.v
+++ b/testfiles/features/blkprefix5.v
@@ -1,0 +1,420 @@
+
+module blkprefix3
+  (
+    input   wire rst_n_i,
+    input   wire clk_i,
+    input   wire wb_cyc_i,
+    input   wire wb_stb_i,
+    input   wire [5:2] wb_adr_i,
+    input   wire [3:0] wb_sel_i,
+    input   wire wb_we_i,
+    input   wire [31:0] wb_dat_i,
+    output  wire wb_ack_o,
+    output  wire wb_err_o,
+    output  wire wb_rty_o,
+    output  wire wb_stall_o,
+    output  reg [31:0] wb_dat_o,
+
+    // REG r1
+    output  wire [2:0] b1_r1_f1_o,
+    output  wire b1_r1_f2_o,
+
+    // REG r2
+    output  wire [63:0] b1_r2_o,
+
+    // REG r3
+    output  wire [2:0] b1_r3_f1_o,
+    output  wire b1_r3_f2_o,
+
+    // REG r4
+    output  wire [63:0] b1_r4_o,
+
+    // REG r1
+    output  wire [2:0] b2_r1_f1_o,
+
+    // REG r2
+    output  wire [63:0] b2_r2_o
+  );
+  wire rd_req_int;
+  wire wr_req_int;
+  reg rd_ack_int;
+  reg wr_ack_int;
+  wire wb_en;
+  wire ack_int;
+  reg wb_rip;
+  reg wb_wip;
+  reg [2:0] b1_r1_f1_reg;
+  reg b1_r1_f2_reg;
+  reg b1_r1_wreq;
+  wire b1_r1_wack;
+  reg [63:0] b1_r2_reg;
+  reg [1:0] b1_r2_wreq;
+  wire [1:0] b1_r2_wack;
+  reg [2:0] b1_b11_r3_f1_reg;
+  reg b1_b11_r3_f2_reg;
+  reg b1_r3_wreq;
+  wire b1_r3_wack;
+  reg [63:0] b1_b11_r4_reg;
+  reg [1:0] b1_r4_wreq;
+  wire [1:0] b1_r4_wack;
+  reg [2:0] b2_r1_f1_reg;
+  reg b2_r1_wreq;
+  wire b2_r1_wack;
+  reg [63:0] b2_r2_reg;
+  reg [1:0] b2_r2_wreq;
+  wire [1:0] b2_r2_wack;
+  reg rd_ack_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [5:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+
+  // WB decode signals
+  always @(wb_sel_i)
+  ;
+  assign wb_en = wb_cyc_i & wb_stb_i;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_rip <= 1'b0;
+    else
+      wb_rip <= (wb_rip | (wb_en & ~wb_we_i)) & ~rd_ack_int;
+  end
+  assign rd_req_int = (wb_en & ~wb_we_i) & ~wb_rip;
+
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      wb_wip <= 1'b0;
+    else
+      wb_wip <= (wb_wip | (wb_en & wb_we_i)) & ~wr_ack_int;
+  end
+  assign wr_req_int = (wb_en & wb_we_i) & ~wb_wip;
+
+  assign ack_int = rd_ack_int | wr_ack_int;
+  assign wb_ack_o = ack_int;
+  assign wb_stall_o = ~ack_int & wb_en;
+  assign wb_rty_o = 1'b0;
+  assign wb_err_o = 1'b0;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        rd_ack_int <= 1'b0;
+        wb_dat_o <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 4'b0000;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack_int <= rd_ack_d0;
+        wb_dat_o <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_adr_d0 <= wb_adr_i;
+        wr_dat_d0 <= wb_dat_i;
+      end
+  end
+
+  // Register b1_r1
+  assign b1_r1_f1_o = b1_r1_f1_reg;
+  assign b1_r1_f2_o = b1_r1_f2_reg;
+  assign b1_r1_wack = b1_r1_wreq;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        b1_r1_f1_reg <= 3'b000;
+        b1_r1_f2_reg <= 1'b0;
+      end
+    else
+      if (b1_r1_wreq == 1'b1)
+        begin
+          b1_r1_f1_reg <= wr_dat_d0[2:0];
+          b1_r1_f2_reg <= wr_dat_d0[4];
+        end
+  end
+
+  // Register b1_r2
+  assign b1_r2_o = b1_r2_reg;
+  assign b1_r2_wack = b1_r2_wreq;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      b1_r2_reg <= 64'b0000000000000000000000000000000000000000000000000000000000000000;
+    else
+      begin
+        if (b1_r2_wreq[0] == 1'b1)
+          b1_r2_reg[31:0] <= wr_dat_d0;
+        if (b1_r2_wreq[1] == 1'b1)
+          b1_r2_reg[63:32] <= wr_dat_d0;
+      end
+  end
+
+  // Register b1_r3
+  assign b1_r3_f1_o = b1_b11_r3_f1_reg;
+  assign b1_r3_f2_o = b1_b11_r3_f2_reg;
+  assign b1_r3_wack = b1_r3_wreq;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      begin
+        b1_b11_r3_f1_reg <= 3'b000;
+        b1_b11_r3_f2_reg <= 1'b0;
+      end
+    else
+      if (b1_r3_wreq == 1'b1)
+        begin
+          b1_b11_r3_f1_reg <= wr_dat_d0[2:0];
+          b1_b11_r3_f2_reg <= wr_dat_d0[4];
+        end
+  end
+
+  // Register b1_r4
+  assign b1_r4_o = b1_b11_r4_reg;
+  assign b1_r4_wack = b1_r4_wreq;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      b1_b11_r4_reg <= 64'b0000000000000000000000000000000000000000000000000000000000000000;
+    else
+      begin
+        if (b1_r4_wreq[0] == 1'b1)
+          b1_b11_r4_reg[31:0] <= wr_dat_d0;
+        if (b1_r4_wreq[1] == 1'b1)
+          b1_b11_r4_reg[63:32] <= wr_dat_d0;
+      end
+  end
+
+  // Register b2_r1
+  assign b2_r1_f1_o = b2_r1_f1_reg;
+  assign b2_r1_wack = b2_r1_wreq;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      b2_r1_f1_reg <= 3'b000;
+    else
+      if (b2_r1_wreq == 1'b1)
+        b2_r1_f1_reg <= wr_dat_d0[2:0];
+  end
+
+  // Register b2_r2
+  assign b2_r2_o = b2_r2_reg;
+  assign b2_r2_wack = b2_r2_wreq;
+  always @(posedge(clk_i))
+  begin
+    if (!rst_n_i)
+      b2_r2_reg <= 64'b0000000000000000000000000000000000000000000000000000000000000000;
+    else
+      begin
+        if (b2_r2_wreq[0] == 1'b1)
+          b2_r2_reg[31:0] <= wr_dat_d0;
+        if (b2_r2_wreq[1] == 1'b1)
+          b2_r2_reg[63:32] <= wr_dat_d0;
+      end
+  end
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, b1_r1_wack, b1_r2_wack, b1_r3_wack, b1_r4_wack, b2_r1_wack, b2_r2_wack)
+  begin
+    b1_r1_wreq = 1'b0;
+    b1_r2_wreq = 2'b0;
+    b1_r3_wreq = 1'b0;
+    b1_r4_wreq = 2'b0;
+    b2_r1_wreq = 1'b0;
+    b2_r2_wreq = 2'b0;
+    case (wr_adr_d0[5:3])
+    3'b000:
+      case (wr_adr_d0[2:2])
+      1'b0:
+        begin
+          // Reg b1_r1
+          b1_r1_wreq = wr_req_d0;
+          wr_ack_int = b1_r1_wack;
+        end
+      default:
+        wr_ack_int = wr_req_d0;
+      endcase
+    3'b001:
+      case (wr_adr_d0[2:2])
+      1'b0:
+        begin
+          // Reg b1_r2
+          b1_r2_wreq[1] = wr_req_d0;
+          wr_ack_int = b1_r2_wack[1];
+        end
+      1'b1:
+        begin
+          // Reg b1_r2
+          b1_r2_wreq[0] = wr_req_d0;
+          wr_ack_int = b1_r2_wack[0];
+        end
+      default:
+        wr_ack_int = wr_req_d0;
+      endcase
+    3'b010:
+      case (wr_adr_d0[2:2])
+      1'b0:
+        begin
+          // Reg b1_r3
+          b1_r3_wreq = wr_req_d0;
+          wr_ack_int = b1_r3_wack;
+        end
+      default:
+        wr_ack_int = wr_req_d0;
+      endcase
+    3'b011:
+      case (wr_adr_d0[2:2])
+      1'b0:
+        begin
+          // Reg b1_r4
+          b1_r4_wreq[1] = wr_req_d0;
+          wr_ack_int = b1_r4_wack[1];
+        end
+      1'b1:
+        begin
+          // Reg b1_r4
+          b1_r4_wreq[0] = wr_req_d0;
+          wr_ack_int = b1_r4_wack[0];
+        end
+      default:
+        wr_ack_int = wr_req_d0;
+      endcase
+    3'b100:
+      case (wr_adr_d0[2:2])
+      1'b0:
+        begin
+          // Reg b2_r1
+          b2_r1_wreq = wr_req_d0;
+          wr_ack_int = b2_r1_wack;
+        end
+      default:
+        wr_ack_int = wr_req_d0;
+      endcase
+    3'b101:
+      case (wr_adr_d0[2:2])
+      1'b0:
+        begin
+          // Reg b2_r2
+          b2_r2_wreq[1] = wr_req_d0;
+          wr_ack_int = b2_r2_wack[1];
+        end
+      1'b1:
+        begin
+          // Reg b2_r2
+          b2_r2_wreq[0] = wr_req_d0;
+          wr_ack_int = b2_r2_wack[0];
+        end
+      default:
+        wr_ack_int = wr_req_d0;
+      endcase
+    default:
+      wr_ack_int = wr_req_d0;
+    endcase
+  end
+
+  // Process for read requests.
+  always @(wb_adr_i, rd_req_int, b1_r1_f1_reg, b1_r1_f2_reg, b1_r2_reg, b1_b11_r3_f1_reg, b1_b11_r3_f2_reg, b1_b11_r4_reg, b2_r1_f1_reg, b2_r2_reg)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    case (wb_adr_i[5:3])
+    3'b000:
+      case (wb_adr_i[2:2])
+      1'b0:
+        begin
+          // Reg b1_r1
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0[2:0] = b1_r1_f1_reg;
+          rd_dat_d0[3] = 1'b0;
+          rd_dat_d0[4] = b1_r1_f2_reg;
+          rd_dat_d0[31:5] = 27'b0;
+        end
+      default:
+        rd_ack_d0 = rd_req_int;
+      endcase
+    3'b001:
+      case (wb_adr_i[2:2])
+      1'b0:
+        begin
+          // Reg b1_r2
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0 = b1_r2_reg[63:32];
+        end
+      1'b1:
+        begin
+          // Reg b1_r2
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0 = b1_r2_reg[31:0];
+        end
+      default:
+        rd_ack_d0 = rd_req_int;
+      endcase
+    3'b010:
+      case (wb_adr_i[2:2])
+      1'b0:
+        begin
+          // Reg b1_r3
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0[2:0] = b1_b11_r3_f1_reg;
+          rd_dat_d0[3] = 1'b0;
+          rd_dat_d0[4] = b1_b11_r3_f2_reg;
+          rd_dat_d0[31:5] = 27'b0;
+        end
+      default:
+        rd_ack_d0 = rd_req_int;
+      endcase
+    3'b011:
+      case (wb_adr_i[2:2])
+      1'b0:
+        begin
+          // Reg b1_r4
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0 = b1_b11_r4_reg[63:32];
+        end
+      1'b1:
+        begin
+          // Reg b1_r4
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0 = b1_b11_r4_reg[31:0];
+        end
+      default:
+        rd_ack_d0 = rd_req_int;
+      endcase
+    3'b100:
+      case (wb_adr_i[2:2])
+      1'b0:
+        begin
+          // Reg b2_r1
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0[2:0] = b2_r1_f1_reg;
+          rd_dat_d0[31:3] = 29'b0;
+        end
+      default:
+        rd_ack_d0 = rd_req_int;
+      endcase
+    3'b101:
+      case (wb_adr_i[2:2])
+      1'b0:
+        begin
+          // Reg b2_r2
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0 = b2_r2_reg[63:32];
+        end
+      1'b1:
+        begin
+          // Reg b2_r2
+          rd_ack_d0 = rd_req_int;
+          rd_dat_d0 = b2_r2_reg[31:0];
+        end
+      default:
+        rd_ack_d0 = rd_req_int;
+      endcase
+    default:
+      rd_ack_d0 = rd_req_int;
+    endcase
+  end
+endmodule

--- a/testfiles/features/blkprefix5.vhdl
+++ b/testfiles/features/blkprefix5.vhdl
@@ -1,0 +1,399 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity blkprefix3 is
+  port (
+    rst_n_i              : in    std_logic;
+    clk_i                : in    std_logic;
+    wb_cyc_i             : in    std_logic;
+    wb_stb_i             : in    std_logic;
+    wb_adr_i             : in    std_logic_vector(5 downto 2);
+    wb_sel_i             : in    std_logic_vector(3 downto 0);
+    wb_we_i              : in    std_logic;
+    wb_dat_i             : in    std_logic_vector(31 downto 0);
+    wb_ack_o             : out   std_logic;
+    wb_err_o             : out   std_logic;
+    wb_rty_o             : out   std_logic;
+    wb_stall_o           : out   std_logic;
+    wb_dat_o             : out   std_logic_vector(31 downto 0);
+
+    -- REG r1
+    b1_r1_f1_o           : out   std_logic_vector(2 downto 0);
+    b1_r1_f2_o           : out   std_logic;
+
+    -- REG r2
+    b1_r2_o              : out   std_logic_vector(63 downto 0);
+
+    -- REG r3
+    b1_r3_f1_o           : out   std_logic_vector(2 downto 0);
+    b1_r3_f2_o           : out   std_logic;
+
+    -- REG r4
+    b1_r4_o              : out   std_logic_vector(63 downto 0);
+
+    -- REG r1
+    b2_r1_f1_o           : out   std_logic_vector(2 downto 0);
+
+    -- REG r2
+    b2_r2_o              : out   std_logic_vector(63 downto 0)
+  );
+end blkprefix3;
+
+architecture syn of blkprefix3 is
+  signal rd_req_int                     : std_logic;
+  signal wr_req_int                     : std_logic;
+  signal rd_ack_int                     : std_logic;
+  signal wr_ack_int                     : std_logic;
+  signal wb_en                          : std_logic;
+  signal ack_int                        : std_logic;
+  signal wb_rip                         : std_logic;
+  signal wb_wip                         : std_logic;
+  signal b1_r1_f1_reg                   : std_logic_vector(2 downto 0);
+  signal b1_r1_f2_reg                   : std_logic;
+  signal b1_r1_wreq                     : std_logic;
+  signal b1_r1_wack                     : std_logic;
+  signal b1_r2_reg                      : std_logic_vector(63 downto 0);
+  signal b1_r2_wreq                     : std_logic_vector(1 downto 0);
+  signal b1_r2_wack                     : std_logic_vector(1 downto 0);
+  signal b1_b11_r3_f1_reg               : std_logic_vector(2 downto 0);
+  signal b1_b11_r3_f2_reg               : std_logic;
+  signal b1_r3_wreq                     : std_logic;
+  signal b1_r3_wack                     : std_logic;
+  signal b1_b11_r4_reg                  : std_logic_vector(63 downto 0);
+  signal b1_r4_wreq                     : std_logic_vector(1 downto 0);
+  signal b1_r4_wack                     : std_logic_vector(1 downto 0);
+  signal b2_r1_f1_reg                   : std_logic_vector(2 downto 0);
+  signal b2_r1_wreq                     : std_logic;
+  signal b2_r1_wack                     : std_logic;
+  signal b2_r2_reg                      : std_logic_vector(63 downto 0);
+  signal b2_r2_wreq                     : std_logic_vector(1 downto 0);
+  signal b2_r2_wack                     : std_logic_vector(1 downto 0);
+  signal rd_ack_d0                      : std_logic;
+  signal rd_dat_d0                      : std_logic_vector(31 downto 0);
+  signal wr_req_d0                      : std_logic;
+  signal wr_adr_d0                      : std_logic_vector(5 downto 2);
+  signal wr_dat_d0                      : std_logic_vector(31 downto 0);
+begin
+
+  -- WB decode signals
+  wb_en <= wb_cyc_i and wb_stb_i;
+
+  process (clk_i) begin
+    if rising_edge(clk_i) then
+      if rst_n_i = '0' then
+        wb_rip <= '0';
+      else
+        wb_rip <= (wb_rip or (wb_en and not wb_we_i)) and not rd_ack_int;
+      end if;
+    end if;
+  end process;
+  rd_req_int <= (wb_en and not wb_we_i) and not wb_rip;
+
+  process (clk_i) begin
+    if rising_edge(clk_i) then
+      if rst_n_i = '0' then
+        wb_wip <= '0';
+      else
+        wb_wip <= (wb_wip or (wb_en and wb_we_i)) and not wr_ack_int;
+      end if;
+    end if;
+  end process;
+  wr_req_int <= (wb_en and wb_we_i) and not wb_wip;
+
+  ack_int <= rd_ack_int or wr_ack_int;
+  wb_ack_o <= ack_int;
+  wb_stall_o <= not ack_int and wb_en;
+  wb_rty_o <= '0';
+  wb_err_o <= '0';
+
+  -- pipelining for wr-in+rd-out
+  process (clk_i) begin
+    if rising_edge(clk_i) then
+      if rst_n_i = '0' then
+        rd_ack_int <= '0';
+        wb_dat_o <= "00000000000000000000000000000000";
+        wr_req_d0 <= '0';
+        wr_adr_d0 <= "0000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
+      else
+        rd_ack_int <= rd_ack_d0;
+        wb_dat_o <= rd_dat_d0;
+        wr_req_d0 <= wr_req_int;
+        wr_adr_d0 <= wb_adr_i;
+        wr_dat_d0 <= wb_dat_i;
+      end if;
+    end if;
+  end process;
+
+  -- Register b1_r1
+  b1_r1_f1_o <= b1_r1_f1_reg;
+  b1_r1_f2_o <= b1_r1_f2_reg;
+  b1_r1_wack <= b1_r1_wreq;
+  process (clk_i) begin
+    if rising_edge(clk_i) then
+      if rst_n_i = '0' then
+        b1_r1_f1_reg <= "000";
+        b1_r1_f2_reg <= '0';
+      else
+        if b1_r1_wreq = '1' then
+          b1_r1_f1_reg <= wr_dat_d0(2 downto 0);
+          b1_r1_f2_reg <= wr_dat_d0(4);
+        end if;
+      end if;
+    end if;
+  end process;
+
+  -- Register b1_r2
+  b1_r2_o <= b1_r2_reg;
+  b1_r2_wack <= b1_r2_wreq;
+  process (clk_i) begin
+    if rising_edge(clk_i) then
+      if rst_n_i = '0' then
+        b1_r2_reg <= "0000000000000000000000000000000000000000000000000000000000000000";
+      else
+        if b1_r2_wreq(0) = '1' then
+          b1_r2_reg(31 downto 0) <= wr_dat_d0;
+        end if;
+        if b1_r2_wreq(1) = '1' then
+          b1_r2_reg(63 downto 32) <= wr_dat_d0;
+        end if;
+      end if;
+    end if;
+  end process;
+
+  -- Register b1_r3
+  b1_r3_f1_o <= b1_b11_r3_f1_reg;
+  b1_r3_f2_o <= b1_b11_r3_f2_reg;
+  b1_r3_wack <= b1_r3_wreq;
+  process (clk_i) begin
+    if rising_edge(clk_i) then
+      if rst_n_i = '0' then
+        b1_b11_r3_f1_reg <= "000";
+        b1_b11_r3_f2_reg <= '0';
+      else
+        if b1_r3_wreq = '1' then
+          b1_b11_r3_f1_reg <= wr_dat_d0(2 downto 0);
+          b1_b11_r3_f2_reg <= wr_dat_d0(4);
+        end if;
+      end if;
+    end if;
+  end process;
+
+  -- Register b1_r4
+  b1_r4_o <= b1_b11_r4_reg;
+  b1_r4_wack <= b1_r4_wreq;
+  process (clk_i) begin
+    if rising_edge(clk_i) then
+      if rst_n_i = '0' then
+        b1_b11_r4_reg <= "0000000000000000000000000000000000000000000000000000000000000000";
+      else
+        if b1_r4_wreq(0) = '1' then
+          b1_b11_r4_reg(31 downto 0) <= wr_dat_d0;
+        end if;
+        if b1_r4_wreq(1) = '1' then
+          b1_b11_r4_reg(63 downto 32) <= wr_dat_d0;
+        end if;
+      end if;
+    end if;
+  end process;
+
+  -- Register b2_r1
+  b2_r1_f1_o <= b2_r1_f1_reg;
+  b2_r1_wack <= b2_r1_wreq;
+  process (clk_i) begin
+    if rising_edge(clk_i) then
+      if rst_n_i = '0' then
+        b2_r1_f1_reg <= "000";
+      else
+        if b2_r1_wreq = '1' then
+          b2_r1_f1_reg <= wr_dat_d0(2 downto 0);
+        end if;
+      end if;
+    end if;
+  end process;
+
+  -- Register b2_r2
+  b2_r2_o <= b2_r2_reg;
+  b2_r2_wack <= b2_r2_wreq;
+  process (clk_i) begin
+    if rising_edge(clk_i) then
+      if rst_n_i = '0' then
+        b2_r2_reg <= "0000000000000000000000000000000000000000000000000000000000000000";
+      else
+        if b2_r2_wreq(0) = '1' then
+          b2_r2_reg(31 downto 0) <= wr_dat_d0;
+        end if;
+        if b2_r2_wreq(1) = '1' then
+          b2_r2_reg(63 downto 32) <= wr_dat_d0;
+        end if;
+      end if;
+    end if;
+  end process;
+
+  -- Process for write requests.
+  process (wr_adr_d0, wr_req_d0, b1_r1_wack, b1_r2_wack, b1_r3_wack, b1_r4_wack,
+           b2_r1_wack, b2_r2_wack) begin
+    b1_r1_wreq <= '0';
+    b1_r2_wreq <= (others => '0');
+    b1_r3_wreq <= '0';
+    b1_r4_wreq <= (others => '0');
+    b2_r1_wreq <= '0';
+    b2_r2_wreq <= (others => '0');
+    case wr_adr_d0(5 downto 3) is
+    when "000" =>
+      case wr_adr_d0(2 downto 2) is
+      when "0" =>
+        -- Reg b1_r1
+        b1_r1_wreq <= wr_req_d0;
+        wr_ack_int <= b1_r1_wack;
+      when others =>
+        wr_ack_int <= wr_req_d0;
+      end case;
+    when "001" =>
+      case wr_adr_d0(2 downto 2) is
+      when "0" =>
+        -- Reg b1_r2
+        b1_r2_wreq(1) <= wr_req_d0;
+        wr_ack_int <= b1_r2_wack(1);
+      when "1" =>
+        -- Reg b1_r2
+        b1_r2_wreq(0) <= wr_req_d0;
+        wr_ack_int <= b1_r2_wack(0);
+      when others =>
+        wr_ack_int <= wr_req_d0;
+      end case;
+    when "010" =>
+      case wr_adr_d0(2 downto 2) is
+      when "0" =>
+        -- Reg b1_r3
+        b1_r3_wreq <= wr_req_d0;
+        wr_ack_int <= b1_r3_wack;
+      when others =>
+        wr_ack_int <= wr_req_d0;
+      end case;
+    when "011" =>
+      case wr_adr_d0(2 downto 2) is
+      when "0" =>
+        -- Reg b1_r4
+        b1_r4_wreq(1) <= wr_req_d0;
+        wr_ack_int <= b1_r4_wack(1);
+      when "1" =>
+        -- Reg b1_r4
+        b1_r4_wreq(0) <= wr_req_d0;
+        wr_ack_int <= b1_r4_wack(0);
+      when others =>
+        wr_ack_int <= wr_req_d0;
+      end case;
+    when "100" =>
+      case wr_adr_d0(2 downto 2) is
+      when "0" =>
+        -- Reg b2_r1
+        b2_r1_wreq <= wr_req_d0;
+        wr_ack_int <= b2_r1_wack;
+      when others =>
+        wr_ack_int <= wr_req_d0;
+      end case;
+    when "101" =>
+      case wr_adr_d0(2 downto 2) is
+      when "0" =>
+        -- Reg b2_r2
+        b2_r2_wreq(1) <= wr_req_d0;
+        wr_ack_int <= b2_r2_wack(1);
+      when "1" =>
+        -- Reg b2_r2
+        b2_r2_wreq(0) <= wr_req_d0;
+        wr_ack_int <= b2_r2_wack(0);
+      when others =>
+        wr_ack_int <= wr_req_d0;
+      end case;
+    when others =>
+      wr_ack_int <= wr_req_d0;
+    end case;
+  end process;
+
+  -- Process for read requests.
+  process (wb_adr_i, rd_req_int, b1_r1_f1_reg, b1_r1_f2_reg, b1_r2_reg,
+           b1_b11_r3_f1_reg, b1_b11_r3_f2_reg, b1_b11_r4_reg, b2_r1_f1_reg,
+           b2_r2_reg) begin
+    -- By default ack read requests
+    rd_dat_d0 <= (others => 'X');
+    case wb_adr_i(5 downto 3) is
+    when "000" =>
+      case wb_adr_i(2 downto 2) is
+      when "0" =>
+        -- Reg b1_r1
+        rd_ack_d0 <= rd_req_int;
+        rd_dat_d0(2 downto 0) <= b1_r1_f1_reg;
+        rd_dat_d0(3) <= '0';
+        rd_dat_d0(4) <= b1_r1_f2_reg;
+        rd_dat_d0(31 downto 5) <= (others => '0');
+      when others =>
+        rd_ack_d0 <= rd_req_int;
+      end case;
+    when "001" =>
+      case wb_adr_i(2 downto 2) is
+      when "0" =>
+        -- Reg b1_r2
+        rd_ack_d0 <= rd_req_int;
+        rd_dat_d0 <= b1_r2_reg(63 downto 32);
+      when "1" =>
+        -- Reg b1_r2
+        rd_ack_d0 <= rd_req_int;
+        rd_dat_d0 <= b1_r2_reg(31 downto 0);
+      when others =>
+        rd_ack_d0 <= rd_req_int;
+      end case;
+    when "010" =>
+      case wb_adr_i(2 downto 2) is
+      when "0" =>
+        -- Reg b1_r3
+        rd_ack_d0 <= rd_req_int;
+        rd_dat_d0(2 downto 0) <= b1_b11_r3_f1_reg;
+        rd_dat_d0(3) <= '0';
+        rd_dat_d0(4) <= b1_b11_r3_f2_reg;
+        rd_dat_d0(31 downto 5) <= (others => '0');
+      when others =>
+        rd_ack_d0 <= rd_req_int;
+      end case;
+    when "011" =>
+      case wb_adr_i(2 downto 2) is
+      when "0" =>
+        -- Reg b1_r4
+        rd_ack_d0 <= rd_req_int;
+        rd_dat_d0 <= b1_b11_r4_reg(63 downto 32);
+      when "1" =>
+        -- Reg b1_r4
+        rd_ack_d0 <= rd_req_int;
+        rd_dat_d0 <= b1_b11_r4_reg(31 downto 0);
+      when others =>
+        rd_ack_d0 <= rd_req_int;
+      end case;
+    when "100" =>
+      case wb_adr_i(2 downto 2) is
+      when "0" =>
+        -- Reg b2_r1
+        rd_ack_d0 <= rd_req_int;
+        rd_dat_d0(2 downto 0) <= b2_r1_f1_reg;
+        rd_dat_d0(31 downto 3) <= (others => '0');
+      when others =>
+        rd_ack_d0 <= rd_req_int;
+      end case;
+    when "101" =>
+      case wb_adr_i(2 downto 2) is
+      when "0" =>
+        -- Reg b2_r2
+        rd_ack_d0 <= rd_req_int;
+        rd_dat_d0 <= b2_r2_reg(63 downto 32);
+      when "1" =>
+        -- Reg b2_r2
+        rd_ack_d0 <= rd_req_int;
+        rd_dat_d0 <= b2_r2_reg(31 downto 0);
+      when others =>
+        rd_ack_d0 <= rd_req_int;
+      end case;
+    when others =>
+      rd_ack_d0 <= rd_req_int;
+    end case;
+  end process;
+end syn;


### PR DESCRIPTION
With the change from #55, I've introduced/triggered a new issue :| If padding is inserted at the top-level and within a block omitted prefix, the same name is given to the padding variable resulting in compilation errors, e.g.

```c
#ifndef __ASSEMBLER__
struct blkprefix3 {
  /* [0x0]: BLOCK (comment missing) */
  /* [0x0]: REG (rw) (comment missing) */
  uint32_t r1;

  /* padding to: 8 Bytes */
  uint32_t __padding_0[1];

  /* [0x8]: REG (rw) (comment missing) */
  uint64_t r2;

  /* [0x10]: BLOCK (comment missing) */
  /* [0x0]: REG (rw) (comment missing) */
  uint32_t r3;

  /* padding to: 8 Bytes */
  uint32_t __padding_0[1];

  /* [0x8]: REG (rw) (comment missing) */
  uint64_t r4;

  /* [0x20]: BLOCK (comment missing) */
  struct b2 {
    /* [0x0]: REG (rw) (comment missing) */
    uint32_t r1;

    /* padding to: 8 Bytes */
    uint32_t __padding_0[1];

    /* [0x8]: REG (rw) (comment missing) */
    uint64_t r2;
  } b2;
};
#endif /* !__ASSEMBLER__*/
```

Note the duplicate `__padding_0`

This MR fixes the issue by tracking the padding numbering using a stack within CPrinter. The numbering is still reset when a new struct (without omitted prefix) starts.
