### PR TITLE
Smaller fixes

### DIFF
--- a/proto/cheby/hdl/axi4litebus.py
+++ b/proto/cheby/hdl/axi4litebus.py
@@ -18,11 +18,10 @@ from cheby.hdltree import (
     HDLParen,
     HDLPackage,
     HDLInterface,
-    HDLInterfaceSelect
+    HDLInterfaceSelect,
 )
 from cheby.hdl.busgen import BusGen
 import cheby.tree as tree
-import cheby.parser as parser
 from cheby.hdl.globals import gconfig, dirname, libname
 from cheby.hdl.ibus import add_bus
 from cheby.hdl.busparams import BusOptions

--- a/proto/cheby/hdl/axi4litebus.py
+++ b/proto/cheby/hdl/axi4litebus.py
@@ -26,6 +26,7 @@ import cheby.parser as parser
 from cheby.hdl.globals import gconfig, dirname, libname
 from cheby.hdl.ibus import add_bus
 from cheby.hdl.busparams import BusOptions
+from typing import List, Tuple
 
 # AXI Lite response codes (BRESP, RRESP)
 RESP_OKAY = HDLBinConst(0, 2)
@@ -44,7 +45,7 @@ class AXI4LiteBus(BusGen):
     def gen_axi4lite_bus(self, module, ports, name, build_port,
                          addr_bits, lo_addr, data_bits, comment,
                          is_master=False, is_group=False, libname = libname) -> \
-                         list[tuple[str, HDLNode]]:
+                         List[Tuple[str, HDLNode]]:
         if is_group:
             if AXI4LiteBus.axi4l_pkg is None:
                 self.gen_axi4l_pkg(module, ports, name, comment, data_bits)

--- a/proto/cheby/hdl/wbbus.py
+++ b/proto/cheby/hdl/wbbus.py
@@ -10,6 +10,7 @@ from cheby.hdl.busgen import BusGen
 import cheby.tree as tree
 from cheby.hdl.globals import gconfig, dirname, libname
 from cheby.hdl.busparams import BusOptions
+from typing import Dict
 
 class WBBus(BusGen):
     # Package wishbone_pkg that contains the wishbone interface
@@ -133,7 +134,7 @@ class WBBus(BusGen):
 
 
     def gen_wishbone_bus(self, build_port, addr_bits, lo_addr,
-                         data_bits, is_master) -> dict[str, HDLNode]:
+                         data_bits, is_master) -> Dict[str, HDLNode]:
         # FIXME: 'dat' is used both as an input and as an output.
         #  This is not a problem in general as a suffix is appended,
         #  except for system verilog interfaces...
@@ -161,7 +162,7 @@ class WBBus(BusGen):
         return res
 
     def gen_wishbone(self, module, ports, name, addr_bits, lo_addr,
-                     data_bits, comment, is_master, is_group, libname = libname) -> dict[str, HDLPort]:
+                     data_bits, comment, is_master, is_group, libname = libname) -> Dict[str, HDLPort]:
         if is_group:
             if WBBus.wb_pkg is None:
                 self.gen_wishbone_pkg()

--- a/proto/cheby/hdl/wbbus.py
+++ b/proto/cheby/hdl/wbbus.py
@@ -1,11 +1,24 @@
-from cheby.hdltree import (HDLPackage,
-                           HDLInterface, HDLInterfaceSelect,
-                           HDLAssign, HDLSync, HDLComb, HDLComment,
-                           HDLIfElse,
-                           bit_1, bit_0,
-                           HDLAnd, HDLOr, HDLNot, HDLEq, HDLConcat,
-                           HDLSlice, HDLReplicate,
-                           HDLParen, HDLPort, HDLNode)
+from cheby.hdltree import (
+    HDLPackage,
+    HDLInterface,
+    HDLInterfaceSelect,
+    HDLAssign,
+    HDLSync,
+    HDLComb,
+    HDLComment,
+    HDLIfElse,
+    bit_1,
+    bit_0,
+    HDLAnd,
+    HDLOr,
+    HDLNot,
+    HDLEq,
+    HDLSlice,
+    HDLReplicate,
+    HDLParen,
+    HDLPort,
+    HDLNode,
+)
 from cheby.hdl.busgen import BusGen
 import cheby.tree as tree
 from cheby.hdl.globals import gconfig, dirname, libname

--- a/testfiles/issue143/map-consts.sv
+++ b/testfiles/issue143/map-consts.sv
@@ -1,4 +1,4 @@
-package top_Consts;
+package pkg_top_consts;
   localparam TOP_SIZE = 32;
   localparam ADDR_TOP_ARRAY_OF_SUBMAPS = 'h0;
   localparam ADDR_MASK_TOP_ARRAY_OF_SUBMAPS = 'h0;

--- a/testfiles/issue143/map-consts.vhdl
+++ b/testfiles/issue143/map-consts.vhdl
@@ -1,7 +1,7 @@
 library ieee;
 use ieee.std_logic_1164.all;
 
-package top_Consts is
+package pkg_top_consts is
   constant TOP_SIZE : Natural := 32;
   constant ADDR_TOP_ARRAY_OF_SUBMAPS : Natural := 16#0#;
   constant ADDR_MASK_TOP_ARRAY_OF_SUBMAPS : Natural := 16#0#;
@@ -47,4 +47,4 @@ package top_Consts is
   constant ADDR_MASK_TOP_ARRAY_OF_SUBMAPS_4_SUBMAP : Natural := 16#1c#;
   constant ADDR_FMASK_TOP_ARRAY_OF_SUBMAPS_4_SUBMAP : Natural := 16#1c#;
   constant TOP_ARRAY_OF_SUBMAPS_4_SUBMAP_SIZE : Natural := 4;
-end package top_Consts;
+end package pkg_top_consts;

--- a/testfiles/mr67/top-consts.sv
+++ b/testfiles/mr67/top-consts.sv
@@ -1,4 +1,4 @@
-package fid_top_axi_Consts;
+package pkg_fid_top_axi_consts;
   localparam FID_TOP_AXI_MEMMAP_VERSION = 'h100;
   localparam ADDR_FID_TOP_AXI_IP = 'h0;
   localparam ADDR_MASK_FID_TOP_AXI_IP = 'h0;

--- a/testfiles/mr67/top-consts.vhdl
+++ b/testfiles/mr67/top-consts.vhdl
@@ -1,10 +1,10 @@
 library ieee;
 use ieee.std_logic_1164.all;
 
-package fid_top_axi_Consts is
+package pkg_fid_top_axi_consts is
   constant FID_TOP_AXI_MEMMAP_VERSION : Natural := 16#100#;
   constant ADDR_FID_TOP_AXI_IP : Natural := 16#0#;
   constant ADDR_MASK_FID_TOP_AXI_IP : Natural := 16#0#;
   constant ADDR_FMASK_FID_TOP_AXI_IP : Natural := 16#0#;
   constant FID_TOP_AXI_IP_SIZE : Natural := 4;
-end package fid_top_axi_Consts;
+end package pkg_fid_top_axi_consts;


### PR DESCRIPTION
- Add correct typing constraints for older Python versions
   * (`Dict` from `typing` package instead of `dict` to support Python < 3.9)
- Remove unused package imports in code
- Fix some VHDL packaging names (to match with the generated version)