### PR TITLE
Remove empty comments from code

### DIFF
--- a/proto/cheby/gen_c.py
+++ b/proto/cheby/gen_c.py
@@ -104,13 +104,17 @@ def cprint_children(cp, n, size, off):
 
 
 def comment(n):
-    return n.comment or "(comment missing)"
+    if n.comment:
+        return " {}".format(n.comment)
+    else:
+        return ""
 
 
 @CPrinter.register(tree.Reg)
 def cprint_reg(cp, n):
-    cp.cp_txt('/* [0x{:x}]: REG ({}) {} */'.format(
-        n.c_address, n.access, comment(n)))
+    cp.cp_txt(
+        "/* [0x{:x}]: REG ({}){} */".format(n.c_address, n.access, comment(n))
+    )
     if n.c_type == 'signed':
         typ = cp.stypes[n.c_size]
     elif n.c_type == 'float':
@@ -126,7 +130,7 @@ def cprint_reg(cp, n):
 
 @CPrinter.register(tree.Block)
 def cprint_block(cp, n):
-    cp.cp_txt('/* [0x{:x}]: BLOCK {} */'.format(n.c_address, comment(n)))
+    cp.cp_txt("/* [0x{:x}]: BLOCK{} */".format(n.c_address, comment(n)))
     if n.hdl_blk_prefix:
         cp.start_struct(n)
     cprint_children(cp, n, n.c_size, n.c_address)
@@ -136,7 +140,7 @@ def cprint_block(cp, n):
 
 @CPrinter.register(tree.Memory)
 def cprint_memory(cp, n):
-    cp.cp_txt('/* [0x{:x}]: MEMORY {} */'.format(n.c_address, comment(n)))
+    cp.cp_txt("/* [0x{:x}]: MEMORY{} */".format(n.c_address, comment(n)))
     cp.start_struct(n)
     cprint_children(cp, n, n.c_elsize, 0)
     cp.end_struct('{}[{}]'.format(n.name, n.memsize_val // n.c_elsize))
@@ -144,7 +148,7 @@ def cprint_memory(cp, n):
 
 @CPrinter.register(tree.Repeat)
 def cprint_repeat(cp, n):
-    cp.cp_txt('/* [0x{:x}]: REPEAT {} */'.format(n.c_address, comment(n)))
+    cp.cp_txt("/* [0x{:x}]: REPEAT{} */".format(n.c_address, comment(n)))
     cp.start_struct(n)
     cprint_children(cp, n, n.c_elsize, 0)
     cp.end_struct('{}[{}]'.format(n.name, n.count))
@@ -152,7 +156,7 @@ def cprint_repeat(cp, n):
 
 @CPrinter.register(tree.Submap)
 def cprint_submap(cp, n):
-    cp.cp_txt('/* [0x{:x}]: SUBMAP {} */'.format(n.c_address, comment(n)))
+    cp.cp_txt("/* [0x{:x}]: SUBMAP{} */".format(n.c_address, comment(n)))
     if n.filename is None:
         # Should depend on bus size ?
         if n.c_size % 4 == 0:

--- a/proto/cheby/print_consts.py
+++ b/proto/cheby/print_consts.py
@@ -258,7 +258,7 @@ class ConstsPrinterC(ConstsPrinterH):
 
     def pr_address(self, n):
         self.pr_raw("\n")
-        self.pr_raw("/* {} */\n".format(n.comment or "(comment missing)"))
+        self.pr_raw("/* {} */\n".format(n.comment or "REG {}".format(n.name)))
         self.pr_hex_const(self.pr_name(n), n.c_abs_addr)
 
     def pr_field(self, f):

--- a/testfiles/bug-gen-c-02/fip_urv_regs.h
+++ b/testfiles/bug-gen-c-02/fip_urv_regs.h
@@ -7,14 +7,14 @@
 #include "mbox_regs.h"
 #define FIP_URV_REGS_SIZE 16384 /* 0x4000 = 16KB */
 
-/* (comment missing) */
+/* REG plc_ctrl */
 #define FIP_URV_REGS_PLC_CTRL 0x0UL
 #define FIP_URV_REGS_PLC_CTRL_RSTN 0x1UL
 #define FIP_URV_REGS_PLC_CTRL_RSTN_MASK 0x1UL
 #define FIP_URV_REGS_PLC_CTRL_RSTN_SHIFT 0
 #define FIP_URV_REGS_PLC_CTRL_RSTN_PRESET 0x0UL
 
-/* (comment missing) */
+/* REG fip_status */
 #define FIP_URV_REGS_FIP_STATUS 0x4UL
 #define FIP_URV_REGS_FIP_STATUS_VAR1_RDY 0x1UL
 #define FIP_URV_REGS_FIP_STATUS_VAR1_RDY_MASK 0x1UL
@@ -23,95 +23,95 @@
 #define FIP_URV_REGS_FIP_STATUS_VAR3_RDY_MASK 0x2UL
 #define FIP_URV_REGS_FIP_STATUS_VAR3_RDY_SHIFT 1
 
-/* (comment missing) */
+/* REG fip_var1 */
 #define FIP_URV_REGS_FIP_VAR1 0x8UL
 #define FIP_URV_REGS_FIP_VAR1_ACC 0x1UL
 #define FIP_URV_REGS_FIP_VAR1_ACC_MASK 0x1UL
 #define FIP_URV_REGS_FIP_VAR1_ACC_SHIFT 0
 
-/* (comment missing) */
+/* REG fip_var3 */
 #define FIP_URV_REGS_FIP_VAR3 0xcUL
 #define FIP_URV_REGS_FIP_VAR3_ACC 0x1UL
 #define FIP_URV_REGS_FIP_VAR3_ACC_MASK 0x1UL
 #define FIP_URV_REGS_FIP_VAR3_ACC_SHIFT 0
 
-/* (comment missing) */
+/* REG mailboxes */
 #define FIP_URV_REGS_MAILBOXES 0x10UL
 #define ADDR_MASK_FIP_URV_REGS_MAILBOXES 0x3ff0UL
 #define FIP_URV_REGS_MAILBOXES_SIZE 16 /* 0x10 */
 
-/* (comment missing) */
+/* REG presence */
 #define FIP_URV_REGS_PRESENCE 0x20UL
 #define FIP_URV_REGS_PRESENCE_EN_MASK 0xffUL
 #define FIP_URV_REGS_PRESENCE_EN_SHIFT 0
 
-/* (comment missing) */
+/* REG leds */
 #define FIP_URV_REGS_LEDS 0x24UL
 #define FIP_URV_REGS_LEDS_VAL_MASK 0x3fUL
 #define FIP_URV_REGS_LEDS_VAL_SHIFT 0
 
-/* (comment missing) */
+/* REG boards */
 #define FIP_URV_REGS_BOARDS 0x40UL
 #define FIP_URV_REGS_BOARDS_SIZE 4 /* 0x4 */
 
-/* (comment missing) */
+/* REG pins */
 #define FIP_URV_REGS_BOARDS_PINS 0x0UL
 
-/* (comment missing) */
+/* REG fip_reg */
 #define FIP_URV_REGS_FIP_REG 0x800UL
 #define ADDR_MASK_FIP_URV_REGS_FIP_REG 0x3800UL
 #define FIP_URV_REGS_FIP_REG_SIZE 2048 /* 0x800 = 2KB */
 
-/* (comment missing) */
+/* REG plc_mem */
 #define FIP_URV_REGS_PLC_MEM 0x2000UL
 #define ADDR_MASK_FIP_URV_REGS_PLC_MEM 0x2000UL
 #define FIP_URV_REGS_PLC_MEM_SIZE 8192 /* 0x2000 = 8KB */
 
 #ifndef __ASSEMBLER__
 struct fip_urv_regs {
-  /* [0x0]: REG (rw) (comment missing) */
+  /* [0x0]: REG (rw) */
   uint32_t plc_ctrl;
 
-  /* [0x4]: REG (ro) (comment missing) */
+  /* [0x4]: REG (ro) */
   uint32_t fip_status;
 
-  /* [0x8]: REG (rw) (comment missing) */
+  /* [0x8]: REG (rw) */
   uint32_t fip_var1;
 
-  /* [0xc]: REG (rw) (comment missing) */
+  /* [0xc]: REG (rw) */
   uint32_t fip_var3;
 
-  /* [0x10]: SUBMAP (comment missing) */
+  /* [0x10]: SUBMAP */
   struct mbox_regs mailboxes;
 
   /* padding to: 32 Bytes */
   uint32_t __padding_0[1];
 
-  /* [0x20]: REG (ro) (comment missing) */
+  /* [0x20]: REG (ro) */
   uint32_t presence;
 
-  /* [0x24]: REG (rw) (comment missing) */
+  /* [0x24]: REG (rw) */
   uint32_t leds;
 
   /* padding to: 64 Bytes */
   uint32_t __padding_1[6];
 
-  /* [0x40]: REPEAT (comment missing) */
+  /* [0x40]: REPEAT */
   struct boards {
-    /* [0x0]: REG (ro) (comment missing) */
+    /* [0x0]: REG (ro) */
     uint32_t pins;
   } boards[8];
 
   /* padding to: 2048 Bytes */
   uint32_t __padding_2[488];
 
-  /* [0x800]: SUBMAP (comment missing) */
+  /* [0x800]: SUBMAP */
   uint32_t fip_reg[512];
 
   /* padding to: 8192 Bytes */
   uint32_t __padding_3[1024];
 
-  /* [0x2000]: SUBMAP (comment missing) */
+  /* [0x2000]: SUBMAP */
   uint32_t plc_mem[2048];
 };
 #endif /* !__ASSEMBLER__*/

--- a/testfiles/bug-gen-c-02/mbox_regs.h
+++ b/testfiles/bug-gen-c-02/mbox_regs.h
@@ -5,13 +5,13 @@
 
 #define MBOX_REGS_SIZE 12 /* 0xc */
 
-/* (comment missing) */
+/* REG mboxout */
 #define MBOX_REGS_MBOXOUT 0x0UL
 
-/* (comment missing) */
+/* REG mboxin */
 #define MBOX_REGS_MBOXIN 0x4UL
 
-/* (comment missing) */
+/* REG status */
 #define MBOX_REGS_STATUS 0x8UL
 #define MBOX_REGS_STATUS_MBIN 0x1UL
 #define MBOX_REGS_STATUS_MBIN_MASK 0x1UL
@@ -22,13 +22,13 @@
 
 #ifndef __ASSEMBLER__
 struct mbox_regs {
-  /* [0x0]: REG (wo) (comment missing) */
+  /* [0x0]: REG (wo) */
   uint32_t mboxout;
 
-  /* [0x4]: REG (ro) (comment missing) */
+  /* [0x4]: REG (ro) */
   uint32_t mboxin;
 
-  /* [0x8]: REG (ro) (comment missing) */
+  /* [0x8]: REG (ro) */
   uint32_t status;
 };
 #endif /* !__ASSEMBLER__*/

--- a/testfiles/bug-same-label/same_label.h
+++ b/testfiles/bug-same-label/same_label.h
@@ -5,21 +5,21 @@
 
 #define SAME_LABEL_REG_SIZE 16 /* 0x10 */
 
-/* (comment missing) */
+/* REG no_fields */
 #define SAME_LABEL_REG_NO_FIELDS 0x0UL
 #define SAME_LABEL_REG_NO_FIELDS_PRESET 0x20UL
 
-/* (comment missing) */
+/* REG same_name */
 #define SAME_LABEL_REG_SAME_NAME 0x4UL
 #define SAME_LABEL_REG_SAME_NAME_MASK 0x1UL
 #define SAME_LABEL_REG_SAME_NAME_SHIFT 0
 
-/* (comment missing) */
+/* REG same_name_multi */
 #define SAME_LABEL_REG_SAME_NAME_MULTI 0x8UL
 #define SAME_LABEL_REG_SAME_NAME_MULTI_MASK 0xfffUL
 #define SAME_LABEL_REG_SAME_NAME_MULTI_SHIFT 0
 
-/* (comment missing) */
+/* REG not_same_reg */
 #define SAME_LABEL_REG_NOT_SAME_REG 0xcUL
 #define SAME_LABEL_REG_NOT_SAME 0x1UL
 #define SAME_LABEL_REG_NOT_SAME_MASK 0x1UL
@@ -27,19 +27,19 @@
 
 #ifndef __ASSEMBLER__
 struct same_label_reg {
-  /* [0x0]: REG (ro) (comment missing) */
+  /* [0x0]: REG (ro) */
   uint8_t no_fields;
 
   /* padding to: 4 Bytes */
   uint8_t __padding_0[3];
 
-  /* [0x4]: REG (ro) (comment missing) */
+  /* [0x4]: REG (ro) */
   uint32_t same_name;
 
-  /* [0x8]: REG (ro) (comment missing) */
+  /* [0x8]: REG (ro) */
   uint32_t same_name_multi;
 
-  /* [0xc]: REG (ro) (comment missing) */
+  /* [0xc]: REG (ro) */
   uint32_t not_same_reg;
 };
 #endif /* !__ASSEMBLER__*/

--- a/testfiles/features/blkprefix3.h
+++ b/testfiles/features/blkprefix3.h
@@ -5,11 +5,11 @@
 
 #define BLKPREFIX3_SIZE 12 /* 0xc */
 
-/* (comment missing) */
+/* REG b1 */
 #define BLKPREFIX3_B1 0x0UL
 #define BLKPREFIX3_B1_SIZE 8 /* 0x8 */
 
-/* (comment missing) */
+/* REG r2 */
 #define BLKPREFIX3_B1_R2 0x0UL
 #define BLKPREFIX3_B1_R2_F1_MASK 0x7UL
 #define BLKPREFIX3_B1_R2_F1_SHIFT 0
@@ -17,7 +17,7 @@
 #define BLKPREFIX3_B1_R2_F2_MASK 0x10UL
 #define BLKPREFIX3_B1_R2_F2_SHIFT 4
 
-/* (comment missing) */
+/* REG r3 */
 #define BLKPREFIX3_B1_R3 0x4UL
 #define BLKPREFIX3_B1_R3_F1_MASK 0x7UL
 #define BLKPREFIX3_B1_R3_F1_SHIFT 0
@@ -25,28 +25,28 @@
 #define BLKPREFIX3_B1_R3_F2_MASK 0x10UL
 #define BLKPREFIX3_B1_R3_F2_SHIFT 4
 
-/* (comment missing) */
+/* REG b2 */
 #define BLKPREFIX3_B2 0x8UL
 #define BLKPREFIX3_B2_SIZE 4 /* 0x4 */
 
-/* (comment missing) */
+/* REG r3 */
 #define BLKPREFIX3_B2_R3 0x8UL
 #define BLKPREFIX3_B2_R3_F1_MASK 0x7UL
 #define BLKPREFIX3_B2_R3_F1_SHIFT 0
 
 #ifndef __ASSEMBLER__
 struct blkprefix3 {
-  /* [0x0]: BLOCK (comment missing) */
-  /* [0x0]: REG (rw) (comment missing) */
+  /* [0x0]: BLOCK */
+  /* [0x0]: REG (rw) */
   uint32_t r2;
 
-  /* [0x4]: BLOCK (comment missing) */
-  /* [0x0]: REG (rw) (comment missing) */
+  /* [0x4]: BLOCK */
+  /* [0x0]: REG (rw) */
   uint32_t r3;
 
-  /* [0x8]: BLOCK (comment missing) */
+  /* [0x8]: BLOCK */
   struct b2 {
-    /* [0x0]: REG (rw) (comment missing) */
+    /* [0x0]: REG (rw) */
     uint32_t r3;
   } b2;
 };

--- a/testfiles/features/blkprefix5.h
+++ b/testfiles/features/blkprefix5.h
@@ -5,11 +5,11 @@
 
 #define BLKPREFIX3_SIZE 48 /* 0x30 */
 
-/* (comment missing) */
+/* REG b1 */
 #define BLKPREFIX3_B1 0x0UL
 #define BLKPREFIX3_B1_SIZE 32 /* 0x20 */
 
-/* (comment missing) */
+/* REG r1 */
 #define BLKPREFIX3_B1_R1 0x0UL
 #define BLKPREFIX3_B1_R1_F1_MASK 0x7UL
 #define BLKPREFIX3_B1_R1_F1_SHIFT 0
@@ -17,10 +17,10 @@
 #define BLKPREFIX3_B1_R1_F2_MASK 0x10UL
 #define BLKPREFIX3_B1_R1_F2_SHIFT 4
 
-/* (comment missing) */
+/* REG r2 */
 #define BLKPREFIX3_B1_R2 0x8UL
 
-/* (comment missing) */
+/* REG r3 */
 #define BLKPREFIX3_B1_R3 0x10UL
 #define BLKPREFIX3_B1_R3_F1_MASK 0x7UL
 #define BLKPREFIX3_B1_R3_F1_SHIFT 0
@@ -28,52 +28,52 @@
 #define BLKPREFIX3_B1_R3_F2_MASK 0x10UL
 #define BLKPREFIX3_B1_R3_F2_SHIFT 4
 
-/* (comment missing) */
+/* REG r4 */
 #define BLKPREFIX3_B1_R4 0x18UL
 
-/* (comment missing) */
+/* REG b2 */
 #define BLKPREFIX3_B2 0x20UL
 #define BLKPREFIX3_B2_SIZE 16 /* 0x10 */
 
-/* (comment missing) */
+/* REG r1 */
 #define BLKPREFIX3_B2_R1 0x20UL
 #define BLKPREFIX3_B2_R1_F1_MASK 0x7UL
 #define BLKPREFIX3_B2_R1_F1_SHIFT 0
 
-/* (comment missing) */
+/* REG r2 */
 #define BLKPREFIX3_B2_R2 0x28UL
 
 #ifndef __ASSEMBLER__
 struct blkprefix3 {
-  /* [0x0]: BLOCK (comment missing) */
-  /* [0x0]: REG (rw) (comment missing) */
+  /* [0x0]: BLOCK */
+  /* [0x0]: REG (rw) */
   uint32_t r1;
 
   /* padding to: 8 Bytes */
   uint32_t __padding_0[1];
 
-  /* [0x8]: REG (rw) (comment missing) */
+  /* [0x8]: REG (rw) */
   uint64_t r2;
 
-  /* [0x10]: BLOCK (comment missing) */
-  /* [0x0]: REG (rw) (comment missing) */
+  /* [0x10]: BLOCK */
+  /* [0x0]: REG (rw) */
   uint32_t r3;
 
   /* padding to: 8 Bytes */
   uint32_t __padding_1[1];
 
-  /* [0x8]: REG (rw) (comment missing) */
+  /* [0x8]: REG (rw) */
   uint64_t r4;
 
-  /* [0x20]: BLOCK (comment missing) */
+  /* [0x20]: BLOCK */
   struct b2 {
-    /* [0x0]: REG (rw) (comment missing) */
+    /* [0x0]: REG (rw) */
     uint32_t r1;
 
     /* padding to: 8 Bytes */
     uint32_t __padding_0[1];
 
-    /* [0x8]: REG (rw) (comment missing) */
+    /* [0x8]: REG (rw) */
     uint64_t r2;
   } b2;
 };

--- a/testfiles/issue103/top.h
+++ b/testfiles/issue103/top.h
@@ -9,30 +9,30 @@
 #include "sub3.h"
 #define TOP_SIZE 12 /* 0xc */
 
-/* (comment missing) */
+/* REG sub1 */
 #define TOP_SUB1 0x0UL
 #define ADDR_MASK_TOP_SUB1 0xcUL
 #define TOP_SUB1_SIZE 4 /* 0x4 */
 
-/* (comment missing) */
+/* REG sub2 */
 #define TOP_SUB2 0x4UL
 #define ADDR_MASK_TOP_SUB2 0xcUL
 #define TOP_SUB2_SIZE 4 /* 0x4 */
 
-/* (comment missing) */
+/* REG sub3 */
 #define TOP_SUB3 0x8UL
 #define ADDR_MASK_TOP_SUB3 0xcUL
 #define TOP_SUB3_SIZE 4 /* 0x4 */
 
 #ifndef __ASSEMBLER__
 struct top {
-  /* [0x0]: SUBMAP (comment missing) */
+  /* [0x0]: SUBMAP */
   struct sub1 sub1;
 
-  /* [0x4]: SUBMAP (comment missing) */
+  /* [0x4]: SUBMAP */
   struct sub2 sub2;
 
-  /* [0x8]: SUBMAP (comment missing) */
+  /* [0x8]: SUBMAP */
   struct sub3 sub3;
 };
 #endif /* !__ASSEMBLER__*/

--- a/testfiles/issue67/repeatInRepeat.h
+++ b/testfiles/issue67/repeatInRepeat.h
@@ -5,30 +5,30 @@
 
 #define REPEATINREPEAT_SIZE 32 /* 0x20 */
 
-/* (comment missing) */
+/* REG repA */
 #define REPEATINREPEAT_REPA 0x0UL
 #define REPEATINREPEAT_REPA_SIZE 8 /* 0x8 */
 
-/* (comment missing) */
+/* REG block1 */
 #define REPEATINREPEAT_REPA_BLOCK1 0x0UL
 #define REPEATINREPEAT_REPA_BLOCK1_SIZE 8 /* 0x8 */
 
-/* (comment missing) */
+/* REG repB */
 #define REPEATINREPEAT_REPA_BLOCK1_REPB 0x0UL
 #define REPEATINREPEAT_REPA_BLOCK1_REPB_SIZE 4 /* 0x4 */
 
-/* (comment missing) */
+/* REG reg1 */
 #define REPEATINREPEAT_REPA_BLOCK1_REPB_REG1 0x0UL
 
 #ifndef __ASSEMBLER__
 struct repeatInRepeat {
-  /* [0x0]: REPEAT (comment missing) */
+  /* [0x0]: REPEAT */
   struct repA {
-    /* [0x0]: BLOCK (comment missing) */
+    /* [0x0]: BLOCK */
     struct repA_block1 {
-      /* [0x0]: REPEAT (comment missing) */
+      /* [0x0]: REPEAT */
       struct repA_block1_repB {
-        /* [0x0]: REG (rw) (comment missing) */
+        /* [0x0]: REG (rw) */
         uint8_t reg1;
 
         /* padding to: 4 Bytes */

--- a/testfiles/issue67/repeatInRepeatC.h
+++ b/testfiles/issue67/repeatInRepeatC.h
@@ -5,30 +5,30 @@
 
 #define REPEATINREPEATC_SIZE 32 /* 0x20 */
 
-/* (comment missing) */
+/* REG repA */
 #define REPEATINREPEATC_REPA 0x0UL
 #define REPEATINREPEATC_REPA_SIZE 8 /* 0x8 */
 
-/* (comment missing) */
+/* REG block1 */
 #define REPEATINREPEATC_REPA_BLOCK1 0x0UL
 #define REPEATINREPEATC_REPA_BLOCK1_SIZE 8 /* 0x8 */
 
-/* (comment missing) */
+/* REG repB */
 #define REPEATINREPEATC_REPA_BLOCK1_REPB 0x0UL
 #define REPEATINREPEATC_REPA_BLOCK1_REPB_SIZE 4 /* 0x4 */
 
-/* (comment missing) */
+/* REG reg1 */
 #define REPEATINREPEATC_REPA_BLOCK1_REPB_REG1 0x0UL
 
 #ifndef __ASSEMBLER__
 struct repeatInRepeatC {
-  /* [0x0]: REPEAT (comment missing) */
+  /* [0x0]: REPEAT */
   struct repeatInRepeatC_repA {
-    /* [0x0]: BLOCK (comment missing) */
+    /* [0x0]: BLOCK */
     struct repeatInRepeatC_repA_block1 {
-      /* [0x0]: REPEAT (comment missing) */
+      /* [0x0]: REPEAT */
       struct repeatInRepeatC_repA_block1_repB {
-        /* [0x0]: REG (rw) (comment missing) */
+        /* [0x0]: REG (rw) */
         uint8_t reg1;
 
         /* padding to: 4 Bytes */


### PR DESCRIPTION
With the changes from #61, descriptions were removed from being printed in the code. If the field contains no comment, the string `(missing comment)` gets printed. Having very little comments in our cheby maps, we have now the `(missing comment)` all over without adding much information to the code.

This pull request improves #61 by printing the name of the field if no comment is present or skipping to print anything altogether. See the regenerated testfiles for a comparison.