### PR TITLE
Distinguish between description and comments

### DIFF
--- a/doc/cheby-ug.txt
+++ b/doc/cheby-ug.txt
@@ -163,16 +163,15 @@ Some attributes are common to all nodes:
 * `name`: The name of the node.  This is required for all nodes.  The name is
 also used to create HDL or C names in general files.
 
-* `comment`: This should be a short text that explain the purpose
-of the node.  The comment is copied into the code (as a comment)
-to make it more readable.  This attribute is not required but it is recommended
-to always provide it.
+* `comment`: A short text that explain the purpose. It is copied into the code
+(as a comment). This attribute is not required but it is recommended to always
+provide it.
 
-* `description`: This is a longer text that will be copied into the generated
-documentation. Newlines are honored according to the YAML specification. In
-regular strings, you can add an empty line to generate a newline.
-Alternatively, you can also explicitly add them in double-quoted strings,
-e.g. `description: "line1 \n line2"`.
+* `description`: A longer text that explain the purpose in detail. It is copied
+into the generated documentation. Newlines are honored according to the YAML
+specification. In regular strings, you can add an empty line to generate a
+newline. Alternatively, you can also explicitly add them in double-quoted
+strings, e.g. `description: "line1 \n line2"`.
 
 * `children`: For nodes that have children, this is a list of the children.
 

--- a/proto/cheby/gen_c.py
+++ b/proto/cheby/gen_c.py
@@ -104,7 +104,7 @@ def cprint_children(cp, n, size, off):
 
 
 def comment(n):
-    return n.comment or n.description or '(comment missing)'
+    return n.comment or "(comment missing)"
 
 
 @CPrinter.register(tree.Reg)

--- a/proto/cheby/hdl/avalonbus.py
+++ b/proto/cheby/hdl/avalonbus.py
@@ -172,7 +172,7 @@ class AvalonBus(BusGen):
             n.h_bus[name] = p
         # Add the comment.  Not that simple as the first port of the bus depends on
         # split or not split, address or no address.
-        comment = '\n' + (n.comment or n.description or 'Avalon bus {}'.format(n.name))
+        comment = '\n' + (n.comment or 'Avalon bus {}'.format(n.name))
         first = 'adr'
         if n.h_bus[first] is None:
             first = 'dato'

--- a/proto/cheby/hdl/axi4litebus.py
+++ b/proto/cheby/hdl/axi4litebus.py
@@ -332,7 +332,7 @@ class AXI4LiteBus(BusGen):
         n.h_bus = {}
         for name, p in ports:
             n.h_bus[name] = p
-        comment = '\n' + (n.comment or n.description or 'AXI-4 lite bus {}'.format(n.name))
+        comment = "\n" + (n.comment or "AXI-4 lite bus {}".format(n.name))
         n.h_bus['awvalid'].comment = comment
         # Internal signals: valid signals.
         n.h_aw_val = module.new_HDLSignal(prefix + 'aw_val')

--- a/proto/cheby/hdl/genblock.py
+++ b/proto/cheby/hdl/genblock.py
@@ -95,7 +95,7 @@ class GenRepeatBlock(GenBlock):
             self.module.global_decls.append(itf_arr)
             ports_arr = self.module.add_modport(self.n.hdl_iogroup, itf_arr, is_master=True)
             c = self.n.origin
-            ports_arr.comment = '\n' + (c.comment or c.description or "REPEAT {}".format(c.name))
+            ports_arr.comment = "\n" + (c.comment or "REPEAT {}".format(c.name))
 
             # Create each port (when first_index is True), and
             # expand all ports.

--- a/proto/cheby/hdl/genreg.py
+++ b/proto/cheby/hdl/genreg.py
@@ -486,7 +486,7 @@ class GenReg(ElGen):
         oport = None
 
         # Register comment.  Always add a separation between registers ports.
-        comment = '\n' + (n.comment or n.description or "REG {}".format(n.name))
+        comment = "\n" + (n.comment or "REG {}".format(n.name))
 
         for f in n.children:
             # Set hdl generator for the field.
@@ -496,9 +496,10 @@ class GenReg(ElGen):
 
             if n.hdl_port != 'reg' and not isinstance(f, tree.FieldReg):
                 # Append field comment to the register comment (if present)
-                pcomment = f.comment or f.description
-                if pcomment is not None:
-                    comment = pcomment if comment is None else comment + '\n' + pcomment
+                if f.comment is not None:
+                    comment = (
+                        f.comment if comment is None else comment + "\n" + f.comment
+                    )
 
             need_iport = f.h_gen.need_iport()
             need_oport = f.h_gen.need_oport()

--- a/proto/cheby/hdl/simplebus.py
+++ b/proto/cheby/hdl/simplebus.py
@@ -141,7 +141,7 @@ class SimpleBus(BusGen):
             n.h_bus[name] = p
         # Add the comment.  Not that simple as the first port of the bus depends on
         # split or not split, address or no address.
-        comment = '\n' + (n.comment or n.description or '{} bus {}'.format(self.busname, n.name))
+        comment = "\n" + (n.comment or "{} bus {}".format(self.busname, n.name))
         if n.c_addr_bits > 0:
             first = 'adrr' if self.split else 'adr'
         else:

--- a/proto/cheby/hdl/wbbus.py
+++ b/proto/cheby/hdl/wbbus.py
@@ -223,7 +223,7 @@ class WBBus(BusGen):
 
     def gen_bus_slave(self, root, module, prefix, n, opts):
         # Create the bus for a submap or a memory
-        comment = '\n' + (n.comment or n.description or 'WB bus {}'.format(n.name))
+        comment = '\n' + (n.comment or 'WB bus {}'.format(n.name))
         n.h_busgroup = opts.busgroup
         n.h_bus = self.gen_wishbone(
             module, module, n.c_name,

--- a/proto/cheby/main.py
+++ b/proto/cheby/main.py
@@ -124,8 +124,11 @@ def decode_args():
                          help='select language for doc generation')
     aparser.add_argument('--gen-doc', nargs='?', const='-',
                          help='generate documentation')
-    aparser.add_argument('--rest-headers', default='#=-',
-                         help='Ordered set of characters to be used for ReST heading levels')
+    aparser.add_argument(
+        "--doc-hide-comments",
+        help="Exclude comment field from being added to documentation.",
+        action="store_true",
+    )
     aparser.add_argument('--doc-no-reg-drawing', help='Disable generation of register drawings in documentation',
                          action='store_true')
     aparser.add_argument('--doc-copy-template', help='Target file to copy a template for the main file (Latex only).',
@@ -136,6 +139,8 @@ def decode_args():
         + "generation",
         action="store_true",
     )
+    aparser.add_argument('--rest-headers', default='#=-',
+                         help='Ordered set of characters to be used for ReST heading levels')
     aparser.add_argument('--input', '-i',
                          help='input file')
     aparser.add_argument('--ff-reset', choices=['sync', 'async'], default='sync',
@@ -280,14 +285,18 @@ def handle_file(args, filename):
             gen_gena_dsp.gen_gena_dsp_c(f, t)
     if args.gen_doc is not None:
         with open_filename(args.gen_doc) as f:
-            if args.doc == 'html':
-                print_html.pprint(f, t, args.doc_include_js_dep)
-            elif args.doc == 'md':
-                print_markdown.print_markdown(f, t)
-            elif args.doc == 'rest':
-                print_rest.print_rest(f, t, args.rest_headers)
-            elif args.doc == 'latex':
-                print_latex.print_latex(f, t, not args.doc_no_reg_drawing)
+            if args.doc == "html":
+                print_html.print_html(
+                    f, t, args.doc_hide_comments, args.doc_include_js_dep
+                )
+            elif args.doc == "md":
+                print_markdown.print_markdown(f, t, args.doc_hide_comments)
+            elif args.doc == "rest":
+                print_rest.print_rest(f, t, args.doc_hide_comments, args.rest_headers)
+            elif args.doc == "latex":
+                print_latex.print_latex(
+                    f, t, args.doc_hide_comments, not args.doc_no_reg_drawing
+                )
             else:
                 raise AssertionError('unknown doc format {}'.format(args.doc))
     if args.doc_copy_template is not None:

--- a/proto/cheby/parser.py
+++ b/proto/cheby/parser.py
@@ -35,7 +35,7 @@ def read_text(parent, key, val, allow_empty = False):
         else:
             error("expect a non-empty string for {}:{}".format(parent.get_path(), key))
     if isstr(val):
-        return val
+        return val.strip()
     error("expect a string for {}:{}".format(parent.get_path(), key))
 
 

--- a/proto/cheby/print_consts.py
+++ b/proto/cheby/print_consts.py
@@ -257,8 +257,8 @@ class ConstsPrinterC(ConstsPrinterH):
         self.pr_raw("#define {} {} /* {} */\n".format(self.pr_name(n) + "_SIZE", sz, cmt))
 
     def pr_address(self, n):
-        self.pr_raw('\n')
-        self.pr_raw('/* {} */\n'.format(n.comment or n.description or "(comment missing)"))
+        self.pr_raw("\n")
+        self.pr_raw("/* {} */\n".format(n.comment or "(comment missing)"))
         self.pr_hex_const(self.pr_name(n), n.c_abs_addr)
 
     def pr_field(self, f):

--- a/proto/cheby/print_html.py
+++ b/proto/cheby/print_html.py
@@ -30,22 +30,9 @@ def print_access(acc, dflt=None):
             'WRITE_ONLY': 'write-only'}.get(acc, acc)
 
 
-def print_description(description, comment=""):
+def print_description(description):
     if description is None:
         description = ""
-    if comment is None:
-        comment = ""
-
-    # Strip trailing whitespaces
-    description = description.strip()
-    comment = comment.strip()
-
-    # Concatenate description and comment
-    if comment:
-        if description:
-            description += "\n\n" + comment
-        else:
-            description = comment
 
     # Replace newlines with corresponding HTML tag
     description = description.replace("\n", "<br>")
@@ -139,7 +126,7 @@ def print_regdescr_reg(_periph, pfx, raw, num):
     for f in r.children:
         name = f.name or r.name
         access = r.access
-        description = print_description(f.description or r.description or "", f.comment)
+        description = print_description(f.description or r.description or "")
 
         res += '  <dt><b>{name}</b> [<i>{access}</i>]</dt>\n'.format(
             name=name, access=access
@@ -248,9 +235,6 @@ def phtml_header(fd, periph, print_js_dep_include=False):
 <h1 class="heading">{entity}</h1>
 <h3>{description}</h3>'''.format(
         entity=entity, description=periph.description))
-    if periph.comment:
-        wln(fd, '<p>{comment}</p>'.format(
-            comment=periph.comment.replace('\n', '<br>')))
     if periph.version is not None:
         wln(fd, "<p>Version: {}</p>".format(periph.version))
 

--- a/proto/cheby/print_latex.py
+++ b/proto/cheby/print_latex.py
@@ -108,8 +108,10 @@ def print_reg(fd, r, raw, print_reg_drawing):
         # Name
         w(fd, '{} & '.format(escape_printable(desc_src.name)))
 
-        # Description
+        # Description + comment
         desc = desc_src.description or ""
+        if desc_src.comment:
+            desc += "\n\n" + desc_src.comment
 
         desc = escape_printable(desc)
         desc = desc.replace('\n', ' \\newline ')

--- a/proto/cheby/print_latex.py
+++ b/proto/cheby/print_latex.py
@@ -42,7 +42,7 @@ def escape_printable(text):
     return text
 
 
-def print_reg(fd, r, raw, print_reg_drawing):
+def print_reg(fd, r, raw, hide_comments=False, print_reg_drawing=True):
     ACCESSES = {
         "rw": "read/write",
         "wo": "write-only",
@@ -110,7 +110,7 @@ def print_reg(fd, r, raw, print_reg_drawing):
 
         # Description + comment
         desc = desc_src.description or ""
-        if desc_src.comment:
+        if desc_src.comment and not hide_comments:
             desc += "\n\n" + desc_src.comment
 
         desc = escape_printable(desc)
@@ -137,16 +137,16 @@ def print_map_summary(fd, summary):
     wln(fd)
 
 
-def print_reg_description(fd, summary, print_reg_drawing):
+def print_reg_description(fd, summary, hide_comments=False, print_reg_drawing=True):
     for ra in summary.raws:
         r = ra.node
         if isinstance(r, tree.Reg):
             wln(fd, "\\subsubsection{{{}}}".format(escape_printable(ra.name)))
             wln(fd, '\\label{{sec:{}}}'.format(ra.name))
-            print_reg(fd, r, ra, print_reg_drawing)
+            print_reg(fd, r, ra, hide_comments, print_reg_drawing)
 
 
-def print_root(fd, root, print_reg_drawing):
+def print_root(fd, root, hide_comments=False, print_reg_drawing=True):
     wln(fd, "\\section{Memory Map Summary}")
     wln(fd, root.description or '(no description)')
     wln(fd)
@@ -158,7 +158,7 @@ def print_root(fd, root, print_reg_drawing):
         summary = gen_doc.MemmapSummary(root)
         print_map_summary(fd, summary)
         wln(fd, "\\section{Register Description}")
-        print_reg_description(fd, summary, print_reg_drawing)
+        print_reg_description(fd, summary, hide_comments, print_reg_drawing)
     else:
         summaries = [(gen_doc.MemmapSummary(space), space) for space in root.children]
         for summary, space in summaries:
@@ -167,14 +167,14 @@ def print_root(fd, root, print_reg_drawing):
         for summary, space in summaries:
             wln(fd, "\\subsection{{Register Description for Space {}}}".format(escape_printable(space.name)))
             wln(fd)
-            print_reg_description(fd, summary, print_reg_drawing)
+            print_reg_description(fd, summary, hide_comments, print_reg_drawing)
 
 
-def print_latex(fd, n, print_reg_drawing=True):
+def print_latex(fd, n, hide_comments=False, print_reg_drawing=True):
     # Print latex documentation of root n to file descriptor fd
 
     if isinstance(n, tree.Root):
-        print_root(fd, n, print_reg_drawing)
+        print_root(fd, n, hide_comments, print_reg_drawing)
     else:
         raise AssertionError
 

--- a/proto/cheby/print_latex.py
+++ b/proto/cheby/print_latex.py
@@ -108,10 +108,8 @@ def print_reg(fd, r, raw, print_reg_drawing):
         # Name
         w(fd, '{} & '.format(escape_printable(desc_src.name)))
 
-        # Description + comment
-        desc = desc_src.description or ''
-        if desc_src.comment is not None:
-            desc += '\n\n' + desc_src.comment
+        # Description
+        desc = desc_src.description or ""
 
         desc = escape_printable(desc)
         desc = desc.replace('\n', ' \\newline ')

--- a/proto/cheby/print_markdown.py
+++ b/proto/cheby/print_markdown.py
@@ -5,8 +5,10 @@ from cheby.wrutils import wln
 #  Generate markdown (asciidoc variant)
 #  Ref: https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#tables
 
-def mls(s):
-    return s.replace('\n', ' +\n')
+
+def format_text(text):
+    return text.replace("\n", " +\n")
+
 
 def print_reg(fd, r, abs_addr):
     wln(fd, "[horizontal]")
@@ -14,9 +16,15 @@ def print_reg(fd, r, abs_addr):
     wln(fd, "address:: 0x{:x}".format(abs_addr))
     wln(fd, "block offset:: 0x{:x}".format(r.c_address))
     wln(fd, "access mode:: {}".format(r.access))
+
     if r.description:
         wln(fd)
-        wln(fd, mls(r.description))
+        wln(fd, format_text(r.description))
+
+    if r.comment:
+        wln(fd)
+        wln(fd, format_text(r.comment))
+
     wln(fd)
     descr = gen_doc.build_regdescr_table(r)
     wln(fd, '[cols="8*^"]')
@@ -36,11 +44,20 @@ def print_reg(fd, r, abs_addr):
         wln(fd)
         for f in r.children:
             wln(fd, "{}::".format(f.name))
+
             if f.description:
-                wln(fd, mls(f.description))
-            else:
+                wln(fd, format_text(f.description))
+
+            if f.comment:
+                if f.description:
+                    wln(fd, "+")
+                wln(fd, format_text(f.comment))
+
+            if not any((f.comment, f.description)):
                 wln(fd, "(not documented)")
+
         wln(fd)
+
 
 def print_map_summary(fd, summary):
     wln(fd, "|===")

--- a/proto/cheby/print_markdown.py
+++ b/proto/cheby/print_markdown.py
@@ -14,10 +14,9 @@ def print_reg(fd, r, abs_addr):
     wln(fd, "address:: 0x{:x}".format(abs_addr))
     wln(fd, "block offset:: 0x{:x}".format(r.c_address))
     wln(fd, "access mode:: {}".format(r.access))
-    for t in (r.comment, r.description):
-        if t:
-            wln(fd)
-            wln(fd, mls(t))
+    if r.description:
+        wln(fd)
+        wln(fd, mls(r.description))
     wln(fd)
     descr = gen_doc.build_regdescr_table(r)
     wln(fd, '[cols="8*^"]')
@@ -37,14 +36,10 @@ def print_reg(fd, r, abs_addr):
         wln(fd)
         for f in r.children:
             wln(fd, "{}::".format(f.name))
-            if f.comment:
-                wln(fd, mls(f.comment))
-                if f.description:
-                    wln(fd, '+')
             if f.description:
                 wln(fd, mls(f.description))
-            if not any((f.comment, f.description)):
-                wln(fd, '(not documented)')
+            else:
+                wln(fd, "(not documented)")
         wln(fd)
 
 def print_map_summary(fd, summary):

--- a/proto/cheby/print_markdown.py
+++ b/proto/cheby/print_markdown.py
@@ -10,7 +10,7 @@ def format_text(text):
     return text.replace("\n", " +\n")
 
 
-def print_reg(fd, r, abs_addr):
+def print_reg(fd, r, abs_addr, hide_comments=False):
     wln(fd, "[horizontal]")
     wln(fd, "HDL name:: {}".format(r.c_name))
     wln(fd, "address:: 0x{:x}".format(abs_addr))
@@ -45,15 +45,18 @@ def print_reg(fd, r, abs_addr):
         for f in r.children:
             wln(fd, "{}::".format(f.name))
 
+            not_documented = True
             if f.description:
                 wln(fd, format_text(f.description))
+                not_documented = False
 
-            if f.comment:
+            if f.comment and not hide_comments:
                 if f.description:
                     wln(fd, "+")
                 wln(fd, format_text(f.comment))
+                not_documented = False
 
-            if not any((f.comment, f.description)):
+            if not_documented:
                 wln(fd, "(not documented)")
 
         wln(fd)
@@ -72,15 +75,15 @@ def print_map_summary(fd, summary):
     wln(fd)
 
 
-def print_reg_description(fd, summary):
+def print_reg_description(fd, summary, hide_comments=False):
     for ra in summary.raws:
         r = ra.node
         if isinstance(r, tree.Reg):
             wln(fd, "=== {}".format(ra.name))
-            print_reg(fd, r, ra.abs_addr)
+            print_reg(fd, r, ra.abs_addr, hide_comments)
 
 
-def print_root(fd, root):
+def print_root(fd, root, hide_comments=False):
     wln(fd, "== Memory map summary")
     wln(fd, root.description or '(no description)')
     wln(fd)
@@ -92,7 +95,7 @@ def print_root(fd, root):
         summary = gen_doc.MemmapSummary(root)
         print_map_summary(fd, summary)
         wln(fd, "== Registers description")
-        print_reg_description(fd, summary)
+        print_reg_description(fd, summary, hide_comments)
     else:
         summaries = [(gen_doc.MemmapSummary(space), space) for space in root.children]
         for summary, space in summaries:
@@ -100,11 +103,11 @@ def print_root(fd, root):
             print_map_summary(fd, summary)
         for summary, space in summaries:
             wln(fd, "== Registers description for space {}\n".format(space.name))
-            print_reg_description(fd, summary)
+            print_reg_description(fd, summary, hide_comments)
 
 
-def print_markdown(fd, n):
+def print_markdown(fd, n, hide_comments=False):
     if isinstance(n, tree.Root):
-        print_root(fd, n)
+        print_root(fd, n, hide_comments)
     else:
         raise AssertionError

--- a/proto/cheby/print_rest.py
+++ b/proto/cheby/print_rest.py
@@ -54,7 +54,16 @@ def print_reg(fd, r, abs_addr):
     if r.has_fields():
         for f in r.children:
             wln(fd, f.name)
-            wln(fd, "  {}".format(f.description or "(not documented)"))
+
+            if f.description:
+                wln(fd, "  {}".format(f.description))
+
+            if f.comment:
+                wln(fd, "  {}".format(f.comment))
+
+            if not f.description and not f.comment:
+                wln(fd, "  (not documented)")
+
         wln(fd)
 
 

--- a/proto/cheby/print_rest.py
+++ b/proto/cheby/print_rest.py
@@ -54,9 +54,7 @@ def print_reg(fd, r, abs_addr):
     if r.has_fields():
         for f in r.children:
             wln(fd, f.name)
-            wln(fd, "  {}".format(f.comment or
-                                  f.description or
-                                  '(not documented)'))
+            wln(fd, "  {}".format(f.description or "(not documented)"))
         wln(fd)
 
 

--- a/proto/cheby/print_rest.py
+++ b/proto/cheby/print_rest.py
@@ -22,7 +22,7 @@ def wtable(fd, table):
         wln(fd, '+' + ''.join('-' * (l + 2) + '+' for l in lens))
 
 
-def print_reg(fd, r, abs_addr):
+def print_reg(fd, r, abs_addr, hide_comments=False):
     wln(fd)
     w(fd, "* HDL name:")
     wln(fd, "  {}".format(r.c_name))
@@ -55,13 +55,16 @@ def print_reg(fd, r, abs_addr):
         for f in r.children:
             wln(fd, f.name)
 
+            not_documented = True
             if f.description:
                 wln(fd, "  {}".format(f.description))
+                not_documented = False
 
-            if f.comment:
+            if f.comment and not hide_comments:
                 wln(fd, "  {}".format(f.comment))
+                not_documented = False
 
-            if not f.description and not f.comment:
+            if not_documented:
                 wln(fd, "  (not documented)")
 
         wln(fd)
@@ -78,17 +81,17 @@ def print_map_summary(fd, summary):
     wln(fd)
 
 
-def print_reg_description(fd, summary, heading):
+def print_reg_description(fd, summary, heading, hide_comments=False):
     for ra in summary.raws:
         r = ra.node
         if isinstance(r, tree.Reg):
             wln(fd, "{}".format(ra.name))
             wln(fd, heading * len(ra.name))
             wln(fd)
-            print_reg(fd, r, ra.abs_addr)
+            print_reg(fd, r, ra.abs_addr, hide_comments)
 
 
-def print_root(fd, root, heading):
+def print_root(fd, root, heading, hide_comments=False):
     title = "Memory map summary"
     wln(fd, heading[0] * len(title))
     wln(fd, title)
@@ -108,7 +111,7 @@ def print_root(fd, root, heading):
         title = "Registers description"
         wln(fd, title)
         wln(fd, heading[1] * len(title))
-        print_reg_description(fd, summary, heading[2])
+        print_reg_description(fd, summary, heading[2], hide_comments)
     else:
         summaries = [(gen_doc.MemmapSummary(space), space) for space in root.children]
         for summary, space in summaries:
@@ -120,8 +123,8 @@ def print_root(fd, root, heading):
             title = "Registers description for space {}\n".format(space.name)
             wln(fd, title)
             wln(fd, heading[1] * len(title))
-            print_reg_description(fd, summary, heading[2])
+            print_reg_description(fd, summary, heading[2], hide_comments)
 
-def print_rest(fd, n, heading="#=-"):
+def print_rest(fd, n, heading="#=-", hide_comments=False):
     assert isinstance(n, tree.Root)
-    print_root(fd, n, heading)
+    print_root(fd, n, heading, hide_comments)

--- a/proto/tests.py
+++ b/proto/tests.py
@@ -284,7 +284,7 @@ def test_genc_ref():
         gen_c.gen_c_cheby(buf, t, 'neutral')
         if not compare_buffer_and_file(buf, h_file):
             error('c header generation error for {}'.format(f))
-        
+
         # Check C syntax
         # Note: Exclude issue103/top because it includes other header files
         # not generated here.
@@ -948,7 +948,7 @@ def test_doc():
         layout.sort_tree(t)
 
         for file, pprint, style in [
-                (html_file, print_html.pprint, 'html'),
+                (html_file, print_html.print_html, 'html'),
                 (md_file, print_markdown.print_markdown, 'md'),
                 (rst_file, print_rest.print_rest, 'rst'),
                 (latex_file, print_latex.print_latex, 'latex')]:

--- a/testfiles/bug-cernbe/repro.sv
+++ b/testfiles/bug-cernbe/repro.sv
@@ -11,7 +11,7 @@ module example
     output  wire VMERdDone,
     output  wire VMEWrDone,
 
-    // The first register (with some fields)
+    // REG regA
     output  wire [31:0] regA_o,
 
     // cern-be-vme bus sm

--- a/testfiles/bug-cernbe/repro.v
+++ b/testfiles/bug-cernbe/repro.v
@@ -11,7 +11,7 @@ module example
     output  wire VMERdDone,
     output  wire VMEWrDone,
 
-    // The first register (with some fields)
+    // REG regA
     output  wire [31:0] regA_o,
 
     // cern-be-vme bus sm

--- a/testfiles/bug-cernbe/repro.vhdl
+++ b/testfiles/bug-cernbe/repro.vhdl
@@ -14,7 +14,7 @@ entity example is
     VMERdDone            : out   std_logic;
     VMEWrDone            : out   std_logic;
 
-    -- The first register (with some fields)
+    -- REG regA
     regA_o               : out   std_logic_vector(31 downto 0);
 
     -- cern-be-vme bus sm

--- a/testfiles/bug-cernbe/sub_repro.sv
+++ b/testfiles/bug-cernbe/sub_repro.sv
@@ -11,10 +11,10 @@ module sub_repro
     output  wire VMERdDone,
     output  wire VMEWrDone,
 
-    // The first register (with some fields)
+    // REG subrA
     output  wire [15:0] subrA_o,
 
-    // The first register (with some fields)
+    // REG subrB
     input   wire [15:0] subrB_i
   );
   wire rst_n;

--- a/testfiles/bug-cernbe/sub_repro.v
+++ b/testfiles/bug-cernbe/sub_repro.v
@@ -11,10 +11,10 @@ module sub_repro
     output  wire VMERdDone,
     output  wire VMEWrDone,
 
-    // The first register (with some fields)
+    // REG subrA
     output  wire [15:0] subrA_o,
 
-    // The first register (with some fields)
+    // REG subrB
     input   wire [15:0] subrB_i
   );
   wire rst_n;

--- a/testfiles/bug-cernbe/sub_repro.vhdl
+++ b/testfiles/bug-cernbe/sub_repro.vhdl
@@ -14,10 +14,10 @@ entity sub_repro is
     VMERdDone            : out   std_logic;
     VMEWrDone            : out   std_logic;
 
-    -- The first register (with some fields)
+    -- REG subrA
     subrA_o              : out   std_logic_vector(15 downto 0);
 
-    -- The first register (with some fields)
+    -- REG subrB
     subrB_i              : in    std_logic_vector(15 downto 0)
   );
 end sub_repro;

--- a/testfiles/bug-gen-c-02/fip_urv_regs.h
+++ b/testfiles/bug-gen-c-02/fip_urv_regs.h
@@ -7,14 +7,14 @@
 #include "mbox_regs.h"
 #define FIP_URV_REGS_SIZE 16384 /* 0x4000 = 16KB */
 
-/* PLC processor control */
+/* (comment missing) */
 #define FIP_URV_REGS_PLC_CTRL 0x0UL
 #define FIP_URV_REGS_PLC_CTRL_RSTN 0x1UL
 #define FIP_URV_REGS_PLC_CTRL_RSTN_MASK 0x1UL
 #define FIP_URV_REGS_PLC_CTRL_RSTN_SHIFT 0
 #define FIP_URV_REGS_PLC_CTRL_RSTN_PRESET 0x0UL
 
-/* Status bits from NanoFIP */
+/* (comment missing) */
 #define FIP_URV_REGS_FIP_STATUS 0x4UL
 #define FIP_URV_REGS_FIP_STATUS_VAR1_RDY 0x1UL
 #define FIP_URV_REGS_FIP_STATUS_VAR1_RDY_MASK 0x1UL
@@ -23,13 +23,13 @@
 #define FIP_URV_REGS_FIP_STATUS_VAR3_RDY_MASK 0x2UL
 #define FIP_URV_REGS_FIP_STATUS_VAR3_RDY_SHIFT 1
 
-/* Set access to var 1 */
+/* (comment missing) */
 #define FIP_URV_REGS_FIP_VAR1 0x8UL
 #define FIP_URV_REGS_FIP_VAR1_ACC 0x1UL
 #define FIP_URV_REGS_FIP_VAR1_ACC_MASK 0x1UL
 #define FIP_URV_REGS_FIP_VAR1_ACC_SHIFT 0
 
-/* Set access to var 1 */
+/* (comment missing) */
 #define FIP_URV_REGS_FIP_VAR3 0xcUL
 #define FIP_URV_REGS_FIP_VAR3_ACC 0x1UL
 #define FIP_URV_REGS_FIP_VAR3_ACC_MASK 0x1UL
@@ -40,12 +40,12 @@
 #define ADDR_MASK_FIP_URV_REGS_MAILBOXES 0x3ff0UL
 #define FIP_URV_REGS_MAILBOXES_SIZE 16 /* 0x10 */
 
-/* presence lines for boards */
+/* (comment missing) */
 #define FIP_URV_REGS_PRESENCE 0x20UL
 #define FIP_URV_REGS_PRESENCE_EN_MASK 0xffUL
 #define FIP_URV_REGS_PRESENCE_EN_SHIFT 0
 
-/* led */
+/* (comment missing) */
 #define FIP_URV_REGS_LEDS 0x24UL
 #define FIP_URV_REGS_LEDS_VAL_MASK 0x3fUL
 #define FIP_URV_REGS_LEDS_VAL_SHIFT 0
@@ -57,28 +57,28 @@
 /* (comment missing) */
 #define FIP_URV_REGS_BOARDS_PINS 0x0UL
 
-/* NanoFIP internal memory/registers */
+/* (comment missing) */
 #define FIP_URV_REGS_FIP_REG 0x800UL
 #define ADDR_MASK_FIP_URV_REGS_FIP_REG 0x3800UL
 #define FIP_URV_REGS_FIP_REG_SIZE 2048 /* 0x800 = 2KB */
 
-/* Memory of the PLC urv */
+/* (comment missing) */
 #define FIP_URV_REGS_PLC_MEM 0x2000UL
 #define ADDR_MASK_FIP_URV_REGS_PLC_MEM 0x2000UL
 #define FIP_URV_REGS_PLC_MEM_SIZE 8192 /* 0x2000 = 8KB */
 
 #ifndef __ASSEMBLER__
 struct fip_urv_regs {
-  /* [0x0]: REG (rw) PLC processor control */
+  /* [0x0]: REG (rw) (comment missing) */
   uint32_t plc_ctrl;
 
-  /* [0x4]: REG (ro) Status bits from NanoFIP */
+  /* [0x4]: REG (ro) (comment missing) */
   uint32_t fip_status;
 
-  /* [0x8]: REG (rw) Set access to var 1 */
+  /* [0x8]: REG (rw) (comment missing) */
   uint32_t fip_var1;
 
-  /* [0xc]: REG (rw) Set access to var 1 */
+  /* [0xc]: REG (rw) (comment missing) */
   uint32_t fip_var3;
 
   /* [0x10]: SUBMAP (comment missing) */
@@ -87,10 +87,10 @@ struct fip_urv_regs {
   /* padding to: 32 Bytes */
   uint32_t __padding_0[1];
 
-  /* [0x20]: REG (ro) presence lines for boards */
+  /* [0x20]: REG (ro) (comment missing) */
   uint32_t presence;
 
-  /* [0x24]: REG (rw) led */
+  /* [0x24]: REG (rw) (comment missing) */
   uint32_t leds;
 
   /* padding to: 64 Bytes */
@@ -105,13 +105,13 @@ struct fip_urv_regs {
   /* padding to: 2048 Bytes */
   uint32_t __padding_2[488];
 
-  /* [0x800]: SUBMAP NanoFIP internal memory/registers */
+  /* [0x800]: SUBMAP (comment missing) */
   uint32_t fip_reg[512];
 
   /* padding to: 8192 Bytes */
   uint32_t __padding_3[1024];
 
-  /* [0x2000]: SUBMAP Memory of the PLC urv */
+  /* [0x2000]: SUBMAP (comment missing) */
   uint32_t plc_mem[2048];
 };
 #endif /* !__ASSEMBLER__*/

--- a/testfiles/bug-gen-c-02/mbox_regs.h
+++ b/testfiles/bug-gen-c-02/mbox_regs.h
@@ -5,13 +5,13 @@
 
 #define MBOX_REGS_SIZE 12 /* 0xc */
 
-/* Mailbox to the fip urv */
+/* (comment missing) */
 #define MBOX_REGS_MBOXOUT 0x0UL
 
-/* Mailbox from the fip urv */
+/* (comment missing) */
 #define MBOX_REGS_MBOXIN 0x4UL
 
-/* Status for mailboxes */
+/* (comment missing) */
 #define MBOX_REGS_STATUS 0x8UL
 #define MBOX_REGS_STATUS_MBIN 0x1UL
 #define MBOX_REGS_STATUS_MBIN_MASK 0x1UL
@@ -22,13 +22,13 @@
 
 #ifndef __ASSEMBLER__
 struct mbox_regs {
-  /* [0x0]: REG (wo) Mailbox to the fip urv */
+  /* [0x0]: REG (wo) (comment missing) */
   uint32_t mboxout;
 
-  /* [0x4]: REG (ro) Mailbox from the fip urv */
+  /* [0x4]: REG (ro) (comment missing) */
   uint32_t mboxin;
 
-  /* [0x8]: REG (ro) Status for mailboxes */
+  /* [0x8]: REG (ro) (comment missing) */
   uint32_t status;
 };
 #endif /* !__ASSEMBLER__*/

--- a/testfiles/bug-memory/mem64ro.sv
+++ b/testfiles/bug-memory/mem64ro.sv
@@ -15,8 +15,7 @@ module mem64ro
     output  wire wb_stall_o,
     output  reg [31:0] wb_dat_o,
 
-    // The first register (with some fields)
-    // 1-bit field
+    // REG regA
     output  wire regA_field0_o,
 
     // RAM port for DdrCapturesIndex

--- a/testfiles/bug-memory/mem64ro.v
+++ b/testfiles/bug-memory/mem64ro.v
@@ -15,8 +15,7 @@ module mem64ro
     output  wire wb_stall_o,
     output  reg [31:0] wb_dat_o,
 
-    // The first register (with some fields)
-    // 1-bit field
+    // REG regA
     output  wire regA_field0_o,
 
     // RAM port for DdrCapturesIndex

--- a/testfiles/bug-memory/mem64ro.vhdl
+++ b/testfiles/bug-memory/mem64ro.vhdl
@@ -19,8 +19,7 @@ entity mem64ro is
     wb_stall_o           : out   std_logic;
     wb_dat_o             : out   std_logic_vector(31 downto 0);
 
-    -- The first register (with some fields)
-    -- 1-bit field
+    -- REG regA
     regA_field0_o        : out   std_logic;
 
     -- RAM port for DdrCapturesIndex

--- a/testfiles/bug-repmem/bran.sv
+++ b/testfiles/bug-repmem/bran.sv
@@ -3,121 +3,87 @@ module bran_wb
   (
     t_wishbone.slave wb,
 
-    // Block identifier - returns 0xcafebeef
+    // REG Token
     input   wire [31:0] Token_i,
 
-    // Common controls
-    // 1 enables the module
+    // REG Ctrl
     output  wire Enable_o,
-    // 1 clears BST_desync flag in stat
     output  wire std_rst_bst_desync,
-    // 1 resets the frame aligner
     output  wire std_reset_alignment,
-    // 1 to zeros instead of ADC data
     output  wire DisableADCStream_o,
-    // 1 to use internal turn clock emulator
     output  wire EnableTurnEmulator_o,
     // Bit indicates whether turn emulator shall provide LHC or SPS timing. If this bit is set, the turn emulator will provide turn clock once every 3564 bunch clocks. Otherwise the turn emulator will emulate SPS timing with its 924 bunch slots
     output  wire LHC_timing,
 
-    // General status work
-    // 1 indicates loss of signal JESD
+    // REG Stat
     input   wire FmcLos_i,
-    // 1 indicates loss of lock JESD
     input   wire FmcLol_i,
-    // 1 indicates error of sysref
     input   wire SysrefFail_i,
-    // 1 indicates DCDC sync is enabled
     input   wire DCDCSyncEnabled_i,
-    // 1 indicates ADC pattern check failed
     input   wire PatternFail_i,
-    // 1 indicates FA waiting for turn clock
     input   wire std_fa_in_reset,
-    // 1 if GBT PLL is not locked
     input   wire GBTPLLLol_i,
-    // 1 if BST turn and bunch clock do not  match
     input   wire std_bst_desynced,
-    // 1 if FMC is NOT powered
     input   wire VfmcDisabled_i,
-    // 1 if no turn mark arrives to capture block
     input   wire NoTurnDetected_i,
-    // 1 if turn emulator is wrongly setup
     input   wire TurnEmulatorError_i,
-    // 1 if turn emulator PLL is not locked
     input   wire TurnEmulatorPLLError_i,
-    // 1 for each line not ready
     input   wire [7:0] JesdRXNotReady_i,
-    // 1 indicates fail of DCDC converter
     input   wire [7:0] VoltageFail_i,
 
-    // Number of ticks detected on sysref clock
+    // REG SysrefTicks
     input   wire [31:0] SysrefTicks_i,
 
-    // Compilation time of gateware
+    // REG GWRevision
     input   wire [31:0] GWRevision_i,
 
-    // Turn emulator period in 8ns increments
+    // REG TurnPeriod
     output  wire [31:0] TurnPeriod_o,
     output  wire TurnPeriod_wr_o,
 
-    // Turn emulator length in 8ns increments
+    // REG TurnLength
     output  wire [31:0] TurnLength_o,
     output  wire TurnLength_wr_o,
 
-    // Upcounts when turn HW or emulated detected
+    // REG TurnsIntercepted
     input   wire [31:0] TurnsIntercepted_b32,
 
-    // Power control of the FMC mezzanine
-    // Enables/disables power to FMC
+    // REG FmcPower
     output  wire FmcPowerEnable_o,
-    // Enables/disables synchronization of DCDC converters on the IAM
     output  wire DCDCSyncEnable_o,
 
-    // ADC pattern checher module control
-    // Resets pattern checking
+    // REG ADCPatternCheckCtrl
     output  wire PatternRst_o,
 
-    // ADC specific control register
-    // ADC reset control
+    // REG ADCCtrl
     output  wire ADCRst_o,
-    // Enables ADC conversion
     output  wire ADCEnable_o,
-    // Synchronization signal value
     output  wire ADCManualSync_o,
-    // 1 = sync comes from ADCManualSync
     output  wire ADCDisableAutoSync_o,
 
-    // JESD204B link interface control
-    // JESD PHY and MAC reset
+    // REG JesdLink
     output  wire JesdXcvrRst_o,
-    // JESD Link interface reset
     output  wire JesdLinkRst_o,
-    // JESD GBT PLL reset
     output  wire JesdPLLRst_o,
-    // MAC wishbone infterface reset
     output  wire JesdAvsRst_o,
-    // 0-1-0 to reset the FMC PLL chip
     output  wire SixxRst_o,
-    // Set link to ready state
     output  wire JesdLinkReady_o,
-    // Enable/disable JESD sysref signal
     output  wire JesdEnableSysref_o,
 
-    // ADC SPI write configuration interface
+    // REG AdcSpiWrite
     output  wire [31:0] AdcSpiWrite_o,
     output  wire AdcSpiWrite_wr_o,
 
-    // ADC SPI read configuration interface
+    // REG AdcSpiRead
     input   wire [31:0] AdcSpiRead_i,
 
-    // SPI status
-    // 1 if SPI sends data to ADC
+    // REG SpiStatus
     input   wire AdcSpiBusy_i,
 
-    // For how many turns to accumulate data
+    // REG CummulativeTurns
     output  wire [31:0] cummulative_turns_b32,
 
-    // Master-of-universe-tool
+    // REG Debug
     output  wire OverrideTurnEmulatorTiming,
 
     // SRAM bus RawData0

--- a/testfiles/bug-repmem/bran.v
+++ b/testfiles/bug-repmem/bran.v
@@ -3,121 +3,87 @@ module bran_wb
   (
     t_wishbone.slave wb,
 
-    // Block identifier - returns 0xcafebeef
+    // REG Token
     input   wire [31:0] Token_i,
 
-    // Common controls
-    // 1 enables the module
+    // REG Ctrl
     output  wire Enable_o,
-    // 1 clears BST_desync flag in stat
     output  wire std_rst_bst_desync,
-    // 1 resets the frame aligner
     output  wire std_reset_alignment,
-    // 1 to zeros instead of ADC data
     output  wire DisableADCStream_o,
-    // 1 to use internal turn clock emulator
     output  wire EnableTurnEmulator_o,
     // Bit indicates whether turn emulator shall provide LHC or SPS timing. If this bit is set, the turn emulator will provide turn clock once every 3564 bunch clocks. Otherwise the turn emulator will emulate SPS timing with its 924 bunch slots
     output  wire LHC_timing,
 
-    // General status work
-    // 1 indicates loss of signal JESD
+    // REG Stat
     input   wire FmcLos_i,
-    // 1 indicates loss of lock JESD
     input   wire FmcLol_i,
-    // 1 indicates error of sysref
     input   wire SysrefFail_i,
-    // 1 indicates DCDC sync is enabled
     input   wire DCDCSyncEnabled_i,
-    // 1 indicates ADC pattern check failed
     input   wire PatternFail_i,
-    // 1 indicates FA waiting for turn clock
     input   wire std_fa_in_reset,
-    // 1 if GBT PLL is not locked
     input   wire GBTPLLLol_i,
-    // 1 if BST turn and bunch clock do not  match
     input   wire std_bst_desynced,
-    // 1 if FMC is NOT powered
     input   wire VfmcDisabled_i,
-    // 1 if no turn mark arrives to capture block
     input   wire NoTurnDetected_i,
-    // 1 if turn emulator is wrongly setup
     input   wire TurnEmulatorError_i,
-    // 1 if turn emulator PLL is not locked
     input   wire TurnEmulatorPLLError_i,
-    // 1 for each line not ready
     input   wire [7:0] JesdRXNotReady_i,
-    // 1 indicates fail of DCDC converter
     input   wire [7:0] VoltageFail_i,
 
-    // Number of ticks detected on sysref clock
+    // REG SysrefTicks
     input   wire [31:0] SysrefTicks_i,
 
-    // Compilation time of gateware
+    // REG GWRevision
     input   wire [31:0] GWRevision_i,
 
-    // Turn emulator period in 8ns increments
+    // REG TurnPeriod
     output  wire [31:0] TurnPeriod_o,
     output  wire TurnPeriod_wr_o,
 
-    // Turn emulator length in 8ns increments
+    // REG TurnLength
     output  wire [31:0] TurnLength_o,
     output  wire TurnLength_wr_o,
 
-    // Upcounts when turn HW or emulated detected
+    // REG TurnsIntercepted
     input   wire [31:0] TurnsIntercepted_b32,
 
-    // Power control of the FMC mezzanine
-    // Enables/disables power to FMC
+    // REG FmcPower
     output  wire FmcPowerEnable_o,
-    // Enables/disables synchronization of DCDC converters on the IAM
     output  wire DCDCSyncEnable_o,
 
-    // ADC pattern checher module control
-    // Resets pattern checking
+    // REG ADCPatternCheckCtrl
     output  wire PatternRst_o,
 
-    // ADC specific control register
-    // ADC reset control
+    // REG ADCCtrl
     output  wire ADCRst_o,
-    // Enables ADC conversion
     output  wire ADCEnable_o,
-    // Synchronization signal value
     output  wire ADCManualSync_o,
-    // 1 = sync comes from ADCManualSync
     output  wire ADCDisableAutoSync_o,
 
-    // JESD204B link interface control
-    // JESD PHY and MAC reset
+    // REG JesdLink
     output  wire JesdXcvrRst_o,
-    // JESD Link interface reset
     output  wire JesdLinkRst_o,
-    // JESD GBT PLL reset
     output  wire JesdPLLRst_o,
-    // MAC wishbone infterface reset
     output  wire JesdAvsRst_o,
-    // 0-1-0 to reset the FMC PLL chip
     output  wire SixxRst_o,
-    // Set link to ready state
     output  wire JesdLinkReady_o,
-    // Enable/disable JESD sysref signal
     output  wire JesdEnableSysref_o,
 
-    // ADC SPI write configuration interface
+    // REG AdcSpiWrite
     output  wire [31:0] AdcSpiWrite_o,
     output  wire AdcSpiWrite_wr_o,
 
-    // ADC SPI read configuration interface
+    // REG AdcSpiRead
     input   wire [31:0] AdcSpiRead_i,
 
-    // SPI status
-    // 1 if SPI sends data to ADC
+    // REG SpiStatus
     input   wire AdcSpiBusy_i,
 
-    // For how many turns to accumulate data
+    // REG CummulativeTurns
     output  wire [31:0] cummulative_turns_b32,
 
-    // Master-of-universe-tool
+    // REG Debug
     output  wire OverrideTurnEmulatorTiming,
 
     // SRAM bus RawData0

--- a/testfiles/bug-repmem/bran.vhdl
+++ b/testfiles/bug-repmem/bran.vhdl
@@ -10,121 +10,87 @@ entity bran_wb is
     wb_i                 : in    t_wishbone_slave_in;
     wb_o                 : out   t_wishbone_slave_out;
 
-    -- Block identifier - returns 0xcafebeef
+    -- REG Token
     Token_i              : in    std_logic_vector(31 downto 0);
 
-    -- Common controls
-    -- 1 enables the module
+    -- REG Ctrl
     Enable_o             : out   std_logic;
-    -- 1 clears BST_desync flag in stat
     std_rst_bst_desync   : out   std_logic;
-    -- 1 resets the frame aligner
     std_reset_alignment  : out   std_logic;
-    -- 1 to zeros instead of ADC data
     DisableADCStream_o   : out   std_logic;
-    -- 1 to use internal turn clock emulator
     EnableTurnEmulator_o : out   std_logic;
     -- Bit indicates whether turn emulator shall provide LHC or SPS timing. If this bit is set, the turn emulator will provide turn clock once every 3564 bunch clocks. Otherwise the turn emulator will emulate SPS timing with its 924 bunch slots
     LHC_timing           : out   std_logic;
 
-    -- General status work
-    -- 1 indicates loss of signal JESD
+    -- REG Stat
     FmcLos_i             : in    std_logic;
-    -- 1 indicates loss of lock JESD
     FmcLol_i             : in    std_logic;
-    -- 1 indicates error of sysref
     SysrefFail_i         : in    std_logic;
-    -- 1 indicates DCDC sync is enabled
     DCDCSyncEnabled_i    : in    std_logic;
-    -- 1 indicates ADC pattern check failed
     PatternFail_i        : in    std_logic;
-    -- 1 indicates FA waiting for turn clock
     std_fa_in_reset      : in    std_logic;
-    -- 1 if GBT PLL is not locked
     GBTPLLLol_i          : in    std_logic;
-    -- 1 if BST turn and bunch clock do not  match
     std_bst_desynced     : in    std_logic;
-    -- 1 if FMC is NOT powered
     VfmcDisabled_i       : in    std_logic;
-    -- 1 if no turn mark arrives to capture block
     NoTurnDetected_i     : in    std_logic;
-    -- 1 if turn emulator is wrongly setup
     TurnEmulatorError_i  : in    std_logic;
-    -- 1 if turn emulator PLL is not locked
     TurnEmulatorPLLError_i : in    std_logic;
-    -- 1 for each line not ready
     JesdRXNotReady_i     : in    std_logic_vector(7 downto 0);
-    -- 1 indicates fail of DCDC converter
     VoltageFail_i        : in    std_logic_vector(7 downto 0);
 
-    -- Number of ticks detected on sysref clock
+    -- REG SysrefTicks
     SysrefTicks_i        : in    std_logic_vector(31 downto 0);
 
-    -- Compilation time of gateware
+    -- REG GWRevision
     GWRevision_i         : in    std_logic_vector(31 downto 0);
 
-    -- Turn emulator period in 8ns increments
+    -- REG TurnPeriod
     TurnPeriod_o         : out   std_logic_vector(31 downto 0);
     TurnPeriod_wr_o      : out   std_logic;
 
-    -- Turn emulator length in 8ns increments
+    -- REG TurnLength
     TurnLength_o         : out   std_logic_vector(31 downto 0);
     TurnLength_wr_o      : out   std_logic;
 
-    -- Upcounts when turn HW or emulated detected
+    -- REG TurnsIntercepted
     TurnsIntercepted_b32 : in    std_logic_vector(31 downto 0);
 
-    -- Power control of the FMC mezzanine
-    -- Enables/disables power to FMC
+    -- REG FmcPower
     FmcPowerEnable_o     : out   std_logic;
-    -- Enables/disables synchronization of DCDC converters on the IAM
     DCDCSyncEnable_o     : out   std_logic;
 
-    -- ADC pattern checher module control
-    -- Resets pattern checking
+    -- REG ADCPatternCheckCtrl
     PatternRst_o         : out   std_logic;
 
-    -- ADC specific control register
-    -- ADC reset control
+    -- REG ADCCtrl
     ADCRst_o             : out   std_logic;
-    -- Enables ADC conversion
     ADCEnable_o          : out   std_logic;
-    -- Synchronization signal value
     ADCManualSync_o      : out   std_logic;
-    -- 1 = sync comes from ADCManualSync
     ADCDisableAutoSync_o : out   std_logic;
 
-    -- JESD204B link interface control
-    -- JESD PHY and MAC reset
+    -- REG JesdLink
     JesdXcvrRst_o        : out   std_logic;
-    -- JESD Link interface reset
     JesdLinkRst_o        : out   std_logic;
-    -- JESD GBT PLL reset
     JesdPLLRst_o         : out   std_logic;
-    -- MAC wishbone infterface reset
     JesdAvsRst_o         : out   std_logic;
-    -- 0-1-0 to reset the FMC PLL chip
     SixxRst_o            : out   std_logic;
-    -- Set link to ready state
     JesdLinkReady_o      : out   std_logic;
-    -- Enable/disable JESD sysref signal
     JesdEnableSysref_o   : out   std_logic;
 
-    -- ADC SPI write configuration interface
+    -- REG AdcSpiWrite
     AdcSpiWrite_o        : out   std_logic_vector(31 downto 0);
     AdcSpiWrite_wr_o     : out   std_logic;
 
-    -- ADC SPI read configuration interface
+    -- REG AdcSpiRead
     AdcSpiRead_i         : in    std_logic_vector(31 downto 0);
 
-    -- SPI status
-    -- 1 if SPI sends data to ADC
+    -- REG SpiStatus
     AdcSpiBusy_i         : in    std_logic;
 
-    -- For how many turns to accumulate data
+    -- REG CummulativeTurns
     cummulative_turns_b32 : out   std_logic_vector(31 downto 0);
 
-    -- Master-of-universe-tool
+    -- REG Debug
     OverrideTurnEmulatorTiming : out   std_logic;
 
     -- SRAM bus RawData0

--- a/testfiles/bug-same-label/same_label.h
+++ b/testfiles/bug-same-label/same_label.h
@@ -5,21 +5,21 @@
 
 #define SAME_LABEL_REG_SIZE 16 /* 0x10 */
 
-/* Register without fields. */
+/* (comment missing) */
 #define SAME_LABEL_REG_NO_FIELDS 0x0UL
 #define SAME_LABEL_REG_NO_FIELDS_PRESET 0x20UL
 
-/* Register with same-name field. */
+/* (comment missing) */
 #define SAME_LABEL_REG_SAME_NAME 0x4UL
 #define SAME_LABEL_REG_SAME_NAME_MASK 0x1UL
 #define SAME_LABEL_REG_SAME_NAME_SHIFT 0
 
-/* Register with multi-bit same-name field. */
+/* (comment missing) */
 #define SAME_LABEL_REG_SAME_NAME_MULTI 0x8UL
 #define SAME_LABEL_REG_SAME_NAME_MULTI_MASK 0xfffUL
 #define SAME_LABEL_REG_SAME_NAME_MULTI_SHIFT 0
 
-/* Register with different-name field. */
+/* (comment missing) */
 #define SAME_LABEL_REG_NOT_SAME_REG 0xcUL
 #define SAME_LABEL_REG_NOT_SAME 0x1UL
 #define SAME_LABEL_REG_NOT_SAME_MASK 0x1UL
@@ -27,19 +27,19 @@
 
 #ifndef __ASSEMBLER__
 struct same_label_reg {
-  /* [0x0]: REG (ro) Register without fields. */
+  /* [0x0]: REG (ro) (comment missing) */
   uint8_t no_fields;
 
   /* padding to: 4 Bytes */
   uint8_t __padding_0[3];
 
-  /* [0x4]: REG (ro) Register with same-name field. */
+  /* [0x4]: REG (ro) (comment missing) */
   uint32_t same_name;
 
-  /* [0x8]: REG (ro) Register with multi-bit same-name field. */
+  /* [0x8]: REG (ro) (comment missing) */
   uint32_t same_name_multi;
 
-  /* [0xc]: REG (ro) Register with different-name field. */
+  /* [0xc]: REG (ro) (comment missing) */
   uint32_t not_same_reg;
 };
 #endif /* !__ASSEMBLER__*/

--- a/testfiles/features/mem64ro.sv
+++ b/testfiles/features/mem64ro.sv
@@ -15,8 +15,7 @@ module mem64ro
     output  wire wb_stall_o,
     output  reg [31:0] wb_dat_o,
 
-    // The first register (with some fields)
-    // 1-bit field
+    // REG regA
     output  wire regA_field0_o,
 
     // RAM port for DdrCapturesIndex

--- a/testfiles/features/mem64ro.v
+++ b/testfiles/features/mem64ro.v
@@ -15,8 +15,7 @@ module mem64ro
     output  wire wb_stall_o,
     output  reg [31:0] wb_dat_o,
 
-    // The first register (with some fields)
-    // 1-bit field
+    // REG regA
     output  wire regA_field0_o,
 
     // RAM port for DdrCapturesIndex

--- a/testfiles/features/mem64ro.vhdl
+++ b/testfiles/features/mem64ro.vhdl
@@ -19,8 +19,7 @@ entity mem64ro is
     wb_stall_o           : out   std_logic;
     wb_dat_o             : out   std_logic_vector(31 downto 0);
 
-    -- The first register (with some fields)
-    -- 1-bit field
+    -- REG regA
     regA_field0_o        : out   std_logic;
 
     -- RAM port for DdrCapturesIndex

--- a/testfiles/features/memwide.sv
+++ b/testfiles/features/memwide.sv
@@ -15,8 +15,7 @@ module mem64ro
     output  wire wb_stall_o,
     output  reg [31:0] wb_dat_o,
 
-    // The first register (with some fields)
-    // 1-bit field
+    // REG regA
     output  wire regA_field0_o,
 
     // SRAM bus ts

--- a/testfiles/features/memwide.v
+++ b/testfiles/features/memwide.v
@@ -15,8 +15,7 @@ module mem64ro
     output  wire wb_stall_o,
     output  reg [31:0] wb_dat_o,
 
-    // The first register (with some fields)
-    // 1-bit field
+    // REG regA
     output  wire regA_field0_o,
 
     // SRAM bus ts

--- a/testfiles/features/memwide.vhdl
+++ b/testfiles/features/memwide.vhdl
@@ -18,8 +18,7 @@ entity mem64ro is
     wb_stall_o           : out   std_logic;
     wb_dat_o             : out   std_logic_vector(31 downto 0);
 
-    -- The first register (with some fields)
-    -- 1-bit field
+    -- REG regA
     regA_field0_o        : out   std_logic;
 
     -- SRAM bus ts

--- a/testfiles/features/reg-strobe.sv
+++ b/testfiles/features/reg-strobe.sv
@@ -14,8 +14,7 @@ module reg_strobe
     output  wire wb_stall_o,
     output  reg [31:0] wb_dat_o,
 
-    // The first register (with some fields)
-    // 1-bit field
+    // REG regA
     output  wire regA_field0_o,
     output  wire regA_wr_o
   );

--- a/testfiles/features/reg-strobe.v
+++ b/testfiles/features/reg-strobe.v
@@ -14,8 +14,7 @@ module reg_strobe
     output  wire wb_stall_o,
     output  reg [31:0] wb_dat_o,
 
-    // The first register (with some fields)
-    // 1-bit field
+    // REG regA
     output  wire regA_field0_o,
     output  wire regA_wr_o
   );

--- a/testfiles/features/reg-strobe.vhdl
+++ b/testfiles/features/reg-strobe.vhdl
@@ -17,8 +17,7 @@ entity reg_strobe is
     wb_stall_o           : out   std_logic;
     wb_dat_o             : out   std_logic_vector(31 downto 0);
 
-    -- The first register (with some fields)
-    -- 1-bit field
+    -- REG regA
     regA_field0_o        : out   std_logic;
     regA_wr_o            : out   std_logic
   );

--- a/testfiles/features/repeat-iogroup4.sv
+++ b/testfiles/features/repeat-iogroup4.sv
@@ -31,7 +31,7 @@ module repeat_iogroup4
     output  wire wb_stall_o,
     output  reg [31:0] wb_dat_o,
 
-    // the array of registers
+    // REPEAT arr1
     t_itf.master itf[1]
   );
   wire rd_req_int;

--- a/testfiles/features/repeat-iogroup4.v
+++ b/testfiles/features/repeat-iogroup4.v
@@ -31,7 +31,7 @@ module repeat_iogroup4
     output  wire wb_stall_o,
     output  reg [31:0] wb_dat_o,
 
-    // the array of registers
+    // REPEAT arr1
     t_itf.master itf[1]
   );
   wire rd_req_int;

--- a/testfiles/features/repeat-iogroup4.vhdl
+++ b/testfiles/features/repeat-iogroup4.vhdl
@@ -45,7 +45,7 @@ entity repeat_iogroup4 is
     wb_stall_o           : out   std_logic;
     wb_dat_o             : out   std_logic_vector(31 downto 0);
 
-    -- the array of registers
+    -- REPEAT arr1
     itf_i                : in    t_itf_master_in_array(0 downto 0);
     itf_o                : out   t_itf_master_out_array(0 downto 0)
   );

--- a/testfiles/fmc-adc01/fmc_adc_alt_trigin.sv
+++ b/testfiles/fmc-adc01/fmc_adc_alt_trigin.sv
@@ -3,16 +3,15 @@ module alt_trigin
   (
     t_wishbone.slave wb,
 
-    // Control register
-    // Enable trigger, cleared when triggered
+    // REG ctrl
     input   wire ctrl_enable_i,
     output  wire ctrl_enable_o,
     output  wire ctrl_wr_o,
 
-    // Time (seconds) to trigger
+    // REG seconds
     input   wire [63:0] seconds_i,
 
-    // Time (cycles) to trigger
+    // REG cycles
     input   wire [31:0] cycles_i
   );
   wire [4:2] adr_int;

--- a/testfiles/fmc-adc01/fmc_adc_alt_trigin.v
+++ b/testfiles/fmc-adc01/fmc_adc_alt_trigin.v
@@ -3,16 +3,15 @@ module alt_trigin
   (
     t_wishbone.slave wb,
 
-    // Control register
-    // Enable trigger, cleared when triggered
+    // REG ctrl
     input   wire ctrl_enable_i,
     output  wire ctrl_enable_o,
     output  wire ctrl_wr_o,
 
-    // Time (seconds) to trigger
+    // REG seconds
     input   wire [63:0] seconds_i,
 
-    // Time (cycles) to trigger
+    // REG cycles
     input   wire [31:0] cycles_i
   );
   wire [4:2] adr_int;

--- a/testfiles/fmc-adc01/fmc_adc_alt_trigin.vhdl
+++ b/testfiles/fmc-adc01/fmc_adc_alt_trigin.vhdl
@@ -10,16 +10,15 @@ entity alt_trigin is
     wb_i                 : in    t_wishbone_slave_in;
     wb_o                 : out   t_wishbone_slave_out;
 
-    -- Control register
-    -- Enable trigger, cleared when triggered
+    -- REG ctrl
     ctrl_enable_i        : in    std_logic;
     ctrl_enable_o        : out   std_logic;
     ctrl_wr_o            : out   std_logic;
 
-    -- Time (seconds) to trigger
+    -- REG seconds
     seconds_i            : in    std_logic_vector(63 downto 0);
 
-    -- Time (cycles) to trigger
+    -- REG cycles
     cycles_i             : in    std_logic_vector(31 downto 0)
   );
 end alt_trigin;

--- a/testfiles/fmc-adc01/fmc_adc_alt_trigout.sv
+++ b/testfiles/fmc-adc01/fmc_adc_alt_trigout.sv
@@ -3,44 +3,28 @@ module alt_trigout
   (
     t_wishbone.slave wb,
 
-    // Status register
-    // Set when WR is enabled
+    // REG status
     input   wire wr_enable_i,
-    // WR link status
     input   wire wr_link_i,
-    // Set when WR time is valid
     input   wire wr_valid_i,
-    // Set when the timestamp fifo is not empty
     input   wire ts_present_i,
 
-    // Control register
-    // Enable channel 1 trigger
+    // REG ctrl
     output  wire ch1_enable_o,
-    // Enable channel 2 trigger
     output  wire ch2_enable_o,
-    // Enable channel 3 trigger
     output  wire ch3_enable_o,
-    // Enable channel 4 trigger
     output  wire ch4_enable_o,
-    // Enable external trigger
     output  wire ext_enable_o,
 
-    // Time (seconds) of the last event
-    // Seconds part of the timestamp
+    // REG ts_mask_sec
     input   wire [39:0] ts_sec_i,
-    // Set if channel 1 triggered
     input   wire ch1_mask_i,
-    // Set if channel 2 triggered
     input   wire ch2_mask_i,
-    // Set if channel 3 triggered
     input   wire ch3_mask_i,
-    // Set if channel 4 triggered
     input   wire ch4_mask_i,
-    // Set if external trigger
     input   wire ext_mask_i,
 
     // Reading this register discard the entry
-    // Cycles
     input   wire [27:0] cycles_i,
     output  reg ts_cycles_rd_o
   );

--- a/testfiles/fmc-adc01/fmc_adc_alt_trigout.v
+++ b/testfiles/fmc-adc01/fmc_adc_alt_trigout.v
@@ -3,44 +3,28 @@ module alt_trigout
   (
     t_wishbone.slave wb,
 
-    // Status register
-    // Set when WR is enabled
+    // REG status
     input   wire wr_enable_i,
-    // WR link status
     input   wire wr_link_i,
-    // Set when WR time is valid
     input   wire wr_valid_i,
-    // Set when the timestamp fifo is not empty
     input   wire ts_present_i,
 
-    // Control register
-    // Enable channel 1 trigger
+    // REG ctrl
     output  wire ch1_enable_o,
-    // Enable channel 2 trigger
     output  wire ch2_enable_o,
-    // Enable channel 3 trigger
     output  wire ch3_enable_o,
-    // Enable channel 4 trigger
     output  wire ch4_enable_o,
-    // Enable external trigger
     output  wire ext_enable_o,
 
-    // Time (seconds) of the last event
-    // Seconds part of the timestamp
+    // REG ts_mask_sec
     input   wire [39:0] ts_sec_i,
-    // Set if channel 1 triggered
     input   wire ch1_mask_i,
-    // Set if channel 2 triggered
     input   wire ch2_mask_i,
-    // Set if channel 3 triggered
     input   wire ch3_mask_i,
-    // Set if channel 4 triggered
     input   wire ch4_mask_i,
-    // Set if external trigger
     input   wire ext_mask_i,
 
     // Reading this register discard the entry
-    // Cycles
     input   wire [27:0] cycles_i,
     output  reg ts_cycles_rd_o
   );

--- a/testfiles/fmc-adc01/fmc_adc_alt_trigout.vhdl
+++ b/testfiles/fmc-adc01/fmc_adc_alt_trigout.vhdl
@@ -10,44 +10,28 @@ entity alt_trigout is
     wb_i                 : in    t_wishbone_slave_in;
     wb_o                 : out   t_wishbone_slave_out;
 
-    -- Status register
-    -- Set when WR is enabled
+    -- REG status
     wr_enable_i          : in    std_logic;
-    -- WR link status
     wr_link_i            : in    std_logic;
-    -- Set when WR time is valid
     wr_valid_i           : in    std_logic;
-    -- Set when the timestamp fifo is not empty
     ts_present_i         : in    std_logic;
 
-    -- Control register
-    -- Enable channel 1 trigger
+    -- REG ctrl
     ch1_enable_o         : out   std_logic;
-    -- Enable channel 2 trigger
     ch2_enable_o         : out   std_logic;
-    -- Enable channel 3 trigger
     ch3_enable_o         : out   std_logic;
-    -- Enable channel 4 trigger
     ch4_enable_o         : out   std_logic;
-    -- Enable external trigger
     ext_enable_o         : out   std_logic;
 
-    -- Time (seconds) of the last event
-    -- Seconds part of the timestamp
+    -- REG ts_mask_sec
     ts_sec_i             : in    std_logic_vector(39 downto 0);
-    -- Set if channel 1 triggered
     ch1_mask_i           : in    std_logic;
-    -- Set if channel 2 triggered
     ch2_mask_i           : in    std_logic;
-    -- Set if channel 3 triggered
     ch3_mask_i           : in    std_logic;
-    -- Set if channel 4 triggered
     ch4_mask_i           : in    std_logic;
-    -- Set if external trigger
     ext_mask_i           : in    std_logic;
 
     -- Reading this register discard the entry
-    -- Cycles
     cycles_i             : in    std_logic_vector(27 downto 0);
     ts_cycles_rd_o       : out   std_logic
   );

--- a/testfiles/issue10/test.sv
+++ b/testfiles/issue10/test.sv
@@ -23,22 +23,18 @@ module test
     output  reg [31:0] rdata,
     output  wire [1:0] rresp,
 
-    // Test register 1
+    // REG register1
     output  wire [63:0] register1_o,
 
-    // Test register 2
-    // Test field 1
+    // REG register2
     input   wire block1_register2_field1_i,
-    // Test field 2
     input   wire [2:0] block1_register2_field2_i,
 
-    // Test register 3
+    // REG register3
     output  wire [31:0] block1_register3_o,
 
-    // Test register 4
-    // Test field 3
+    // REG register4
     input   wire block1_block2_register4_field3_i,
-    // Test field 4
     input   wire [2:0] block1_block2_register4_field4_i
   );
   reg wr_req;

--- a/testfiles/issue10/test.v
+++ b/testfiles/issue10/test.v
@@ -23,22 +23,18 @@ module test
     output  reg [31:0] rdata,
     output  wire [1:0] rresp,
 
-    // Test register 1
+    // REG register1
     output  wire [63:0] register1_o,
 
-    // Test register 2
-    // Test field 1
+    // REG register2
     input   wire block1_register2_field1_i,
-    // Test field 2
     input   wire [2:0] block1_register2_field2_i,
 
-    // Test register 3
+    // REG register3
     output  wire [31:0] block1_register3_o,
 
-    // Test register 4
-    // Test field 3
+    // REG register4
     input   wire block1_block2_register4_field3_i,
-    // Test field 4
     input   wire [2:0] block1_block2_register4_field4_i
   );
   reg wr_req;

--- a/testfiles/issue10/test.vhdl
+++ b/testfiles/issue10/test.vhdl
@@ -26,22 +26,18 @@ entity test is
     rdata                : out   std_logic_vector(31 downto 0);
     rresp                : out   std_logic_vector(1 downto 0);
 
-    -- Test register 1
+    -- REG register1
     register1_o          : out   std_logic_vector(63 downto 0);
 
-    -- Test register 2
-    -- Test field 1
+    -- REG register2
     block1_register2_field1_i : in    std_logic;
-    -- Test field 2
     block1_register2_field2_i : in    std_logic_vector(2 downto 0);
 
-    -- Test register 3
+    -- REG register3
     block1_register3_o   : out   std_logic_vector(31 downto 0);
 
-    -- Test register 4
-    -- Test field 3
+    -- REG register4
     block1_block2_register4_field3_i : in    std_logic;
-    -- Test field 4
     block1_block2_register4_field4_i : in    std_logic_vector(2 downto 0)
   );
 end test;

--- a/testfiles/issue103/top.h
+++ b/testfiles/issue103/top.h
@@ -9,30 +9,30 @@
 #include "sub3.h"
 #define TOP_SIZE 12 /* 0xc */
 
-/* A normal submap */
+/* (comment missing) */
 #define TOP_SUB1 0x0UL
 #define ADDR_MASK_TOP_SUB1 0xcUL
 #define TOP_SUB1_SIZE 4 /* 0x4 */
 
-/* An included submap */
+/* (comment missing) */
 #define TOP_SUB2 0x4UL
 #define ADDR_MASK_TOP_SUB2 0xcUL
 #define TOP_SUB2_SIZE 4 /* 0x4 */
 
-/* An included submap */
+/* (comment missing) */
 #define TOP_SUB3 0x8UL
 #define ADDR_MASK_TOP_SUB3 0xcUL
 #define TOP_SUB3_SIZE 4 /* 0x4 */
 
 #ifndef __ASSEMBLER__
 struct top {
-  /* [0x0]: SUBMAP A normal submap */
+  /* [0x0]: SUBMAP (comment missing) */
   struct sub1 sub1;
 
-  /* [0x4]: SUBMAP An included submap */
+  /* [0x4]: SUBMAP (comment missing) */
   struct sub2 sub2;
 
-  /* [0x8]: SUBMAP An included submap */
+  /* [0x8]: SUBMAP (comment missing) */
   struct sub3 sub3;
 };
 #endif /* !__ASSEMBLER__*/

--- a/testfiles/issue14/test-axi.sv
+++ b/testfiles/issue14/test-axi.sv
@@ -23,7 +23,7 @@ module test_axi4
     output  reg [31:0] rdata,
     output  wire [1:0] rresp,
 
-    // Test register 1
+    // REG register1
     output  wire [63:0] register1_o
   );
   reg wr_req;

--- a/testfiles/issue14/test-axi.v
+++ b/testfiles/issue14/test-axi.v
@@ -23,7 +23,7 @@ module test_axi4
     output  reg [31:0] rdata,
     output  wire [1:0] rresp,
 
-    // Test register 1
+    // REG register1
     output  wire [63:0] register1_o
   );
   reg wr_req;

--- a/testfiles/issue14/test-axi.vhdl
+++ b/testfiles/issue14/test-axi.vhdl
@@ -26,7 +26,7 @@ entity test_axi4 is
     rdata                : out   std_logic_vector(31 downto 0);
     rresp                : out   std_logic_vector(1 downto 0);
 
-    -- Test register 1
+    -- REG register1
     register1_o          : out   std_logic_vector(63 downto 0)
   );
 end test_axi4;

--- a/testfiles/issue14/test-be.sv
+++ b/testfiles/issue14/test-be.sv
@@ -23,7 +23,7 @@ module test_axi4
     output  reg [31:0] rdata,
     output  wire [1:0] rresp,
 
-    // Test register 1
+    // REG register1
     output  wire [63:0] register1_o
   );
   reg wr_req;

--- a/testfiles/issue14/test-be.v
+++ b/testfiles/issue14/test-be.v
@@ -23,7 +23,7 @@ module test_axi4
     output  reg [31:0] rdata,
     output  wire [1:0] rresp,
 
-    // Test register 1
+    // REG register1
     output  wire [63:0] register1_o
   );
   reg wr_req;

--- a/testfiles/issue14/test-be.vhdl
+++ b/testfiles/issue14/test-be.vhdl
@@ -26,7 +26,7 @@ entity test_axi4 is
     rdata                : out   std_logic_vector(31 downto 0);
     rresp                : out   std_logic_vector(1 downto 0);
 
-    -- Test register 1
+    -- REG register1
     register1_o          : out   std_logic_vector(63 downto 0)
   );
 end test_axi4;

--- a/testfiles/issue14/test-le.sv
+++ b/testfiles/issue14/test-le.sv
@@ -23,7 +23,7 @@ module test_axi4
     output  reg [31:0] rdata,
     output  wire [1:0] rresp,
 
-    // Test register 1
+    // REG register1
     output  wire [63:0] register1_o
   );
   reg wr_req;

--- a/testfiles/issue14/test-le.v
+++ b/testfiles/issue14/test-le.v
@@ -23,7 +23,7 @@ module test_axi4
     output  reg [31:0] rdata,
     output  wire [1:0] rresp,
 
-    // Test register 1
+    // REG register1
     output  wire [63:0] register1_o
   );
   reg wr_req;

--- a/testfiles/issue14/test-le.vhdl
+++ b/testfiles/issue14/test-le.vhdl
@@ -26,7 +26,7 @@ entity test_axi4 is
     rdata                : out   std_logic_vector(31 downto 0);
     rresp                : out   std_logic_vector(1 downto 0);
 
-    -- Test register 1
+    -- REG register1
     register1_o          : out   std_logic_vector(63 downto 0)
   );
 end test_axi4;

--- a/testfiles/issue39/addressingMemory.sv
+++ b/testfiles/issue39/addressingMemory.sv
@@ -11,7 +11,7 @@ module eda02175v2
     output  wire VMERdDone,
     output  wire VMEWrDone,
 
-    // ViewPort to the internal acquisition RAM/SRAM blocs
+    // cern-be-vme bus acqVP
     output  reg [16:1] acqVP_VMEAddr_o,
     input   wire [15:0] acqVP_VMERdData_i,
     output  wire [15:0] acqVP_VMEWrData_o,
@@ -20,7 +20,7 @@ module eda02175v2
     input   wire acqVP_VMERdDone_i,
     input   wire acqVP_VMEWrDone_i,
 
-    // Resets the system part of the logic in the FPGA. ONLY FOR LAB PURPOSES
+    // REG softReset
     output  wire softReset_reset_o
   );
   wire rst_n;

--- a/testfiles/issue39/addressingMemory.v
+++ b/testfiles/issue39/addressingMemory.v
@@ -11,7 +11,7 @@ module eda02175v2
     output  wire VMERdDone,
     output  wire VMEWrDone,
 
-    // ViewPort to the internal acquisition RAM/SRAM blocs
+    // cern-be-vme bus acqVP
     output  reg [16:1] acqVP_VMEAddr_o,
     input   wire [15:0] acqVP_VMERdData_i,
     output  wire [15:0] acqVP_VMEWrData_o,
@@ -20,7 +20,7 @@ module eda02175v2
     input   wire acqVP_VMERdDone_i,
     input   wire acqVP_VMEWrDone_i,
 
-    // Resets the system part of the logic in the FPGA. ONLY FOR LAB PURPOSES
+    // REG softReset
     output  wire softReset_reset_o
   );
   wire rst_n;

--- a/testfiles/issue39/addressingMemory.vhdl
+++ b/testfiles/issue39/addressingMemory.vhdl
@@ -14,7 +14,7 @@ entity eda02175v2 is
     VMERdDone            : out   std_logic;
     VMEWrDone            : out   std_logic;
 
-    -- ViewPort to the internal acquisition RAM/SRAM blocs
+    -- cern-be-vme bus acqVP
     acqVP_VMEAddr_o      : out   std_logic_vector(16 downto 1);
     acqVP_VMERdData_i    : in    std_logic_vector(15 downto 0);
     acqVP_VMEWrData_o    : out   std_logic_vector(15 downto 0);
@@ -23,7 +23,7 @@ entity eda02175v2 is
     acqVP_VMERdDone_i    : in    std_logic;
     acqVP_VMEWrDone_i    : in    std_logic;
 
-    -- Resets the system part of the logic in the FPGA. ONLY FOR LAB PURPOSES
+    -- REG softReset
     softReset_reset_o    : out   std_logic
   );
 end eda02175v2;

--- a/testfiles/issue52/hwInfo.sv
+++ b/testfiles/issue52/hwInfo.sv
@@ -11,21 +11,20 @@ module hwInfo
     output  wire VMERdDone,
     output  wire VMEWrDone,
 
-    // HW serial number
+    // REG serialNumber
     input   wire [63:0] serialNumber_i,
 
-    // Firmware Version
+    // REG firmwareVersion
     input   wire [7:0] firmwareVersion_major_i,
     input   wire [7:0] firmwareVersion_minor_i,
     input   wire [7:0] firmwareVersion_patch_i,
 
-    // Memory Map Version
+    // REG memMapVersion
     input   wire [7:0] memMapVersion_major_i,
     input   wire [7:0] memMapVersion_minor_i,
     input   wire [7:0] memMapVersion_patch_i,
 
-    // Echo register
-    // This version of the standard foresees only 8bits linked to real memory
+    // REG echo
     output  wire [7:0] echo_echo_o
   );
   wire rst_n;

--- a/testfiles/issue52/hwInfo.v
+++ b/testfiles/issue52/hwInfo.v
@@ -11,21 +11,20 @@ module hwInfo
     output  wire VMERdDone,
     output  wire VMEWrDone,
 
-    // HW serial number
+    // REG serialNumber
     input   wire [63:0] serialNumber_i,
 
-    // Firmware Version
+    // REG firmwareVersion
     input   wire [7:0] firmwareVersion_major_i,
     input   wire [7:0] firmwareVersion_minor_i,
     input   wire [7:0] firmwareVersion_patch_i,
 
-    // Memory Map Version
+    // REG memMapVersion
     input   wire [7:0] memMapVersion_major_i,
     input   wire [7:0] memMapVersion_minor_i,
     input   wire [7:0] memMapVersion_patch_i,
 
-    // Echo register
-    // This version of the standard foresees only 8bits linked to real memory
+    // REG echo
     output  wire [7:0] echo_echo_o
   );
   wire rst_n;

--- a/testfiles/issue52/hwInfo.vhdl
+++ b/testfiles/issue52/hwInfo.vhdl
@@ -14,21 +14,20 @@ entity hwInfo is
     VMERdDone            : out   std_logic;
     VMEWrDone            : out   std_logic;
 
-    -- HW serial number
+    -- REG serialNumber
     serialNumber_i       : in    std_logic_vector(63 downto 0);
 
-    -- Firmware Version
+    -- REG firmwareVersion
     firmwareVersion_major_i : in    std_logic_vector(7 downto 0);
     firmwareVersion_minor_i : in    std_logic_vector(7 downto 0);
     firmwareVersion_patch_i : in    std_logic_vector(7 downto 0);
 
-    -- Memory Map Version
+    -- REG memMapVersion
     memMapVersion_major_i : in    std_logic_vector(7 downto 0);
     memMapVersion_minor_i : in    std_logic_vector(7 downto 0);
     memMapVersion_patch_i : in    std_logic_vector(7 downto 0);
 
-    -- Echo register
-    -- This version of the standard foresees only 8bits linked to real memory
+    -- REG echo
     echo_echo_o          : out   std_logic_vector(7 downto 0)
   );
 end hwInfo;

--- a/testfiles/issue59/inherit.sv
+++ b/testfiles/issue59/inherit.sv
@@ -14,13 +14,10 @@ module inherit
     output  wire wb_stall_o,
     output  reg [31:0] wb_dat_o,
 
-    // a normal reg with some fields
-    // 1-bit field
+    // REG reg0
     input   wire reg0_field00_i,
     output  wire reg0_field00_o,
-    // multi bit field
     output  wire [3:0] reg0_field01_o,
-    // a field with a preset value
     input   wire [2:0] reg0_field02_i,
     output  wire [2:0] reg0_field02_o,
     output  wire reg0_wr_o

--- a/testfiles/issue59/inherit.v
+++ b/testfiles/issue59/inherit.v
@@ -14,13 +14,10 @@ module inherit
     output  wire wb_stall_o,
     output  reg [31:0] wb_dat_o,
 
-    // a normal reg with some fields
-    // 1-bit field
+    // REG reg0
     input   wire reg0_field00_i,
     output  wire reg0_field00_o,
-    // multi bit field
     output  wire [3:0] reg0_field01_o,
-    // a field with a preset value
     input   wire [2:0] reg0_field02_i,
     output  wire [2:0] reg0_field02_o,
     output  wire reg0_wr_o

--- a/testfiles/issue59/inherit.vhdl
+++ b/testfiles/issue59/inherit.vhdl
@@ -17,13 +17,10 @@ entity inherit is
     wb_stall_o           : out   std_logic;
     wb_dat_o             : out   std_logic_vector(31 downto 0);
 
-    -- a normal reg with some fields
-    -- 1-bit field
+    -- REG reg0
     reg0_field00_i       : in    std_logic;
     reg0_field00_o       : out   std_logic;
-    -- multi bit field
     reg0_field01_o       : out   std_logic_vector(3 downto 0);
-    -- a field with a preset value
     reg0_field02_i       : in    std_logic_vector(2 downto 0);
     reg0_field02_o       : out   std_logic_vector(2 downto 0);
     reg0_wr_o            : out   std_logic

--- a/testfiles/issue79/CSR.sv
+++ b/testfiles/issue79/CSR.sv
@@ -15,17 +15,16 @@ module csr
     output  wire wb_stall_o,
     output  reg [31:0] wb_dat_o,
 
-    // Board identifier
+    // REG ident
     input   wire [63:0] ident_i,
 
-    // Firmware version
+    // REG version
     input   wire [31:0] version_i,
 
-    // Calibrator control bits
-    // Calibrator/ADC select: 00=C1/A1, 01=C2/A2, 10=C1+2/A1, 11=C1+2/A2
+    // REG cal_ctrl
     output  wire [1:0] cal_ctrl_cal_sel_o,
 
-    // OpenCores I2C Master
+    // WB bus i2c_master
     output  wire i2c_master_cyc_o,
     output  wire i2c_master_stb_o,
     output  wire [4:2] i2c_master_adr_o,

--- a/testfiles/issue79/CSR.v
+++ b/testfiles/issue79/CSR.v
@@ -15,17 +15,16 @@ module csr
     output  wire wb_stall_o,
     output  reg [31:0] wb_dat_o,
 
-    // Board identifier
+    // REG ident
     input   wire [63:0] ident_i,
 
-    // Firmware version
+    // REG version
     input   wire [31:0] version_i,
 
-    // Calibrator control bits
-    // Calibrator/ADC select: 00=C1/A1, 01=C2/A2, 10=C1+2/A1, 11=C1+2/A2
+    // REG cal_ctrl
     output  wire [1:0] cal_ctrl_cal_sel_o,
 
-    // OpenCores I2C Master
+    // WB bus i2c_master
     output  wire i2c_master_cyc_o,
     output  wire i2c_master_stb_o,
     output  wire [4:2] i2c_master_adr_o,

--- a/testfiles/issue79/CSR.vhdl
+++ b/testfiles/issue79/CSR.vhdl
@@ -19,17 +19,16 @@ entity csr is
     wb_stall_o           : out   std_logic;
     wb_dat_o             : out   std_logic_vector(31 downto 0);
 
-    -- Board identifier
+    -- REG ident
     ident_i              : in    std_logic_vector(63 downto 0);
 
-    -- Firmware version
+    -- REG version
     version_i            : in    std_logic_vector(31 downto 0);
 
-    -- Calibrator control bits
-    -- Calibrator/ADC select: 00=C1/A1, 01=C2/A2, 10=C1+2/A1, 11=C1+2/A2
+    -- REG cal_ctrl
     cal_ctrl_cal_sel_o   : out   std_logic_vector(1 downto 0);
 
-    -- OpenCores I2C Master
+    -- WB bus i2c_master
     i2c_master_cyc_o     : out   std_logic;
     i2c_master_stb_o     : out   std_logic;
     i2c_master_adr_o     : out   std_logic_vector(4 downto 2);

--- a/testfiles/issue84/sps200CavityControl_as.html
+++ b/testfiles/issue84/sps200CavityControl_as.html
@@ -392,9 +392,7 @@
 <tr><td><b>C prefix:</b></td><td class="td_code">hwInfo.serialNumber</td></tr>
 <tr><td><b>C block offset:</b></td><td class="td_code">0x8</td></tr>
 </table>
-<p>
-HW serial number
-</p>
+<p>HW serial number</p>
 <table cellpadding=0 cellspacing=0 border=0>
 <tr>
  <td class="td_bit" colspan="1">63</td>
@@ -513,9 +511,7 @@ HW serial number
 <tr><td><b>C prefix:</b></td><td class="td_code">hwInfo.firmwareVersion</td></tr>
 <tr><td><b>C block offset:</b></td><td class="td_code">0x10</td></tr>
 </table>
-<p>
-Firmware Version
-</p>
+<p>Firmware Version</p>
 <table cellpadding=0 cellspacing=0 border=0>
 <tr>
  <td class="td_bit" colspan="1">31</td>
@@ -593,9 +589,7 @@ Firmware Version
 <tr><td><b>C prefix:</b></td><td class="td_code">hwInfo.memMapVersion</td></tr>
 <tr><td><b>C block offset:</b></td><td class="td_code">0x14</td></tr>
 </table>
-<p>
-Memory Map Version
-</p>
+<p>Memory Map Version</p>
 <table cellpadding=0 cellspacing=0 border=0>
 <tr>
  <td class="td_bit" colspan="1">31</td>
@@ -673,9 +667,8 @@ Memory Map Version
 <tr><td><b>C prefix:</b></td><td class="td_code">hwInfo.echo</td></tr>
 <tr><td><b>C block offset:</b></td><td class="td_code">0x18</td></tr>
 </table>
-<p>
-Echo register. This version of the standard foresees only 8bits linked to real memory
-</p>
+<p>Echo register. This version of the standard foresees only 8bits linked to real memory</p>
+<p>Register used solely by software. No interaction with the firmware foreseen.<br>The idea is to use this register as "flag" in the hardware to remember your actions from the software side.<br><br>Reading 0xFF often happens when the board is not even reachable (i.e. bus problems on VME)<br><br>On the other hand if the board is reachable the usual state of flipflops are 0x00. Thus this would indicate that no initialization has been attempted yet.<br><br>At start of your software (FESA class) you should set the value 0x40 indicating that initialization is in progress. <br>This is important for you to later one check if you can read this value back before finally setting it to 0x80 (the value previously used with Cheburashka).<br><br>If your initialization failed but you want to continue anyway you should set the register to 0xC0 to indicate this error <br><br>This register is in particular useful if you have several entities interacting with the hardware. In this case several bits could be assigned to this entities (bits 5..0) to signalize that they have done there part successful and a main entity checks all the expected bits.</p>
 <table cellpadding=0 cellspacing=0 border=0>
 <tr>
  <td class="td_bit" colspan="1">31</td>
@@ -732,7 +725,8 @@ Echo register. This version of the standard foresees only 8bits linked to real m
 </table>
 <dl>
   <dt><b>echo</b> [<i>rw</i>]</dt>
-  <dd>Echo register. This version of the standard foresees only 8bits linked to real memory<br><br>Register used solely by software. No interaction with the firmware foreseen.<br>The idea is to use this register as "flag" in the hardware to remember your actions from the software side.<br><br>Reading 0xFF often happens when the board is not even reachable (i.e. bus problems on VME)<br><br>On the other hand if the board is reachable the usual state of flipflops are 0x00. Thus this would indicate that no initialization has been attempted yet.<br><br>At start of your software (FESA class) you should set the value 0x40 indicating that initialization is in progress. <br>This is important for you to later one check if you can read this value back before finally setting it to 0x80 (the value previously used with Cheburashka).<br><br>If your initialization failed but you want to continue anyway you should set the register to 0xC0 to indicate this error <br><br>This register is in particular useful if you have several entities interacting with the hardware. In this case several bits could be assigned to this entities (bits 5..0) to signalize that they have done there part successful and a main entity checks all the expected bits.</dd>
+  <dd>Echo register. This version of the standard foresees only 8bits linked to real memory</dd>
+  <dd>Register used solely by software. No interaction with the firmware foreseen.<br>The idea is to use this register as "flag" in the hardware to remember your actions from the software side.<br><br>Reading 0xFF often happens when the board is not even reachable (i.e. bus problems on VME)<br><br>On the other hand if the board is reachable the usual state of flipflops are 0x00. Thus this would indicate that no initialization has been attempted yet.<br><br>At start of your software (FESA class) you should set the value 0x40 indicating that initialization is in progress. <br>This is important for you to later one check if you can read this value back before finally setting it to 0x80 (the value previously used with Cheburashka).<br><br>If your initialization failed but you want to continue anyway you should set the register to 0xC0 to indicate this error <br><br>This register is in particular useful if you have several entities interacting with the hardware. In this case several bits could be assigned to this entities (bits 5..0) to signalize that they have done there part successful and a main entity checks all the expected bits.</dd>
 </dl>
 <a name="app.modulation.ipInfo.stdVersion"></a>
 <h3>2.1.6. app.modulation.ipInfo.stdVersion</h3>
@@ -819,9 +813,7 @@ Echo register. This version of the standard foresees only 8bits linked to real m
 <tr><td><b>C prefix:</b></td><td class="td_code">app.modulation.ipInfo.ident</td></tr>
 <tr><td><b>C block offset:</b></td><td class="td_code">0x4</td></tr>
 </table>
-<p>
-IP Ident code
-</p>
+<p>IP Ident code</p>
 <table cellpadding=0 cellspacing=0 border=0>
 <tr>
  <td class="td_bit" colspan="1">31</td>
@@ -888,9 +880,7 @@ IP Ident code
 <tr><td><b>C prefix:</b></td><td class="td_code">app.modulation.ipInfo.firmwareVersion</td></tr>
 <tr><td><b>C block offset:</b></td><td class="td_code">0x8</td></tr>
 </table>
-<p>
-Firmware Version
-</p>
+<p>Firmware Version</p>
 <table cellpadding=0 cellspacing=0 border=0>
 <tr>
  <td class="td_bit" colspan="1">31</td>
@@ -968,9 +958,7 @@ Firmware Version
 <tr><td><b>C prefix:</b></td><td class="td_code">app.modulation.ipInfo.memMapVersion</td></tr>
 <tr><td><b>C block offset:</b></td><td class="td_code">0xc</td></tr>
 </table>
-<p>
-Memory Map Version
-</p>
+<p>Memory Map Version</p>
 <table cellpadding=0 cellspacing=0 border=0>
 <tr>
  <td class="td_bit" colspan="1">31</td>
@@ -1048,9 +1036,8 @@ Memory Map Version
 <tr><td><b>C prefix:</b></td><td class="td_code">app.modulation.ipInfo.echo</td></tr>
 <tr><td><b>C block offset:</b></td><td class="td_code">0x10</td></tr>
 </table>
-<p>
-Echo register. This version of the standard foresees only 8bits linked to real memory
-</p>
+<p>Echo register. This version of the standard foresees only 8bits linked to real memory</p>
+<p>Register used solely by software. No interaction with the firmware foreseen.<br>The idea is to use this register as "flag" in the hardware to remember your actions from the software side.<br><br>Reading 0xFF often happens when the board is not even reachable (i.e. bus problems on VME)<br><br>On the other hand if the board is reachable the usual state of flipflops are 0x00. Thus this would indicate that no initialization has been attempted yet.<br><br>At start of your software (FESA class) you should set the value 0x40 indicating that initialization is in progress. <br>This is important for you to later one check if you can read this value back before finally setting it to 0x80 (the value previously used with Cheburashka).<br><br>If your initialization failed but you want to continue anyway you should set the register to 0xC0 to indicate this error <br><br>This register is in particular useful if you have several entities interacting with the hardware. In this case several bits could be assigned to this entities (bits 5..0) to signalize that they have done there part successful and a main entity checks all the expected bits.</p>
 <table cellpadding=0 cellspacing=0 border=0>
 <tr>
  <td class="td_bit" colspan="1">31</td>
@@ -1220,7 +1207,8 @@ Echo register. This version of the standard foresees only 8bits linked to real m
 </table>
 <dl>
   <dt><b>useTestSignal</b> [<i>rw</i>]</dt>
-  <dd>Use DDS generated test signal instead of ADC input as demodulation input<br><br>Test signal is synthezied with additional internal DDS, test signals frequency given by ftw_RF.</dd>
+  <dd>Use DDS generated test signal instead of ADC input as demodulation input</dd>
+  <dd>Test signal is synthezied with additional internal DDS, test signals frequency given by ftw_RF.</dd>
   <dt><b>useImpulse</b> [<i>rw</i>]</dt>
   <dd>Use impulse instead of demodulation output</dd>
   <dt><b>useStaticSignal</b> [<i>rw</i>]</dt>
@@ -1252,9 +1240,7 @@ Echo register. This version of the standard foresees only 8bits linked to real m
 <tr><td><b>C prefix:</b></td><td class="td_code">app.modulation.testSignal.amplitude</td></tr>
 <tr><td><b>C block offset:</b></td><td class="td_code">0x0</td></tr>
 </table>
-<p>
-Amplitude for the test signal
-</p>
+<p>Amplitude for the test signal</p>
 <table cellpadding=0 cellspacing=0 border=0>
 <tr>
  <td class="td_bit" colspan="1">15</td>
@@ -1295,9 +1281,7 @@ Amplitude for the test signal
 <tr><td><b>C prefix:</b></td><td class="td_code">app.modulation.testSignal.ftw</td></tr>
 <tr><td><b>C block offset:</b></td><td class="td_code">0x8</td></tr>
 </table>
-<p>
-FTW of the test signal (frequency relative to fs)
-</p>
+<p>FTW of the test signal (frequency relative to fs)</p>
 <table cellpadding=0 cellspacing=0 border=0>
 <tr>
  <td class="td_bit" colspan="1">63</td>
@@ -1416,9 +1400,7 @@ FTW of the test signal (frequency relative to fs)
 <tr><td><b>C prefix:</b></td><td class="td_code">app.modulation.staticSignal.i</td></tr>
 <tr><td><b>C block offset:</b></td><td class="td_code">0x0</td></tr>
 </table>
-<p>
-Constant to be used as OTF input for channel I
-</p>
+<p>Constant to be used as OTF input for channel I</p>
 <table cellpadding=0 cellspacing=0 border=0>
 <tr>
  <td class="td_bit" colspan="1">15</td>
@@ -1459,9 +1441,7 @@ Constant to be used as OTF input for channel I
 <tr><td><b>C prefix:</b></td><td class="td_code">app.modulation.staticSignal.q</td></tr>
 <tr><td><b>C block offset:</b></td><td class="td_code">0x4</td></tr>
 </table>
-<p>
-Constant to be used as OTF input for channel Q
-</p>
+<p>Constant to be used as OTF input for channel Q</p>
 <table cellpadding=0 cellspacing=0 border=0>
 <tr>
  <td class="td_bit" colspan="1">15</td>

--- a/testfiles/issue84/sps200CavityControl_as.md
+++ b/testfiles/issue84/sps200CavityControl_as.md
@@ -501,6 +501,8 @@ address:: 0x18
 block offset:: 0x18
 access mode:: rw
 
+Echo register. This version of the standard foresees only 8bits linked to real memory
+
 Register used solely by software. No interaction with the firmware foreseen. +
 The idea is to use this register as "flag" in the hardware to remember your actions from the software side. +
  +
@@ -514,8 +516,6 @@ This is important for you to later one check if you can read this value back bef
 If your initialization failed but you want to continue anyway you should set the register to 0xC0 to indicate this error  +
  +
 This register is in particular useful if you have several entities interacting with the hardware. In this case several bits could be assigned to this entities (bits 5..0) to signalize that they have done there part successful and a main entity checks all the expected bits.
-
-Echo register. This version of the standard foresees only 8bits linked to real memory
 
 [cols="8*^"]
 |===
@@ -838,6 +838,8 @@ address:: 0x100010
 block offset:: 0x10
 access mode:: rw
 
+Echo register. This version of the standard foresees only 8bits linked to real memory
+
 Register used solely by software. No interaction with the firmware foreseen. +
 The idea is to use this register as "flag" in the hardware to remember your actions from the software side. +
  +
@@ -851,8 +853,6 @@ This is important for you to later one check if you can read this value back bef
 If your initialization failed but you want to continue anyway you should set the register to 0xC0 to indicate this error  +
  +
 This register is in particular useful if you have several entities interacting with the hardware. In this case several bits could be assigned to this entities (bits 5..0) to signalize that they have done there part successful and a main entity checks all the expected bits.
-
-Echo register. This version of the standard foresees only 8bits linked to real memory
 
 [cols="8*^"]
 |===
@@ -1008,9 +1008,9 @@ s| useTestSignal
 |===
 
 useTestSignal::
-Test signal is synthezied with additional internal DDS, test signals frequency given by ftw_RF.
-+
 Use DDS generated test signal instead of ADC input as demodulation input
++
+Test signal is synthezied with additional internal DDS, test signals frequency given by ftw_RF.
 useImpulse::
 Use impulse instead of demodulation output
 useStaticSignal::

--- a/testfiles/issue84/sps200CavityControl_as.rst
+++ b/testfiles/issue84/sps200CavityControl_as.rst
@@ -477,6 +477,7 @@ app.modulation.control
 +------------------+------------------+------------------+------------------+------------------+------------------+------------------+------------------+
 
 useTestSignal
+  Use DDS generated test signal instead of ADC input as demodulation input
   Test signal is synthezied with additional internal DDS, test signals frequency given by ftw_RF.
 useImpulse
   Use impulse instead of demodulation output

--- a/testfiles/issue87/qsm_regs.sv
+++ b/testfiles/issue87/qsm_regs.sv
@@ -3,52 +3,32 @@ module qsm_regs
   (
     t_wishbone.slave wb,
 
-    // Control register
-    // Send the Reset state to DIM
+    // REG control
     output  wire regs_0_control_reset_o,
-    // Trigger DIM readout
     output  wire regs_0_control_trig_o,
-    // Address of last DIM register (number of registers - 1)
     output  wire [3:0] regs_0_control_last_reg_adr_o,
-    // Maximum number of devices present on line
     output  wire [3:0] regs_0_control_max_dim_no_o,
-    // Delay between consecutive register reads in microseconds (usually 512 us)
     output  wire [9:0] regs_0_control_read_delay_o,
 
-    // Status register
-    // QSPI master is busy (either in RESET or READOUT)
+    // REG status
     input   wire regs_0_status_busy_i,
-    // QSPI master has finished DIM readout
     input   wire regs_0_status_done_i,
-    // Too many devices on DIM line (more than set by 'max_dim_no' register)
     input   wire regs_0_status_err_many_i,
-    // Detected error on QSPI fb line
     input   wire regs_0_status_err_fb_i,
-    // Detected number of DIM devices (can be lower than 'max_dim_no')
     input   wire [3:0] regs_0_status_dim_count_i,
 
-    // Control register
-    // Send the Reset state to DIM
+    // REG control
     output  wire regs_1_control_reset_o,
-    // Trigger DIM readout
     output  wire regs_1_control_trig_o,
-    // Address of last DIM register (number of registers - 1)
     output  wire [3:0] regs_1_control_last_reg_adr_o,
-    // Maximum number of devices present on line
     output  wire [3:0] regs_1_control_max_dim_no_o,
-    // Delay between consecutive register reads in microseconds (usually 512 us)
     output  wire [9:0] regs_1_control_read_delay_o,
 
-    // Status register
-    // QSPI master is busy (either in RESET or READOUT)
+    // REG status
     input   wire regs_1_status_busy_i,
-    // QSPI master has finished DIM readout
     input   wire regs_1_status_done_i,
-    // Too many devices on DIM line (more than set by 'max_dim_no' register)
     input   wire regs_1_status_err_many_i,
-    // Detected error on QSPI fb line
     input   wire regs_1_status_err_fb_i,
-    // Detected number of DIM devices (can be lower than 'max_dim_no')
     input   wire [3:0] regs_1_status_dim_count_i,
 
     // SRAM bus memory_0_mem_readout

--- a/testfiles/issue87/qsm_regs.v
+++ b/testfiles/issue87/qsm_regs.v
@@ -3,52 +3,32 @@ module qsm_regs
   (
     t_wishbone.slave wb,
 
-    // Control register
-    // Send the Reset state to DIM
+    // REG control
     output  wire regs_0_control_reset_o,
-    // Trigger DIM readout
     output  wire regs_0_control_trig_o,
-    // Address of last DIM register (number of registers - 1)
     output  wire [3:0] regs_0_control_last_reg_adr_o,
-    // Maximum number of devices present on line
     output  wire [3:0] regs_0_control_max_dim_no_o,
-    // Delay between consecutive register reads in microseconds (usually 512 us)
     output  wire [9:0] regs_0_control_read_delay_o,
 
-    // Status register
-    // QSPI master is busy (either in RESET or READOUT)
+    // REG status
     input   wire regs_0_status_busy_i,
-    // QSPI master has finished DIM readout
     input   wire regs_0_status_done_i,
-    // Too many devices on DIM line (more than set by 'max_dim_no' register)
     input   wire regs_0_status_err_many_i,
-    // Detected error on QSPI fb line
     input   wire regs_0_status_err_fb_i,
-    // Detected number of DIM devices (can be lower than 'max_dim_no')
     input   wire [3:0] regs_0_status_dim_count_i,
 
-    // Control register
-    // Send the Reset state to DIM
+    // REG control
     output  wire regs_1_control_reset_o,
-    // Trigger DIM readout
     output  wire regs_1_control_trig_o,
-    // Address of last DIM register (number of registers - 1)
     output  wire [3:0] regs_1_control_last_reg_adr_o,
-    // Maximum number of devices present on line
     output  wire [3:0] regs_1_control_max_dim_no_o,
-    // Delay between consecutive register reads in microseconds (usually 512 us)
     output  wire [9:0] regs_1_control_read_delay_o,
 
-    // Status register
-    // QSPI master is busy (either in RESET or READOUT)
+    // REG status
     input   wire regs_1_status_busy_i,
-    // QSPI master has finished DIM readout
     input   wire regs_1_status_done_i,
-    // Too many devices on DIM line (more than set by 'max_dim_no' register)
     input   wire regs_1_status_err_many_i,
-    // Detected error on QSPI fb line
     input   wire regs_1_status_err_fb_i,
-    // Detected number of DIM devices (can be lower than 'max_dim_no')
     input   wire [3:0] regs_1_status_dim_count_i,
 
     // SRAM bus memory_0_mem_readout

--- a/testfiles/issue87/qsm_regs.vhdl
+++ b/testfiles/issue87/qsm_regs.vhdl
@@ -10,52 +10,32 @@ entity qsm_regs is
     wb_i                 : in    t_wishbone_slave_in;
     wb_o                 : out   t_wishbone_slave_out;
 
-    -- Control register
-    -- Send the Reset state to DIM
+    -- REG control
     regs_0_control_reset_o : out   std_logic;
-    -- Trigger DIM readout
     regs_0_control_trig_o : out   std_logic;
-    -- Address of last DIM register (number of registers - 1)
     regs_0_control_last_reg_adr_o : out   std_logic_vector(3 downto 0);
-    -- Maximum number of devices present on line
     regs_0_control_max_dim_no_o : out   std_logic_vector(3 downto 0);
-    -- Delay between consecutive register reads in microseconds (usually 512 us)
     regs_0_control_read_delay_o : out   std_logic_vector(9 downto 0);
 
-    -- Status register
-    -- QSPI master is busy (either in RESET or READOUT)
+    -- REG status
     regs_0_status_busy_i : in    std_logic;
-    -- QSPI master has finished DIM readout
     regs_0_status_done_i : in    std_logic;
-    -- Too many devices on DIM line (more than set by 'max_dim_no' register)
     regs_0_status_err_many_i : in    std_logic;
-    -- Detected error on QSPI fb line
     regs_0_status_err_fb_i : in    std_logic;
-    -- Detected number of DIM devices (can be lower than 'max_dim_no')
     regs_0_status_dim_count_i : in    std_logic_vector(3 downto 0);
 
-    -- Control register
-    -- Send the Reset state to DIM
+    -- REG control
     regs_1_control_reset_o : out   std_logic;
-    -- Trigger DIM readout
     regs_1_control_trig_o : out   std_logic;
-    -- Address of last DIM register (number of registers - 1)
     regs_1_control_last_reg_adr_o : out   std_logic_vector(3 downto 0);
-    -- Maximum number of devices present on line
     regs_1_control_max_dim_no_o : out   std_logic_vector(3 downto 0);
-    -- Delay between consecutive register reads in microseconds (usually 512 us)
     regs_1_control_read_delay_o : out   std_logic_vector(9 downto 0);
 
-    -- Status register
-    -- QSPI master is busy (either in RESET or READOUT)
+    -- REG status
     regs_1_status_busy_i : in    std_logic;
-    -- QSPI master has finished DIM readout
     regs_1_status_done_i : in    std_logic;
-    -- Too many devices on DIM line (more than set by 'max_dim_no' register)
     regs_1_status_err_many_i : in    std_logic;
-    -- Detected error on QSPI fb line
     regs_1_status_err_fb_i : in    std_logic;
-    -- Detected number of DIM devices (can be lower than 'max_dim_no')
     regs_1_status_dim_count_i : in    std_logic_vector(3 downto 0);
 
     -- SRAM bus memory_0_mem_readout

--- a/testfiles/issue9/test.html
+++ b/testfiles/issue9/test.html
@@ -105,9 +105,7 @@
 <tr><td><b>C prefix:</b></td><td class="td_code">register1</td></tr>
 <tr><td><b>C block offset:</b></td><td class="td_code">0x0</td></tr>
 </table>
-<p>
-Test register 1
-</p>
+<p>Test register 1</p>
 <table cellpadding=0 cellspacing=0 border=0>
 <tr>
  <td class="td_bit" colspan="1">31</td>
@@ -174,9 +172,7 @@ Test register 1
 <tr><td><b>C prefix:</b></td><td class="td_code">block1.register2</td></tr>
 <tr><td><b>C block offset:</b></td><td class="td_code">0x0</td></tr>
 </table>
-<p>
-Test register 2
-</p>
+<p>Test register 2</p>
 <table cellpadding=0 cellspacing=0 border=0>
 <tr>
  <td class="td_bit" colspan="1">31</td>
@@ -271,9 +267,7 @@ Test register 2
 <tr><td><b>C prefix:</b></td><td class="td_code">block1.register3</td></tr>
 <tr><td><b>C block offset:</b></td><td class="td_code">0x4</td></tr>
 </table>
-<p>
-Test register 3
-</p>
+<p>Test register 3</p>
 <table cellpadding=0 cellspacing=0 border=0>
 <tr>
  <td class="td_bit" colspan="1">31</td>
@@ -340,9 +334,7 @@ Test register 3
 <tr><td><b>C prefix:</b></td><td class="td_code">block1.block2.register4</td></tr>
 <tr><td><b>C block offset:</b></td><td class="td_code">0x0</td></tr>
 </table>
-<p>
-Test register 4
-</p>
+<p>Test register 4</p>
 <table cellpadding=0 cellspacing=0 border=0>
 <tr>
  <td class="td_bit" colspan="1">31</td>

--- a/testfiles/issue9/test.sv
+++ b/testfiles/issue9/test.sv
@@ -23,22 +23,18 @@ module test
     output  reg [31:0] rdata,
     output  wire [1:0] rresp,
 
-    // Test register 1
+    // REG register1
     output  wire [31:0] register1_o,
 
-    // Test register 2
-    // Test field 1
+    // REG register2
     input   wire block1_register2_field1_i,
-    // Test field 2
     input   wire [2:0] block1_register2_field2_i,
 
-    // Test register 3
+    // REG register3
     output  wire [31:0] block1_register3_o,
 
-    // Test register 4
-    // Test field 3
+    // REG register4
     input   wire block1_block2_register4_field3_i,
-    // Test field 4
     input   wire [2:0] block1_block2_register4_field4_i
   );
   reg wr_req;

--- a/testfiles/issue9/test.v
+++ b/testfiles/issue9/test.v
@@ -23,22 +23,18 @@ module test
     output  reg [31:0] rdata,
     output  wire [1:0] rresp,
 
-    // Test register 1
+    // REG register1
     output  wire [31:0] register1_o,
 
-    // Test register 2
-    // Test field 1
+    // REG register2
     input   wire block1_register2_field1_i,
-    // Test field 2
     input   wire [2:0] block1_register2_field2_i,
 
-    // Test register 3
+    // REG register3
     output  wire [31:0] block1_register3_o,
 
-    // Test register 4
-    // Test field 3
+    // REG register4
     input   wire block1_block2_register4_field3_i,
-    // Test field 4
     input   wire [2:0] block1_block2_register4_field4_i
   );
   reg wr_req;

--- a/testfiles/issue9/test.vhdl
+++ b/testfiles/issue9/test.vhdl
@@ -26,22 +26,18 @@ entity test is
     rdata                : out   std_logic_vector(31 downto 0);
     rresp                : out   std_logic_vector(1 downto 0);
 
-    -- Test register 1
+    -- REG register1
     register1_o          : out   std_logic_vector(31 downto 0);
 
-    -- Test register 2
-    -- Test field 1
+    -- REG register2
     block1_register2_field1_i : in    std_logic;
-    -- Test field 2
     block1_register2_field2_i : in    std_logic_vector(2 downto 0);
 
-    -- Test register 3
+    -- REG register3
     block1_register3_o   : out   std_logic_vector(31 downto 0);
 
-    -- Test register 4
-    -- Test field 3
+    -- REG register4
     block1_block2_register4_field3_i : in    std_logic;
-    -- Test field 4
     block1_block2_register4_field4_i : in    std_logic_vector(2 downto 0)
   );
 end test;

--- a/testfiles/tb/all1_simple.vhdl
+++ b/testfiles/tb/all1_simple.vhdl
@@ -15,7 +15,7 @@ entity all1_simple is
     rack                 : out   std_logic;
     wack                 : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -37,7 +37,7 @@ entity all1_simple is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -50,7 +50,7 @@ entity all1_simple is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -71,7 +71,7 @@ entity all1_simple is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -80,7 +80,7 @@ entity all1_simple is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -99,7 +99,7 @@ entity all1_simple is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/addrwidth_axi4_mst_byte-byte.vhdl
+++ b/testfiles/tb/golden_files/addrwidth_axi4_mst_byte-byte.vhdl
@@ -26,10 +26,10 @@ entity addrwidth_axi4_byte is
     rdata                : out   std_logic_vector(31 downto 0);
     rresp                : out   std_logic_vector(1 downto 0);
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(2 downto 0);

--- a/testfiles/tb/golden_files/addrwidth_axi4_mst_byte-word.vhdl
+++ b/testfiles/tb/golden_files/addrwidth_axi4_mst_byte-word.vhdl
@@ -26,10 +26,10 @@ entity addrwidth_axi4_byte is
     rdata                : out   std_logic_vector(31 downto 0);
     rresp                : out   std_logic_vector(1 downto 0);
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(2 downto 2);

--- a/testfiles/tb/golden_files/addrwidth_axi4_mst_word-byte.vhdl
+++ b/testfiles/tb/golden_files/addrwidth_axi4_mst_word-byte.vhdl
@@ -26,10 +26,10 @@ entity addrwidth_axi4_word is
     rdata                : out   std_logic_vector(31 downto 0);
     rresp                : out   std_logic_vector(1 downto 0);
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(2 downto 0);

--- a/testfiles/tb/golden_files/addrwidth_axi4_sub_byte-byte.vhdl
+++ b/testfiles/tb/golden_files/addrwidth_axi4_sub_byte-byte.vhdl
@@ -26,10 +26,10 @@ entity addrwidth_axi4_sub_byte is
     rdata                : out   std_logic_vector(31 downto 0);
     rresp                : out   std_logic_vector(1 downto 0);
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
-    -- A register
+    -- REG reg2
     reg2_o               : out   std_logic_vector(31 downto 0)
   );
 end addrwidth_axi4_sub_byte;

--- a/testfiles/tb/golden_files/addrwidth_axi4_sub_byte-word.vhdl
+++ b/testfiles/tb/golden_files/addrwidth_axi4_sub_byte-word.vhdl
@@ -26,10 +26,10 @@ entity addrwidth_axi4_sub_byte is
     rdata                : out   std_logic_vector(31 downto 0);
     rresp                : out   std_logic_vector(1 downto 0);
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
-    -- A register
+    -- REG reg2
     reg2_o               : out   std_logic_vector(31 downto 0)
   );
 end addrwidth_axi4_sub_byte;

--- a/testfiles/tb/golden_files/addrwidth_axi4_sub_word-byte.vhdl
+++ b/testfiles/tb/golden_files/addrwidth_axi4_sub_word-byte.vhdl
@@ -26,10 +26,10 @@ entity addrwidth_axi4_sub_word is
     rdata                : out   std_logic_vector(31 downto 0);
     rresp                : out   std_logic_vector(1 downto 0);
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
-    -- A register
+    -- REG reg2
     reg2_o               : out   std_logic_vector(31 downto 0)
   );
 end addrwidth_axi4_sub_word;

--- a/testfiles/tb/golden_files/all1_apb_all.vhdl
+++ b/testfiles/tb/golden_files/all1_apb_all.vhdl
@@ -17,7 +17,7 @@ entity all1_apb is
     prdata               : out   std_logic_vector(31 downto 0);
     pslverr              : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -39,7 +39,7 @@ entity all1_apb is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -52,7 +52,7 @@ entity all1_apb is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -73,7 +73,7 @@ entity all1_apb is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -82,7 +82,7 @@ entity all1_apb is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -101,7 +101,7 @@ entity all1_apb is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_apb_in,out.vhdl
+++ b/testfiles/tb/golden_files/all1_apb_in,out.vhdl
@@ -17,7 +17,7 @@ entity all1_apb is
     prdata               : out   std_logic_vector(31 downto 0);
     pslverr              : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -39,7 +39,7 @@ entity all1_apb is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -52,7 +52,7 @@ entity all1_apb is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -73,7 +73,7 @@ entity all1_apb is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -82,7 +82,7 @@ entity all1_apb is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -101,7 +101,7 @@ entity all1_apb is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_apb_in.vhdl
+++ b/testfiles/tb/golden_files/all1_apb_in.vhdl
@@ -17,7 +17,7 @@ entity all1_apb is
     prdata               : out   std_logic_vector(31 downto 0);
     pslverr              : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -39,7 +39,7 @@ entity all1_apb is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -52,7 +52,7 @@ entity all1_apb is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -73,7 +73,7 @@ entity all1_apb is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -82,7 +82,7 @@ entity all1_apb is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -101,7 +101,7 @@ entity all1_apb is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_apb_none.vhdl
+++ b/testfiles/tb/golden_files/all1_apb_none.vhdl
@@ -17,7 +17,7 @@ entity all1_apb is
     prdata               : out   std_logic_vector(31 downto 0);
     pslverr              : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -39,7 +39,7 @@ entity all1_apb is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -52,7 +52,7 @@ entity all1_apb is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -73,7 +73,7 @@ entity all1_apb is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -82,7 +82,7 @@ entity all1_apb is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -101,7 +101,7 @@ entity all1_apb is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_apb_out.vhdl
+++ b/testfiles/tb/golden_files/all1_apb_out.vhdl
@@ -17,7 +17,7 @@ entity all1_apb is
     prdata               : out   std_logic_vector(31 downto 0);
     pslverr              : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -39,7 +39,7 @@ entity all1_apb is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -52,7 +52,7 @@ entity all1_apb is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -73,7 +73,7 @@ entity all1_apb is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -82,7 +82,7 @@ entity all1_apb is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -101,7 +101,7 @@ entity all1_apb is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_apb_rd-in,wr-out.vhdl
+++ b/testfiles/tb/golden_files/all1_apb_rd-in,wr-out.vhdl
@@ -17,7 +17,7 @@ entity all1_apb is
     prdata               : out   std_logic_vector(31 downto 0);
     pslverr              : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -39,7 +39,7 @@ entity all1_apb is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -52,7 +52,7 @@ entity all1_apb is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -73,7 +73,7 @@ entity all1_apb is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -82,7 +82,7 @@ entity all1_apb is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -101,7 +101,7 @@ entity all1_apb is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_apb_rd-in.vhdl
+++ b/testfiles/tb/golden_files/all1_apb_rd-in.vhdl
@@ -17,7 +17,7 @@ entity all1_apb is
     prdata               : out   std_logic_vector(31 downto 0);
     pslverr              : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -39,7 +39,7 @@ entity all1_apb is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -52,7 +52,7 @@ entity all1_apb is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -73,7 +73,7 @@ entity all1_apb is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -82,7 +82,7 @@ entity all1_apb is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -101,7 +101,7 @@ entity all1_apb is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_apb_rd-out.vhdl
+++ b/testfiles/tb/golden_files/all1_apb_rd-out.vhdl
@@ -17,7 +17,7 @@ entity all1_apb is
     prdata               : out   std_logic_vector(31 downto 0);
     pslverr              : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -39,7 +39,7 @@ entity all1_apb is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -52,7 +52,7 @@ entity all1_apb is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -73,7 +73,7 @@ entity all1_apb is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -82,7 +82,7 @@ entity all1_apb is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -101,7 +101,7 @@ entity all1_apb is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_apb_rd.vhdl
+++ b/testfiles/tb/golden_files/all1_apb_rd.vhdl
@@ -17,7 +17,7 @@ entity all1_apb is
     prdata               : out   std_logic_vector(31 downto 0);
     pslverr              : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -39,7 +39,7 @@ entity all1_apb is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -52,7 +52,7 @@ entity all1_apb is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -73,7 +73,7 @@ entity all1_apb is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -82,7 +82,7 @@ entity all1_apb is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -101,7 +101,7 @@ entity all1_apb is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_apb_wr-in,rd-out.vhdl
+++ b/testfiles/tb/golden_files/all1_apb_wr-in,rd-out.vhdl
@@ -17,7 +17,7 @@ entity all1_apb is
     prdata               : out   std_logic_vector(31 downto 0);
     pslverr              : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -39,7 +39,7 @@ entity all1_apb is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -52,7 +52,7 @@ entity all1_apb is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -73,7 +73,7 @@ entity all1_apb is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -82,7 +82,7 @@ entity all1_apb is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -101,7 +101,7 @@ entity all1_apb is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_apb_wr-in.vhdl
+++ b/testfiles/tb/golden_files/all1_apb_wr-in.vhdl
@@ -17,7 +17,7 @@ entity all1_apb is
     prdata               : out   std_logic_vector(31 downto 0);
     pslverr              : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -39,7 +39,7 @@ entity all1_apb is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -52,7 +52,7 @@ entity all1_apb is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -73,7 +73,7 @@ entity all1_apb is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -82,7 +82,7 @@ entity all1_apb is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -101,7 +101,7 @@ entity all1_apb is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_apb_wr-out.vhdl
+++ b/testfiles/tb/golden_files/all1_apb_wr-out.vhdl
@@ -17,7 +17,7 @@ entity all1_apb is
     prdata               : out   std_logic_vector(31 downto 0);
     pslverr              : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -39,7 +39,7 @@ entity all1_apb is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -52,7 +52,7 @@ entity all1_apb is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -73,7 +73,7 @@ entity all1_apb is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -82,7 +82,7 @@ entity all1_apb is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -101,7 +101,7 @@ entity all1_apb is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_apb_wr.vhdl
+++ b/testfiles/tb/golden_files/all1_apb_wr.vhdl
@@ -17,7 +17,7 @@ entity all1_apb is
     prdata               : out   std_logic_vector(31 downto 0);
     pslverr              : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -39,7 +39,7 @@ entity all1_apb is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -52,7 +52,7 @@ entity all1_apb is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -73,7 +73,7 @@ entity all1_apb is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -82,7 +82,7 @@ entity all1_apb is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -101,7 +101,7 @@ entity all1_apb is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_avalon_all.vhdl
+++ b/testfiles/tb/golden_files/all1_avalon_all.vhdl
@@ -16,7 +16,7 @@ entity all1_avalon is
     readdatavalid        : out   std_logic;
     waitrequest          : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -38,7 +38,7 @@ entity all1_avalon is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -51,7 +51,7 @@ entity all1_avalon is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -72,7 +72,7 @@ entity all1_avalon is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -81,7 +81,7 @@ entity all1_avalon is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -100,7 +100,7 @@ entity all1_avalon is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_avalon_in,out.vhdl
+++ b/testfiles/tb/golden_files/all1_avalon_in,out.vhdl
@@ -16,7 +16,7 @@ entity all1_avalon is
     readdatavalid        : out   std_logic;
     waitrequest          : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -38,7 +38,7 @@ entity all1_avalon is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -51,7 +51,7 @@ entity all1_avalon is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -72,7 +72,7 @@ entity all1_avalon is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -81,7 +81,7 @@ entity all1_avalon is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -100,7 +100,7 @@ entity all1_avalon is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_avalon_in.vhdl
+++ b/testfiles/tb/golden_files/all1_avalon_in.vhdl
@@ -16,7 +16,7 @@ entity all1_avalon is
     readdatavalid        : out   std_logic;
     waitrequest          : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -38,7 +38,7 @@ entity all1_avalon is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -51,7 +51,7 @@ entity all1_avalon is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -72,7 +72,7 @@ entity all1_avalon is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -81,7 +81,7 @@ entity all1_avalon is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -100,7 +100,7 @@ entity all1_avalon is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_avalon_none.vhdl
+++ b/testfiles/tb/golden_files/all1_avalon_none.vhdl
@@ -16,7 +16,7 @@ entity all1_avalon is
     readdatavalid        : out   std_logic;
     waitrequest          : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -38,7 +38,7 @@ entity all1_avalon is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -51,7 +51,7 @@ entity all1_avalon is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -72,7 +72,7 @@ entity all1_avalon is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -81,7 +81,7 @@ entity all1_avalon is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -100,7 +100,7 @@ entity all1_avalon is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_avalon_out.vhdl
+++ b/testfiles/tb/golden_files/all1_avalon_out.vhdl
@@ -16,7 +16,7 @@ entity all1_avalon is
     readdatavalid        : out   std_logic;
     waitrequest          : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -38,7 +38,7 @@ entity all1_avalon is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -51,7 +51,7 @@ entity all1_avalon is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -72,7 +72,7 @@ entity all1_avalon is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -81,7 +81,7 @@ entity all1_avalon is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -100,7 +100,7 @@ entity all1_avalon is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_avalon_rd-in,wr-out.vhdl
+++ b/testfiles/tb/golden_files/all1_avalon_rd-in,wr-out.vhdl
@@ -16,7 +16,7 @@ entity all1_avalon is
     readdatavalid        : out   std_logic;
     waitrequest          : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -38,7 +38,7 @@ entity all1_avalon is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -51,7 +51,7 @@ entity all1_avalon is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -72,7 +72,7 @@ entity all1_avalon is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -81,7 +81,7 @@ entity all1_avalon is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -100,7 +100,7 @@ entity all1_avalon is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_avalon_rd-in.vhdl
+++ b/testfiles/tb/golden_files/all1_avalon_rd-in.vhdl
@@ -16,7 +16,7 @@ entity all1_avalon is
     readdatavalid        : out   std_logic;
     waitrequest          : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -38,7 +38,7 @@ entity all1_avalon is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -51,7 +51,7 @@ entity all1_avalon is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -72,7 +72,7 @@ entity all1_avalon is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -81,7 +81,7 @@ entity all1_avalon is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -100,7 +100,7 @@ entity all1_avalon is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_avalon_rd-out.vhdl
+++ b/testfiles/tb/golden_files/all1_avalon_rd-out.vhdl
@@ -16,7 +16,7 @@ entity all1_avalon is
     readdatavalid        : out   std_logic;
     waitrequest          : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -38,7 +38,7 @@ entity all1_avalon is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -51,7 +51,7 @@ entity all1_avalon is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -72,7 +72,7 @@ entity all1_avalon is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -81,7 +81,7 @@ entity all1_avalon is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -100,7 +100,7 @@ entity all1_avalon is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_avalon_rd.vhdl
+++ b/testfiles/tb/golden_files/all1_avalon_rd.vhdl
@@ -16,7 +16,7 @@ entity all1_avalon is
     readdatavalid        : out   std_logic;
     waitrequest          : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -38,7 +38,7 @@ entity all1_avalon is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -51,7 +51,7 @@ entity all1_avalon is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -72,7 +72,7 @@ entity all1_avalon is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -81,7 +81,7 @@ entity all1_avalon is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -100,7 +100,7 @@ entity all1_avalon is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_avalon_wr-in,rd-out.vhdl
+++ b/testfiles/tb/golden_files/all1_avalon_wr-in,rd-out.vhdl
@@ -16,7 +16,7 @@ entity all1_avalon is
     readdatavalid        : out   std_logic;
     waitrequest          : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -38,7 +38,7 @@ entity all1_avalon is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -51,7 +51,7 @@ entity all1_avalon is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -72,7 +72,7 @@ entity all1_avalon is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -81,7 +81,7 @@ entity all1_avalon is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -100,7 +100,7 @@ entity all1_avalon is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_avalon_wr-in.vhdl
+++ b/testfiles/tb/golden_files/all1_avalon_wr-in.vhdl
@@ -16,7 +16,7 @@ entity all1_avalon is
     readdatavalid        : out   std_logic;
     waitrequest          : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -38,7 +38,7 @@ entity all1_avalon is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -51,7 +51,7 @@ entity all1_avalon is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -72,7 +72,7 @@ entity all1_avalon is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -81,7 +81,7 @@ entity all1_avalon is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -100,7 +100,7 @@ entity all1_avalon is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_avalon_wr-out.vhdl
+++ b/testfiles/tb/golden_files/all1_avalon_wr-out.vhdl
@@ -16,7 +16,7 @@ entity all1_avalon is
     readdatavalid        : out   std_logic;
     waitrequest          : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -38,7 +38,7 @@ entity all1_avalon is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -51,7 +51,7 @@ entity all1_avalon is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -72,7 +72,7 @@ entity all1_avalon is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -81,7 +81,7 @@ entity all1_avalon is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -100,7 +100,7 @@ entity all1_avalon is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_avalon_wr.vhdl
+++ b/testfiles/tb/golden_files/all1_avalon_wr.vhdl
@@ -16,7 +16,7 @@ entity all1_avalon is
     readdatavalid        : out   std_logic;
     waitrequest          : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -38,7 +38,7 @@ entity all1_avalon is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -51,7 +51,7 @@ entity all1_avalon is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -72,7 +72,7 @@ entity all1_avalon is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -81,7 +81,7 @@ entity all1_avalon is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -100,7 +100,7 @@ entity all1_avalon is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_axi4_all.vhdl
+++ b/testfiles/tb/golden_files/all1_axi4_all.vhdl
@@ -27,7 +27,7 @@ entity all1_axi4 is
     rdata                : out   std_logic_vector(31 downto 0);
     rresp                : out   std_logic_vector(1 downto 0);
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -49,7 +49,7 @@ entity all1_axi4 is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -62,7 +62,7 @@ entity all1_axi4 is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -83,7 +83,7 @@ entity all1_axi4 is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -92,7 +92,7 @@ entity all1_axi4 is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -111,7 +111,7 @@ entity all1_axi4 is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_axi4_in,out.vhdl
+++ b/testfiles/tb/golden_files/all1_axi4_in,out.vhdl
@@ -27,7 +27,7 @@ entity all1_axi4 is
     rdata                : out   std_logic_vector(31 downto 0);
     rresp                : out   std_logic_vector(1 downto 0);
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -49,7 +49,7 @@ entity all1_axi4 is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -62,7 +62,7 @@ entity all1_axi4 is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -83,7 +83,7 @@ entity all1_axi4 is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -92,7 +92,7 @@ entity all1_axi4 is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -111,7 +111,7 @@ entity all1_axi4 is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_axi4_in.vhdl
+++ b/testfiles/tb/golden_files/all1_axi4_in.vhdl
@@ -27,7 +27,7 @@ entity all1_axi4 is
     rdata                : out   std_logic_vector(31 downto 0);
     rresp                : out   std_logic_vector(1 downto 0);
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -49,7 +49,7 @@ entity all1_axi4 is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -62,7 +62,7 @@ entity all1_axi4 is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -83,7 +83,7 @@ entity all1_axi4 is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -92,7 +92,7 @@ entity all1_axi4 is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -111,7 +111,7 @@ entity all1_axi4 is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_axi4_none.vhdl
+++ b/testfiles/tb/golden_files/all1_axi4_none.vhdl
@@ -27,7 +27,7 @@ entity all1_axi4 is
     rdata                : out   std_logic_vector(31 downto 0);
     rresp                : out   std_logic_vector(1 downto 0);
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -49,7 +49,7 @@ entity all1_axi4 is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -62,7 +62,7 @@ entity all1_axi4 is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -83,7 +83,7 @@ entity all1_axi4 is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -92,7 +92,7 @@ entity all1_axi4 is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -111,7 +111,7 @@ entity all1_axi4 is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_axi4_out.vhdl
+++ b/testfiles/tb/golden_files/all1_axi4_out.vhdl
@@ -27,7 +27,7 @@ entity all1_axi4 is
     rdata                : out   std_logic_vector(31 downto 0);
     rresp                : out   std_logic_vector(1 downto 0);
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -49,7 +49,7 @@ entity all1_axi4 is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -62,7 +62,7 @@ entity all1_axi4 is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -83,7 +83,7 @@ entity all1_axi4 is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -92,7 +92,7 @@ entity all1_axi4 is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -111,7 +111,7 @@ entity all1_axi4 is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_axi4_rd-in,wr-out.vhdl
+++ b/testfiles/tb/golden_files/all1_axi4_rd-in,wr-out.vhdl
@@ -27,7 +27,7 @@ entity all1_axi4 is
     rdata                : out   std_logic_vector(31 downto 0);
     rresp                : out   std_logic_vector(1 downto 0);
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -49,7 +49,7 @@ entity all1_axi4 is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -62,7 +62,7 @@ entity all1_axi4 is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -83,7 +83,7 @@ entity all1_axi4 is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -92,7 +92,7 @@ entity all1_axi4 is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -111,7 +111,7 @@ entity all1_axi4 is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_axi4_rd-in.vhdl
+++ b/testfiles/tb/golden_files/all1_axi4_rd-in.vhdl
@@ -27,7 +27,7 @@ entity all1_axi4 is
     rdata                : out   std_logic_vector(31 downto 0);
     rresp                : out   std_logic_vector(1 downto 0);
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -49,7 +49,7 @@ entity all1_axi4 is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -62,7 +62,7 @@ entity all1_axi4 is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -83,7 +83,7 @@ entity all1_axi4 is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -92,7 +92,7 @@ entity all1_axi4 is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -111,7 +111,7 @@ entity all1_axi4 is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_axi4_rd-out.vhdl
+++ b/testfiles/tb/golden_files/all1_axi4_rd-out.vhdl
@@ -27,7 +27,7 @@ entity all1_axi4 is
     rdata                : out   std_logic_vector(31 downto 0);
     rresp                : out   std_logic_vector(1 downto 0);
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -49,7 +49,7 @@ entity all1_axi4 is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -62,7 +62,7 @@ entity all1_axi4 is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -83,7 +83,7 @@ entity all1_axi4 is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -92,7 +92,7 @@ entity all1_axi4 is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -111,7 +111,7 @@ entity all1_axi4 is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_axi4_rd.vhdl
+++ b/testfiles/tb/golden_files/all1_axi4_rd.vhdl
@@ -27,7 +27,7 @@ entity all1_axi4 is
     rdata                : out   std_logic_vector(31 downto 0);
     rresp                : out   std_logic_vector(1 downto 0);
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -49,7 +49,7 @@ entity all1_axi4 is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -62,7 +62,7 @@ entity all1_axi4 is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -83,7 +83,7 @@ entity all1_axi4 is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -92,7 +92,7 @@ entity all1_axi4 is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -111,7 +111,7 @@ entity all1_axi4 is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_axi4_wr-in,rd-out.vhdl
+++ b/testfiles/tb/golden_files/all1_axi4_wr-in,rd-out.vhdl
@@ -27,7 +27,7 @@ entity all1_axi4 is
     rdata                : out   std_logic_vector(31 downto 0);
     rresp                : out   std_logic_vector(1 downto 0);
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -49,7 +49,7 @@ entity all1_axi4 is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -62,7 +62,7 @@ entity all1_axi4 is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -83,7 +83,7 @@ entity all1_axi4 is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -92,7 +92,7 @@ entity all1_axi4 is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -111,7 +111,7 @@ entity all1_axi4 is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_axi4_wr-in.vhdl
+++ b/testfiles/tb/golden_files/all1_axi4_wr-in.vhdl
@@ -27,7 +27,7 @@ entity all1_axi4 is
     rdata                : out   std_logic_vector(31 downto 0);
     rresp                : out   std_logic_vector(1 downto 0);
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -49,7 +49,7 @@ entity all1_axi4 is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -62,7 +62,7 @@ entity all1_axi4 is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -83,7 +83,7 @@ entity all1_axi4 is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -92,7 +92,7 @@ entity all1_axi4 is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -111,7 +111,7 @@ entity all1_axi4 is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_axi4_wr-out.vhdl
+++ b/testfiles/tb/golden_files/all1_axi4_wr-out.vhdl
@@ -27,7 +27,7 @@ entity all1_axi4 is
     rdata                : out   std_logic_vector(31 downto 0);
     rresp                : out   std_logic_vector(1 downto 0);
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -49,7 +49,7 @@ entity all1_axi4 is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -62,7 +62,7 @@ entity all1_axi4 is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -83,7 +83,7 @@ entity all1_axi4 is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -92,7 +92,7 @@ entity all1_axi4 is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -111,7 +111,7 @@ entity all1_axi4 is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_axi4_wr.vhdl
+++ b/testfiles/tb/golden_files/all1_axi4_wr.vhdl
@@ -27,7 +27,7 @@ entity all1_axi4 is
     rdata                : out   std_logic_vector(31 downto 0);
     rresp                : out   std_logic_vector(1 downto 0);
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -49,7 +49,7 @@ entity all1_axi4 is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -62,7 +62,7 @@ entity all1_axi4 is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -83,7 +83,7 @@ entity all1_axi4 is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -92,7 +92,7 @@ entity all1_axi4 is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -111,7 +111,7 @@ entity all1_axi4 is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_cernbe_all.vhdl
+++ b/testfiles/tb/golden_files/all1_cernbe_all.vhdl
@@ -15,7 +15,7 @@ entity all1_cernbe is
     VMERdDone            : out   std_logic;
     VMEWrDone            : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -37,7 +37,7 @@ entity all1_cernbe is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -50,7 +50,7 @@ entity all1_cernbe is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -71,7 +71,7 @@ entity all1_cernbe is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -80,7 +80,7 @@ entity all1_cernbe is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -99,7 +99,7 @@ entity all1_cernbe is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_cernbe_in,out.vhdl
+++ b/testfiles/tb/golden_files/all1_cernbe_in,out.vhdl
@@ -15,7 +15,7 @@ entity all1_cernbe is
     VMERdDone            : out   std_logic;
     VMEWrDone            : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -37,7 +37,7 @@ entity all1_cernbe is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -50,7 +50,7 @@ entity all1_cernbe is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -71,7 +71,7 @@ entity all1_cernbe is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -80,7 +80,7 @@ entity all1_cernbe is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -99,7 +99,7 @@ entity all1_cernbe is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_cernbe_in.vhdl
+++ b/testfiles/tb/golden_files/all1_cernbe_in.vhdl
@@ -15,7 +15,7 @@ entity all1_cernbe is
     VMERdDone            : out   std_logic;
     VMEWrDone            : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -37,7 +37,7 @@ entity all1_cernbe is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -50,7 +50,7 @@ entity all1_cernbe is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -71,7 +71,7 @@ entity all1_cernbe is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -80,7 +80,7 @@ entity all1_cernbe is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -99,7 +99,7 @@ entity all1_cernbe is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_cernbe_none.vhdl
+++ b/testfiles/tb/golden_files/all1_cernbe_none.vhdl
@@ -15,7 +15,7 @@ entity all1_cernbe is
     VMERdDone            : out   std_logic;
     VMEWrDone            : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -37,7 +37,7 @@ entity all1_cernbe is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -50,7 +50,7 @@ entity all1_cernbe is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -71,7 +71,7 @@ entity all1_cernbe is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -80,7 +80,7 @@ entity all1_cernbe is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -99,7 +99,7 @@ entity all1_cernbe is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_cernbe_out.vhdl
+++ b/testfiles/tb/golden_files/all1_cernbe_out.vhdl
@@ -15,7 +15,7 @@ entity all1_cernbe is
     VMERdDone            : out   std_logic;
     VMEWrDone            : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -37,7 +37,7 @@ entity all1_cernbe is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -50,7 +50,7 @@ entity all1_cernbe is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -71,7 +71,7 @@ entity all1_cernbe is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -80,7 +80,7 @@ entity all1_cernbe is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -99,7 +99,7 @@ entity all1_cernbe is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_cernbe_rd-in,wr-out.vhdl
+++ b/testfiles/tb/golden_files/all1_cernbe_rd-in,wr-out.vhdl
@@ -15,7 +15,7 @@ entity all1_cernbe is
     VMERdDone            : out   std_logic;
     VMEWrDone            : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -37,7 +37,7 @@ entity all1_cernbe is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -50,7 +50,7 @@ entity all1_cernbe is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -71,7 +71,7 @@ entity all1_cernbe is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -80,7 +80,7 @@ entity all1_cernbe is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -99,7 +99,7 @@ entity all1_cernbe is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_cernbe_rd-in.vhdl
+++ b/testfiles/tb/golden_files/all1_cernbe_rd-in.vhdl
@@ -15,7 +15,7 @@ entity all1_cernbe is
     VMERdDone            : out   std_logic;
     VMEWrDone            : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -37,7 +37,7 @@ entity all1_cernbe is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -50,7 +50,7 @@ entity all1_cernbe is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -71,7 +71,7 @@ entity all1_cernbe is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -80,7 +80,7 @@ entity all1_cernbe is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -99,7 +99,7 @@ entity all1_cernbe is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_cernbe_rd-out.vhdl
+++ b/testfiles/tb/golden_files/all1_cernbe_rd-out.vhdl
@@ -15,7 +15,7 @@ entity all1_cernbe is
     VMERdDone            : out   std_logic;
     VMEWrDone            : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -37,7 +37,7 @@ entity all1_cernbe is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -50,7 +50,7 @@ entity all1_cernbe is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -71,7 +71,7 @@ entity all1_cernbe is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -80,7 +80,7 @@ entity all1_cernbe is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -99,7 +99,7 @@ entity all1_cernbe is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_cernbe_rd.vhdl
+++ b/testfiles/tb/golden_files/all1_cernbe_rd.vhdl
@@ -15,7 +15,7 @@ entity all1_cernbe is
     VMERdDone            : out   std_logic;
     VMEWrDone            : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -37,7 +37,7 @@ entity all1_cernbe is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -50,7 +50,7 @@ entity all1_cernbe is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -71,7 +71,7 @@ entity all1_cernbe is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -80,7 +80,7 @@ entity all1_cernbe is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -99,7 +99,7 @@ entity all1_cernbe is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_cernbe_wr-in,rd-out.vhdl
+++ b/testfiles/tb/golden_files/all1_cernbe_wr-in,rd-out.vhdl
@@ -15,7 +15,7 @@ entity all1_cernbe is
     VMERdDone            : out   std_logic;
     VMEWrDone            : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -37,7 +37,7 @@ entity all1_cernbe is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -50,7 +50,7 @@ entity all1_cernbe is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -71,7 +71,7 @@ entity all1_cernbe is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -80,7 +80,7 @@ entity all1_cernbe is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -99,7 +99,7 @@ entity all1_cernbe is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_cernbe_wr-in.vhdl
+++ b/testfiles/tb/golden_files/all1_cernbe_wr-in.vhdl
@@ -15,7 +15,7 @@ entity all1_cernbe is
     VMERdDone            : out   std_logic;
     VMEWrDone            : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -37,7 +37,7 @@ entity all1_cernbe is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -50,7 +50,7 @@ entity all1_cernbe is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -71,7 +71,7 @@ entity all1_cernbe is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -80,7 +80,7 @@ entity all1_cernbe is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -99,7 +99,7 @@ entity all1_cernbe is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_cernbe_wr-out.vhdl
+++ b/testfiles/tb/golden_files/all1_cernbe_wr-out.vhdl
@@ -15,7 +15,7 @@ entity all1_cernbe is
     VMERdDone            : out   std_logic;
     VMEWrDone            : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -37,7 +37,7 @@ entity all1_cernbe is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -50,7 +50,7 @@ entity all1_cernbe is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -71,7 +71,7 @@ entity all1_cernbe is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -80,7 +80,7 @@ entity all1_cernbe is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -99,7 +99,7 @@ entity all1_cernbe is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_cernbe_wr.vhdl
+++ b/testfiles/tb/golden_files/all1_cernbe_wr.vhdl
@@ -15,7 +15,7 @@ entity all1_cernbe is
     VMERdDone            : out   std_logic;
     VMEWrDone            : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -37,7 +37,7 @@ entity all1_cernbe is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -50,7 +50,7 @@ entity all1_cernbe is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -71,7 +71,7 @@ entity all1_cernbe is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -80,7 +80,7 @@ entity all1_cernbe is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -99,7 +99,7 @@ entity all1_cernbe is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_simple_all.vhdl
+++ b/testfiles/tb/golden_files/all1_simple_all.vhdl
@@ -15,7 +15,7 @@ entity all1_simple is
     rack                 : out   std_logic;
     wack                 : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -37,7 +37,7 @@ entity all1_simple is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -50,7 +50,7 @@ entity all1_simple is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -71,7 +71,7 @@ entity all1_simple is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -80,7 +80,7 @@ entity all1_simple is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -99,7 +99,7 @@ entity all1_simple is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_simple_in,out.vhdl
+++ b/testfiles/tb/golden_files/all1_simple_in,out.vhdl
@@ -15,7 +15,7 @@ entity all1_simple is
     rack                 : out   std_logic;
     wack                 : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -37,7 +37,7 @@ entity all1_simple is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -50,7 +50,7 @@ entity all1_simple is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -71,7 +71,7 @@ entity all1_simple is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -80,7 +80,7 @@ entity all1_simple is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -99,7 +99,7 @@ entity all1_simple is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_simple_in.vhdl
+++ b/testfiles/tb/golden_files/all1_simple_in.vhdl
@@ -15,7 +15,7 @@ entity all1_simple is
     rack                 : out   std_logic;
     wack                 : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -37,7 +37,7 @@ entity all1_simple is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -50,7 +50,7 @@ entity all1_simple is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -71,7 +71,7 @@ entity all1_simple is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -80,7 +80,7 @@ entity all1_simple is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -99,7 +99,7 @@ entity all1_simple is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_simple_none.vhdl
+++ b/testfiles/tb/golden_files/all1_simple_none.vhdl
@@ -15,7 +15,7 @@ entity all1_simple is
     rack                 : out   std_logic;
     wack                 : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -37,7 +37,7 @@ entity all1_simple is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -50,7 +50,7 @@ entity all1_simple is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -71,7 +71,7 @@ entity all1_simple is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -80,7 +80,7 @@ entity all1_simple is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -99,7 +99,7 @@ entity all1_simple is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_simple_out.vhdl
+++ b/testfiles/tb/golden_files/all1_simple_out.vhdl
@@ -15,7 +15,7 @@ entity all1_simple is
     rack                 : out   std_logic;
     wack                 : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -37,7 +37,7 @@ entity all1_simple is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -50,7 +50,7 @@ entity all1_simple is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -71,7 +71,7 @@ entity all1_simple is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -80,7 +80,7 @@ entity all1_simple is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -99,7 +99,7 @@ entity all1_simple is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_simple_rd-in,wr-out.vhdl
+++ b/testfiles/tb/golden_files/all1_simple_rd-in,wr-out.vhdl
@@ -15,7 +15,7 @@ entity all1_simple is
     rack                 : out   std_logic;
     wack                 : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -37,7 +37,7 @@ entity all1_simple is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -50,7 +50,7 @@ entity all1_simple is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -71,7 +71,7 @@ entity all1_simple is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -80,7 +80,7 @@ entity all1_simple is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -99,7 +99,7 @@ entity all1_simple is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_simple_rd-in.vhdl
+++ b/testfiles/tb/golden_files/all1_simple_rd-in.vhdl
@@ -15,7 +15,7 @@ entity all1_simple is
     rack                 : out   std_logic;
     wack                 : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -37,7 +37,7 @@ entity all1_simple is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -50,7 +50,7 @@ entity all1_simple is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -71,7 +71,7 @@ entity all1_simple is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -80,7 +80,7 @@ entity all1_simple is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -99,7 +99,7 @@ entity all1_simple is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_simple_rd-out.vhdl
+++ b/testfiles/tb/golden_files/all1_simple_rd-out.vhdl
@@ -15,7 +15,7 @@ entity all1_simple is
     rack                 : out   std_logic;
     wack                 : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -37,7 +37,7 @@ entity all1_simple is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -50,7 +50,7 @@ entity all1_simple is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -71,7 +71,7 @@ entity all1_simple is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -80,7 +80,7 @@ entity all1_simple is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -99,7 +99,7 @@ entity all1_simple is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_simple_rd.vhdl
+++ b/testfiles/tb/golden_files/all1_simple_rd.vhdl
@@ -15,7 +15,7 @@ entity all1_simple is
     rack                 : out   std_logic;
     wack                 : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -37,7 +37,7 @@ entity all1_simple is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -50,7 +50,7 @@ entity all1_simple is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -71,7 +71,7 @@ entity all1_simple is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -80,7 +80,7 @@ entity all1_simple is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -99,7 +99,7 @@ entity all1_simple is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_simple_wr-in,rd-out.vhdl
+++ b/testfiles/tb/golden_files/all1_simple_wr-in,rd-out.vhdl
@@ -15,7 +15,7 @@ entity all1_simple is
     rack                 : out   std_logic;
     wack                 : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -37,7 +37,7 @@ entity all1_simple is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -50,7 +50,7 @@ entity all1_simple is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -71,7 +71,7 @@ entity all1_simple is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -80,7 +80,7 @@ entity all1_simple is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -99,7 +99,7 @@ entity all1_simple is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_simple_wr-in.vhdl
+++ b/testfiles/tb/golden_files/all1_simple_wr-in.vhdl
@@ -15,7 +15,7 @@ entity all1_simple is
     rack                 : out   std_logic;
     wack                 : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -37,7 +37,7 @@ entity all1_simple is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -50,7 +50,7 @@ entity all1_simple is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -71,7 +71,7 @@ entity all1_simple is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -80,7 +80,7 @@ entity all1_simple is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -99,7 +99,7 @@ entity all1_simple is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_simple_wr-out.vhdl
+++ b/testfiles/tb/golden_files/all1_simple_wr-out.vhdl
@@ -15,7 +15,7 @@ entity all1_simple is
     rack                 : out   std_logic;
     wack                 : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -37,7 +37,7 @@ entity all1_simple is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -50,7 +50,7 @@ entity all1_simple is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -71,7 +71,7 @@ entity all1_simple is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -80,7 +80,7 @@ entity all1_simple is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -99,7 +99,7 @@ entity all1_simple is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_simple_wr.vhdl
+++ b/testfiles/tb/golden_files/all1_simple_wr.vhdl
@@ -15,7 +15,7 @@ entity all1_simple is
     rack                 : out   std_logic;
     wack                 : out   std_logic;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -37,7 +37,7 @@ entity all1_simple is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -50,7 +50,7 @@ entity all1_simple is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -71,7 +71,7 @@ entity all1_simple is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -80,7 +80,7 @@ entity all1_simple is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -99,7 +99,7 @@ entity all1_simple is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_wb_all.vhdl
+++ b/testfiles/tb/golden_files/all1_wb_all.vhdl
@@ -11,7 +11,7 @@ entity all1_wb is
     wb_i                 : in    t_wishbone_slave_in;
     wb_o                 : out   t_wishbone_slave_out;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -33,7 +33,7 @@ entity all1_wb is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -46,7 +46,7 @@ entity all1_wb is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -67,7 +67,7 @@ entity all1_wb is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -76,7 +76,7 @@ entity all1_wb is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -95,7 +95,7 @@ entity all1_wb is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_wb_in,out.vhdl
+++ b/testfiles/tb/golden_files/all1_wb_in,out.vhdl
@@ -11,7 +11,7 @@ entity all1_wb is
     wb_i                 : in    t_wishbone_slave_in;
     wb_o                 : out   t_wishbone_slave_out;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -33,7 +33,7 @@ entity all1_wb is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -46,7 +46,7 @@ entity all1_wb is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -67,7 +67,7 @@ entity all1_wb is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -76,7 +76,7 @@ entity all1_wb is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -95,7 +95,7 @@ entity all1_wb is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_wb_in.vhdl
+++ b/testfiles/tb/golden_files/all1_wb_in.vhdl
@@ -11,7 +11,7 @@ entity all1_wb is
     wb_i                 : in    t_wishbone_slave_in;
     wb_o                 : out   t_wishbone_slave_out;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -33,7 +33,7 @@ entity all1_wb is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -46,7 +46,7 @@ entity all1_wb is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -67,7 +67,7 @@ entity all1_wb is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -76,7 +76,7 @@ entity all1_wb is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -95,7 +95,7 @@ entity all1_wb is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_wb_none.vhdl
+++ b/testfiles/tb/golden_files/all1_wb_none.vhdl
@@ -11,7 +11,7 @@ entity all1_wb is
     wb_i                 : in    t_wishbone_slave_in;
     wb_o                 : out   t_wishbone_slave_out;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -33,7 +33,7 @@ entity all1_wb is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -46,7 +46,7 @@ entity all1_wb is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -67,7 +67,7 @@ entity all1_wb is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -76,7 +76,7 @@ entity all1_wb is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -95,7 +95,7 @@ entity all1_wb is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_wb_out.vhdl
+++ b/testfiles/tb/golden_files/all1_wb_out.vhdl
@@ -11,7 +11,7 @@ entity all1_wb is
     wb_i                 : in    t_wishbone_slave_in;
     wb_o                 : out   t_wishbone_slave_out;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -33,7 +33,7 @@ entity all1_wb is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -46,7 +46,7 @@ entity all1_wb is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -67,7 +67,7 @@ entity all1_wb is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -76,7 +76,7 @@ entity all1_wb is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -95,7 +95,7 @@ entity all1_wb is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_wb_rd-in,wr-out.vhdl
+++ b/testfiles/tb/golden_files/all1_wb_rd-in,wr-out.vhdl
@@ -11,7 +11,7 @@ entity all1_wb is
     wb_i                 : in    t_wishbone_slave_in;
     wb_o                 : out   t_wishbone_slave_out;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -33,7 +33,7 @@ entity all1_wb is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -46,7 +46,7 @@ entity all1_wb is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -67,7 +67,7 @@ entity all1_wb is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -76,7 +76,7 @@ entity all1_wb is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -95,7 +95,7 @@ entity all1_wb is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_wb_rd-in.vhdl
+++ b/testfiles/tb/golden_files/all1_wb_rd-in.vhdl
@@ -11,7 +11,7 @@ entity all1_wb is
     wb_i                 : in    t_wishbone_slave_in;
     wb_o                 : out   t_wishbone_slave_out;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -33,7 +33,7 @@ entity all1_wb is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -46,7 +46,7 @@ entity all1_wb is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -67,7 +67,7 @@ entity all1_wb is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -76,7 +76,7 @@ entity all1_wb is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -95,7 +95,7 @@ entity all1_wb is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_wb_rd-out.vhdl
+++ b/testfiles/tb/golden_files/all1_wb_rd-out.vhdl
@@ -11,7 +11,7 @@ entity all1_wb is
     wb_i                 : in    t_wishbone_slave_in;
     wb_o                 : out   t_wishbone_slave_out;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -33,7 +33,7 @@ entity all1_wb is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -46,7 +46,7 @@ entity all1_wb is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -67,7 +67,7 @@ entity all1_wb is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -76,7 +76,7 @@ entity all1_wb is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -95,7 +95,7 @@ entity all1_wb is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_wb_rd.vhdl
+++ b/testfiles/tb/golden_files/all1_wb_rd.vhdl
@@ -11,7 +11,7 @@ entity all1_wb is
     wb_i                 : in    t_wishbone_slave_in;
     wb_o                 : out   t_wishbone_slave_out;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -33,7 +33,7 @@ entity all1_wb is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -46,7 +46,7 @@ entity all1_wb is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -67,7 +67,7 @@ entity all1_wb is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -76,7 +76,7 @@ entity all1_wb is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -95,7 +95,7 @@ entity all1_wb is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_wb_wr-in,rd-out.vhdl
+++ b/testfiles/tb/golden_files/all1_wb_wr-in,rd-out.vhdl
@@ -11,7 +11,7 @@ entity all1_wb is
     wb_i                 : in    t_wishbone_slave_in;
     wb_o                 : out   t_wishbone_slave_out;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -33,7 +33,7 @@ entity all1_wb is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -46,7 +46,7 @@ entity all1_wb is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -67,7 +67,7 @@ entity all1_wb is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -76,7 +76,7 @@ entity all1_wb is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -95,7 +95,7 @@ entity all1_wb is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_wb_wr-in.vhdl
+++ b/testfiles/tb/golden_files/all1_wb_wr-in.vhdl
@@ -11,7 +11,7 @@ entity all1_wb is
     wb_i                 : in    t_wishbone_slave_in;
     wb_o                 : out   t_wishbone_slave_out;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -33,7 +33,7 @@ entity all1_wb is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -46,7 +46,7 @@ entity all1_wb is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -67,7 +67,7 @@ entity all1_wb is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -76,7 +76,7 @@ entity all1_wb is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -95,7 +95,7 @@ entity all1_wb is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_wb_wr-out.vhdl
+++ b/testfiles/tb/golden_files/all1_wb_wr-out.vhdl
@@ -11,7 +11,7 @@ entity all1_wb is
     wb_i                 : in    t_wishbone_slave_in;
     wb_o                 : out   t_wishbone_slave_out;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -33,7 +33,7 @@ entity all1_wb is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -46,7 +46,7 @@ entity all1_wb is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -67,7 +67,7 @@ entity all1_wb is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -76,7 +76,7 @@ entity all1_wb is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -95,7 +95,7 @@ entity all1_wb is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all1_wb_wr.vhdl
+++ b/testfiles/tb/golden_files/all1_wb_wr.vhdl
@@ -11,7 +11,7 @@ entity all1_wb is
     wb_i                 : in    t_wishbone_slave_in;
     wb_o                 : out   t_wishbone_slave_out;
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2
@@ -33,7 +33,7 @@ entity all1_wb is
     ram2_data_o          : out   std_logic_vector(31 downto 0);
     ram2_wr_o            : out   std_logic;
 
-    -- A WB bus
+    -- WB bus sub1_wb
     sub1_wb_cyc_o        : out   std_logic;
     sub1_wb_stb_o        : out   std_logic;
     sub1_wb_adr_o        : out   std_logic_vector(11 downto 2);
@@ -46,7 +46,7 @@ entity all1_wb is
     sub1_wb_stall_i      : in    std_logic;
     sub1_wb_dat_i        : in    std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(11 downto 2);
@@ -67,7 +67,7 @@ entity all1_wb is
     sub2_axi4_rdata_i    : in    std_logic_vector(31 downto 0);
     sub2_axi4_rresp_i    : in    std_logic_vector(1 downto 0);
 
-    -- A CERN-BE bus
+    -- cern-be-vme bus sub3_cernbe
     sub3_cernbe_VMEAddr_o : out   std_logic_vector(11 downto 2);
     sub3_cernbe_VMERdData_i : in    std_logic_vector(31 downto 0);
     sub3_cernbe_VMEWrData_o : out   std_logic_vector(31 downto 0);
@@ -76,7 +76,7 @@ entity all1_wb is
     sub3_cernbe_VMERdDone_i : in    std_logic;
     sub3_cernbe_VMEWrDone_i : in    std_logic;
 
-    -- An AVALON bus
+    -- Avalon bus sub4_avalon
     sub4_avalon_address_o : out   std_logic_vector(11 downto 2);
     sub4_avalon_readdata_i : in    std_logic_vector(31 downto 0);
     sub4_avalon_writedata_o : out   std_logic_vector(31 downto 0);
@@ -95,7 +95,7 @@ entity all1_wb is
     sub5_apb_prdata_i    : in    std_logic_vector(31 downto 0);
     sub5_apb_pslverr_i   : in    std_logic;
 
-    -- A simple bus
+    -- simple bus sub6_simple
     sub6_simple_adr_o    : out   std_logic_vector(11 downto 2);
     sub6_simple_dato_i   : in    std_logic_vector(31 downto 0);
     sub6_simple_dati_o   : out   std_logic_vector(31 downto 0);

--- a/testfiles/tb/golden_files/all2_axi4.vhdl
+++ b/testfiles/tb/golden_files/all2_axi4.vhdl
@@ -26,10 +26,10 @@ entity all2_axi4 is
     rdata                : out   std_logic_vector(31 downto 0);
     rresp                : out   std_logic_vector(1 downto 0);
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
-    -- An AXI4-Lite bus
+    -- AXI-4 lite bus sub2_axi4
     sub2_axi4_awvalid_o  : out   std_logic;
     sub2_axi4_awready_i  : in    std_logic;
     sub2_axi4_awaddr_o   : out   std_logic_vector(5 downto 2);

--- a/testfiles/tb/golden_files/sub2_axi4.vhdl
+++ b/testfiles/tb/golden_files/sub2_axi4.vhdl
@@ -27,7 +27,7 @@ entity sub2_axi4 is
     rdata                : out   std_logic_vector(31 downto 0);
     rresp                : out   std_logic_vector(1 downto 0);
 
-    -- A register
+    -- REG reg1
     reg1_o               : out   std_logic_vector(31 downto 0);
 
     -- REG reg2


### PR DESCRIPTION
cheby support to fields to provide context and documentation to the registers:
- `description`
- `comment`

Currently both fields are used almost intertwined, whereby one is used as fallback for the other (if empty) or both are concatenated together. Based on the documentation, it seems that
- `description` is intended for the generation of **documentation**, and
- `comment` is intended for providing context in the **code**.

Since we use both fields (and as intended by the documentation), the concatenation of the two fields in the documentation generation leads to unwanted results.

This PR removes any fallback option between the two as well as the concatenation. Any `comment` is only used in generated code while any `description` is only used for documentation.