### PR TITLE
Match Markdown to LaTeX documentation

### DIFF
--- a/proto/cheby/main.py
+++ b/proto/cheby/main.py
@@ -160,7 +160,7 @@ def decode_args():
                          help='specify address space for --gen-hdl')
     aparser.add_argument('--out-prefix', default='',
                          help='specify path prefix for automatic output files')
-    
+
     aparser.add_argument('--wb-lib-name',
                          default = cheby.hdl.globals.libname,
                         help = 'Specify name of VHDL library where wishbone_pkg is compiled')
@@ -306,7 +306,9 @@ def handle_file(args, filename):
                     f, t, args.doc_hide_comments, args.doc_include_js_dep
                 )
             elif args.doc == "md":
-                print_markdown.print_markdown(f, t, args.doc_hide_comments)
+                print_markdown.print_markdown(
+                    f, t, args.doc_hide_comments, not args.doc_no_reg_drawing
+                )
             elif args.doc == "rest":
                 print_rest.print_rest(f, t, args.doc_hide_comments, args.rest_headers)
             elif args.doc == "latex":

--- a/proto/cheby/print_markdown.py
+++ b/proto/cheby/print_markdown.py
@@ -1,6 +1,6 @@
 import cheby.tree as tree
 import cheby.gen_doc as gen_doc
-from cheby.wrutils import wln
+from cheby.wrutils import w, wln
 
 #  Generate markdown (asciidoc variant)
 #  Ref: https://asciidoctor.org/docs/asciidoc-syntax-quick-reference/#tables
@@ -10,9 +10,22 @@ def format_text(text):
     return text.replace("\n", " +\n")
 
 
-def print_reg(fd, r, name, abs_addr, hide_comments=False):
+def print_reg(fd, r, raw, hide_comments=False, print_reg_drawing=True):
+    ACCESSES = {
+        "rw": "read/write",
+        "wo": "write-only",
+        "ro": "read-only",
+    }
+
     # Description of Register
-    wln(fd, "### Register: {}".format(name))
+    wln(fd, "### Register: {}".format(raw.name))
+    wln(fd)
+
+    wln(fd, "- **HW Prefix**: {}".format(r.c_name))
+    wln(fd, "- **HW Address**: 0x{:x}".format(raw.abs_addr))
+    wln(fd, "- **C Prefix**: {}".format(raw.name))
+    wln(fd, "- **C Block Offset**: 0x{:x}".format(r.c_address))
+    wln(fd, "- **Access**: {}".format(ACCESSES[r.access]))
     wln(fd)
 
     if r.description:
@@ -23,56 +36,58 @@ def print_reg(fd, r, name, abs_addr, hide_comments=False):
         wln(fd, format_text(r.comment))
         wln(fd)
 
-    wln(fd, "- **HDL name**: {}".format(r.c_name))
-    wln(fd, "- **Address**: 0x{:x}".format(abs_addr))
-    wln(fd, "- **Block Offset**: 0x{:x}".format(r.c_address))
-    wln(fd, "- **Access Mode**: {}".format(r.access))
+    if print_reg_drawing:
+        # Graphical representation of bit fields in register (HTML format)
+        descr = gen_doc.build_regdescr_table(r)
+        wln(fd, "<table>")
+        for desc_raw in descr:
+            wln(fd, "  <tr>")
+            for col in desc_raw:
+                if col.style == "bit":
+                    wln(fd, "    <td><b>{}</b></td>".format(col.content))
+                else:
+                    attrs = ""
+                    if col.colspan > 1:
+                        attrs = ' colspan="{}" style="text-align: center;"'.format(
+                            col.colspan
+                        )
+
+                    wln(fd, "    <td{}>{}</td>".format(attrs, col.content))
+
+            wln(fd, "  </tr>")
+
+        wln(fd, "</table>")
+        wln(fd)
+
+    # Table of Bit Fileds
+    wln(fd, "| Bits | Name | Description |")
+    wln(fd, "|------|------|------------|")
+
+    for f in r.children:
+        if r.has_fields():
+            desc_src = f
+        else:
+            desc_src = r
+
+        # Bit range
+        if f.hi is not None:
+            w(fd, '| {}:{} | '.format(f.hi, f.lo))
+        else:
+            w(fd, '| {} | '.format(f.lo))
+
+        # Name
+        w(fd, '{} | '.format(format_text(desc_src.name)))
+
+        # Description + comment
+        desc = desc_src.description or ""
+        if desc_src.comment and not hide_comments:
+            desc += "\n\n" + desc_src.comment
+
+        desc = desc.replace('\n', '<br>')
+
+        wln(fd, '{} |'.format(desc))
 
     wln(fd)
-
-    # Table of Bit Fields (HTML format)
-    descr = gen_doc.build_regdescr_table(r)
-    wln(fd, "<table>")
-    for desc_raw in descr:
-        wln(fd, "  <tr>")
-        for col in desc_raw:
-            if col.style == "bit":
-                wln(fd, "    <td><b>{}</b></td>".format(col.content))
-            else:
-                attrs = ""
-                if col.colspan > 1:
-                    attrs = ' colspan="{}" style="text-align: center;"'.format(
-                        col.colspan
-                    )
-
-                wln(fd, "    <td{}>{}</td>".format(attrs, col.content))
-
-        wln(fd, "  </tr>")
-
-    wln(fd, "</table>")
-    wln(fd)
-
-    # Description of Bit Fields (HTML format)
-    if r.has_fields():
-        for f in r.children:
-            wln(fd, "#### Bit: {}".format(f.name))
-            wln(fd)
-
-            not_documented = True
-
-            if f.description:
-                wln(fd, format_text(f.description))
-                wln(fd)
-                not_documented = False
-
-            if f.comment and not hide_comments:
-                wln(fd, format_text(f.comment))
-                wln(fd)
-                not_documented = False
-
-            if not_documented:
-                wln(fd, "_(not documented)_")
-                wln(fd)
 
 
 def print_map_summary(fd, summary):
@@ -83,14 +98,14 @@ def print_map_summary(fd, summary):
     wln(fd)
 
 
-def print_reg_description(fd, summary, hide_comments=False):
+def print_reg_description(fd, summary, hide_comments=False, print_reg_drawing=True):
     for ra in summary.raws:
         r = ra.node
         if isinstance(r, tree.Reg):
-            print_reg(fd, r, ra.name, ra.abs_addr, hide_comments)
+            print_reg(fd, r, ra, hide_comments, print_reg_drawing)
 
 
-def print_root(fd, root, hide_comments=False):
+def print_root(fd, root, hide_comments=False, print_reg_drawing=True):
     wln(fd, "## Memory Map Summary")
 
     if root.description:
@@ -106,7 +121,7 @@ def print_root(fd, root, hide_comments=False):
         print_map_summary(fd, summary)
 
         wln(fd, "## Registers Description")
-        print_reg_description(fd, summary, hide_comments)
+        print_reg_description(fd, summary, hide_comments, print_reg_drawing)
 
     else:
         summaries = [(gen_doc.MemmapSummary(space), space) for space in root.children]
@@ -116,11 +131,11 @@ def print_root(fd, root, hide_comments=False):
 
         for summary, space in summaries:
             wln(fd, "## Registers Description for Space {}\n".format(space.name))
-            print_reg_description(fd, summary, hide_comments)
+            print_reg_description(fd, summary, hide_comments, print_reg_drawing)
 
 
-def print_markdown(fd, n, hide_comments=False):
+def print_markdown(fd, n, hide_comments=False, print_reg_drawing=True):
     if isinstance(n, tree.Root):
-        print_root(fd, n, hide_comments)
+        print_root(fd, n, hide_comments, print_reg_drawing)
     else:
         raise AssertionError

--- a/proto/cheby/print_markdown.py
+++ b/proto/cheby/print_markdown.py
@@ -10,68 +10,76 @@ def format_text(text):
     return text.replace("\n", " +\n")
 
 
-def print_reg(fd, r, abs_addr, hide_comments=False):
-    wln(fd, "[horizontal]")
-    wln(fd, "HDL name:: {}".format(r.c_name))
-    wln(fd, "address:: 0x{:x}".format(abs_addr))
-    wln(fd, "block offset:: 0x{:x}".format(r.c_address))
-    wln(fd, "access mode:: {}".format(r.access))
+def print_reg(fd, r, name, abs_addr, hide_comments=False):
+    # Description of Register
+    wln(fd, "### Register: {}".format(name))
+    wln(fd)
 
     if r.description:
-        wln(fd)
         wln(fd, format_text(r.description))
-
-    if r.comment:
         wln(fd)
+
+    if r.comment and not hide_comments:
         wln(fd, format_text(r.comment))
+        wln(fd)
+
+    wln(fd, "- **HDL name**: {}".format(r.c_name))
+    wln(fd, "- **Address**: 0x{:x}".format(abs_addr))
+    wln(fd, "- **Block Offset**: 0x{:x}".format(r.c_address))
+    wln(fd, "- **Access Mode**: {}".format(r.access))
 
     wln(fd)
-    descr = gen_doc.build_regdescr_table(r)
-    wln(fd, '[cols="8*^"]')
-    wln(fd, "|===")
-    for desc_raw in descr:
-        wln(fd)
-        for col in desc_raw:
-            style = ""
-            if col.colspan > 1:
-                style += "{}+".format(col.colspan)
-            if col.style == 'field':
-                style += 's'
-            wln(fd, "{}| {}".format(style, col.content))
-    wln(fd, "|===")
 
+    # Table of Bit Fields (HTML format)
+    descr = gen_doc.build_regdescr_table(r)
+    wln(fd, "<table>")
+    for desc_raw in descr:
+        wln(fd, "  <tr>")
+        for col in desc_raw:
+            if col.style == "bit":
+                wln(fd, "    <td><b>{}</b></td>".format(col.content))
+            else:
+                attrs = ""
+                if col.colspan > 1:
+                    attrs = ' colspan="{}" style="text-align: center;"'.format(
+                        col.colspan
+                    )
+
+                wln(fd, "    <td{}>{}</td>".format(attrs, col.content))
+
+        wln(fd, "  </tr>")
+
+    wln(fd, "</table>")
+    wln(fd)
+
+    # Description of Bit Fields (HTML format)
     if r.has_fields():
-        wln(fd)
         for f in r.children:
-            wln(fd, "{}::".format(f.name))
+            wln(fd, "#### Bit: {}".format(f.name))
+            wln(fd)
 
             not_documented = True
+
             if f.description:
                 wln(fd, format_text(f.description))
+                wln(fd)
                 not_documented = False
 
             if f.comment and not hide_comments:
-                if f.description:
-                    wln(fd, "+")
                 wln(fd, format_text(f.comment))
+                wln(fd)
                 not_documented = False
 
             if not_documented:
-                wln(fd, "(not documented)")
-
-        wln(fd)
+                wln(fd, "_(not documented)_")
+                wln(fd)
 
 
 def print_map_summary(fd, summary):
-    wln(fd, "|===")
-    wln(fd, "|HW address | Type | Name | HDL name")
+    wln(fd, "| HW address | Type | Name | HDL Name |")
+    wln(fd, "|------------|------|------|----------|")
     for r in summary.raws:
-        wln(fd)
-        wln(fd, "|{}".format(r.address))
-        wln(fd, "|{}".format(r.typ))
-        wln(fd, "|{}".format(r.name))
-        wln(fd, "|{}".format(r.node.c_name))
-    wln(fd, "|===")
+        wln(fd, "| {} | {} | {} | {} |".format(r.address, r.typ, r.name, r.node.c_name))
     wln(fd)
 
 
@@ -79,30 +87,35 @@ def print_reg_description(fd, summary, hide_comments=False):
     for ra in summary.raws:
         r = ra.node
         if isinstance(r, tree.Reg):
-            wln(fd, "=== {}".format(ra.name))
-            print_reg(fd, r, ra.abs_addr, hide_comments)
+            print_reg(fd, r, ra.name, ra.abs_addr, hide_comments)
 
 
 def print_root(fd, root, hide_comments=False):
-    wln(fd, "== Memory map summary")
-    wln(fd, root.description or '(no description)')
-    wln(fd)
+    wln(fd, "## Memory Map Summary")
+
+    if root.description:
+        wln(fd, root.description)
+        wln(fd)
+
     if root.version is not None:
-        wln(fd, "version: {}".format(root.version))
+        wln(fd, "Version: {}".format(root.version))
         wln(fd)
 
     if root.c_address_spaces_map is None:
         summary = gen_doc.MemmapSummary(root)
         print_map_summary(fd, summary)
-        wln(fd, "== Registers description")
+
+        wln(fd, "## Registers Description")
         print_reg_description(fd, summary, hide_comments)
+
     else:
         summaries = [(gen_doc.MemmapSummary(space), space) for space in root.children]
         for summary, space in summaries:
-            wln(fd, "== For space {}".format(space.name))
+            wln(fd, "## For Space {}".format(space.name))
             print_map_summary(fd, summary)
+
         for summary, space in summaries:
-            wln(fd, "== Registers description for space {}\n".format(space.name))
+            wln(fd, "## Registers Description for Space {}\n".format(space.name))
             print_reg_description(fd, summary, hide_comments)
 
 

--- a/testfiles/features/semver1.md
+++ b/testfiles/features/semver1.md
@@ -10,10 +10,11 @@ Version: 1.0.0
 ## Registers Description
 ### Register: r1
 
-- **HDL name**: r1
-- **Address**: 0x0
-- **Block Offset**: 0x0
-- **Access Mode**: rw
+- **HW Prefix**: r1
+- **HW Address**: 0x0
+- **C Prefix**: r1
+- **C Block Offset**: 0x0
+- **Access**: read/write
 
 <table>
   <tr>
@@ -69,4 +70,8 @@ Version: 1.0.0
     <td colspan="8" style="text-align: center;">r1[7:0]</td>
   </tr>
 </table>
+
+| Bits | Name | Description |
+|------|------|------------|
+| 31:0 | r1 |  |
 

--- a/testfiles/features/semver1.md
+++ b/testfiles/features/semver1.md
@@ -1,69 +1,72 @@
-== Memory map summary
+## Memory Map Summary
 a single register
 
-version: 1.0.0
+Version: 1.0.0
 
-|===
-|HW address | Type | Name | HDL name
+| HW address | Type | Name | HDL Name |
+|------------|------|------|----------|
+| 0x0 | REG | r1 | r1 |
 
-|0x0
-|REG
-|r1
-|r1
-|===
+## Registers Description
+### Register: r1
 
-== Registers description
-=== r1
-[horizontal]
-HDL name:: r1
-address:: 0x0
-block offset:: 0x0
-access mode:: rw
+- **HDL name**: r1
+- **Address**: 0x0
+- **Block Offset**: 0x0
+- **Access Mode**: rw
 
-[cols="8*^"]
-|===
+<table>
+  <tr>
+    <td><b>31</b></td>
+    <td><b>30</b></td>
+    <td><b>29</b></td>
+    <td><b>28</b></td>
+    <td><b>27</b></td>
+    <td><b>26</b></td>
+    <td><b>25</b></td>
+    <td><b>24</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">r1[31:24]</td>
+  </tr>
+  <tr>
+    <td><b>23</b></td>
+    <td><b>22</b></td>
+    <td><b>21</b></td>
+    <td><b>20</b></td>
+    <td><b>19</b></td>
+    <td><b>18</b></td>
+    <td><b>17</b></td>
+    <td><b>16</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">r1[23:16]</td>
+  </tr>
+  <tr>
+    <td><b>15</b></td>
+    <td><b>14</b></td>
+    <td><b>13</b></td>
+    <td><b>12</b></td>
+    <td><b>11</b></td>
+    <td><b>10</b></td>
+    <td><b>9</b></td>
+    <td><b>8</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">r1[15:8]</td>
+  </tr>
+  <tr>
+    <td><b>7</b></td>
+    <td><b>6</b></td>
+    <td><b>5</b></td>
+    <td><b>4</b></td>
+    <td><b>3</b></td>
+    <td><b>2</b></td>
+    <td><b>1</b></td>
+    <td><b>0</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">r1[7:0]</td>
+  </tr>
+</table>
 
-| 31
-| 30
-| 29
-| 28
-| 27
-| 26
-| 25
-| 24
-
-8+s| r1[31:24]
-
-| 23
-| 22
-| 21
-| 20
-| 19
-| 18
-| 17
-| 16
-
-8+s| r1[23:16]
-
-| 15
-| 14
-| 13
-| 12
-| 11
-| 10
-| 9
-| 8
-
-8+s| r1[15:8]
-
-| 7
-| 6
-| 5
-| 4
-| 3
-| 2
-| 1
-| 0
-
-8+s| r1[7:0]
-|===

--- a/testfiles/issue67/repeatInRepeat.md
+++ b/testfiles/issue67/repeatInRepeat.md
@@ -34,10 +34,11 @@
 ## Registers Description
 ### Register: repA.0.block1.repB.0.reg1
 
-- **HDL name**: repA_0_block1_repB_0_reg1
-- **Address**: 0x0
-- **Block Offset**: 0x0
-- **Access Mode**: rw
+- **HW Prefix**: repA_0_block1_repB_0_reg1
+- **HW Address**: 0x0
+- **C Prefix**: repA.0.block1.repB.0.reg1
+- **C Block Offset**: 0x0
+- **Access**: read/write
 
 <table>
   <tr>
@@ -54,13 +55,18 @@
     <td colspan="8" style="text-align: center;">reg1[7:0]</td>
   </tr>
 </table>
+
+| Bits | Name | Description |
+|------|------|------------|
+| 7:0 | reg1 |  |
 
 ### Register: repA.0.block1.repB.1.reg1
 
-- **HDL name**: repA_0_block1_repB_1_reg1
-- **Address**: 0x4
-- **Block Offset**: 0x0
-- **Access Mode**: rw
+- **HW Prefix**: repA_0_block1_repB_1_reg1
+- **HW Address**: 0x4
+- **C Prefix**: repA.0.block1.repB.1.reg1
+- **C Block Offset**: 0x0
+- **Access**: read/write
 
 <table>
   <tr>
@@ -77,13 +83,18 @@
     <td colspan="8" style="text-align: center;">reg1[7:0]</td>
   </tr>
 </table>
+
+| Bits | Name | Description |
+|------|------|------------|
+| 7:0 | reg1 |  |
 
 ### Register: repA.1.block1.repB.0.reg1
 
-- **HDL name**: repA_1_block1_repB_0_reg1
-- **Address**: 0x8
-- **Block Offset**: 0x0
-- **Access Mode**: rw
+- **HW Prefix**: repA_1_block1_repB_0_reg1
+- **HW Address**: 0x8
+- **C Prefix**: repA.1.block1.repB.0.reg1
+- **C Block Offset**: 0x0
+- **Access**: read/write
 
 <table>
   <tr>
@@ -100,13 +111,18 @@
     <td colspan="8" style="text-align: center;">reg1[7:0]</td>
   </tr>
 </table>
+
+| Bits | Name | Description |
+|------|------|------------|
+| 7:0 | reg1 |  |
 
 ### Register: repA.1.block1.repB.1.reg1
 
-- **HDL name**: repA_1_block1_repB_1_reg1
-- **Address**: 0xc
-- **Block Offset**: 0x0
-- **Access Mode**: rw
+- **HW Prefix**: repA_1_block1_repB_1_reg1
+- **HW Address**: 0xc
+- **C Prefix**: repA.1.block1.repB.1.reg1
+- **C Block Offset**: 0x0
+- **Access**: read/write
 
 <table>
   <tr>
@@ -123,13 +139,18 @@
     <td colspan="8" style="text-align: center;">reg1[7:0]</td>
   </tr>
 </table>
+
+| Bits | Name | Description |
+|------|------|------------|
+| 7:0 | reg1 |  |
 
 ### Register: repA.2.block1.repB.0.reg1
 
-- **HDL name**: repA_2_block1_repB_0_reg1
-- **Address**: 0x10
-- **Block Offset**: 0x0
-- **Access Mode**: rw
+- **HW Prefix**: repA_2_block1_repB_0_reg1
+- **HW Address**: 0x10
+- **C Prefix**: repA.2.block1.repB.0.reg1
+- **C Block Offset**: 0x0
+- **Access**: read/write
 
 <table>
   <tr>
@@ -146,13 +167,18 @@
     <td colspan="8" style="text-align: center;">reg1[7:0]</td>
   </tr>
 </table>
+
+| Bits | Name | Description |
+|------|------|------------|
+| 7:0 | reg1 |  |
 
 ### Register: repA.2.block1.repB.1.reg1
 
-- **HDL name**: repA_2_block1_repB_1_reg1
-- **Address**: 0x14
-- **Block Offset**: 0x0
-- **Access Mode**: rw
+- **HW Prefix**: repA_2_block1_repB_1_reg1
+- **HW Address**: 0x14
+- **C Prefix**: repA.2.block1.repB.1.reg1
+- **C Block Offset**: 0x0
+- **Access**: read/write
 
 <table>
   <tr>
@@ -169,13 +195,18 @@
     <td colspan="8" style="text-align: center;">reg1[7:0]</td>
   </tr>
 </table>
+
+| Bits | Name | Description |
+|------|------|------------|
+| 7:0 | reg1 |  |
 
 ### Register: repA.3.block1.repB.0.reg1
 
-- **HDL name**: repA_3_block1_repB_0_reg1
-- **Address**: 0x18
-- **Block Offset**: 0x0
-- **Access Mode**: rw
+- **HW Prefix**: repA_3_block1_repB_0_reg1
+- **HW Address**: 0x18
+- **C Prefix**: repA.3.block1.repB.0.reg1
+- **C Block Offset**: 0x0
+- **Access**: read/write
 
 <table>
   <tr>
@@ -192,13 +223,18 @@
     <td colspan="8" style="text-align: center;">reg1[7:0]</td>
   </tr>
 </table>
+
+| Bits | Name | Description |
+|------|------|------------|
+| 7:0 | reg1 |  |
 
 ### Register: repA.3.block1.repB.1.reg1
 
-- **HDL name**: repA_3_block1_repB_1_reg1
-- **Address**: 0x1c
-- **Block Offset**: 0x0
-- **Access Mode**: rw
+- **HW Prefix**: repA_3_block1_repB_1_reg1
+- **HW Address**: 0x1c
+- **C Prefix**: repA.3.block1.repB.1.reg1
+- **C Block Offset**: 0x0
+- **Access**: read/write
 
 <table>
   <tr>
@@ -215,4 +251,8 @@
     <td colspan="8" style="text-align: center;">reg1[7:0]</td>
   </tr>
 </table>
+
+| Bits | Name | Description |
+|------|------|------------|
+| 7:0 | reg1 |  |
 

--- a/testfiles/issue67/repeatInRepeat.md
+++ b/testfiles/issue67/repeatInRepeat.md
@@ -1,321 +1,218 @@
-== Memory map summary
-(no description)
+## Memory Map Summary
+| HW address | Type | Name | HDL Name |
+|------------|------|------|----------|
+| 0x00-0x1f | BLOCK | repA | repA |
+| 0x00-0x07 | BLOCK | repA.0 | repA_0 |
+| 0x00-0x07 | BLOCK | repA.0.block1 | repA_0_block1 |
+| 0x00-0x07 | BLOCK | repA.0.block1.repB | repA_0_block1_repB |
+| 0x00-0x03 | BLOCK | repA.0.block1.repB.0 | repA_0_block1_repB_0 |
+| 0x00 | REG | repA.0.block1.repB.0.reg1 | repA_0_block1_repB_0_reg1 |
+| 0x04-0x07 | BLOCK | repA.0.block1.repB.1 | repA_0_block1_repB_1 |
+| 0x04 | REG | repA.0.block1.repB.1.reg1 | repA_0_block1_repB_1_reg1 |
+| 0x08-0x0f | BLOCK | repA.1 | repA_1 |
+| 0x08-0x0f | BLOCK | repA.1.block1 | repA_1_block1 |
+| 0x08-0x0f | BLOCK | repA.1.block1.repB | repA_1_block1_repB |
+| 0x08-0x0b | BLOCK | repA.1.block1.repB.0 | repA_1_block1_repB_0 |
+| 0x08 | REG | repA.1.block1.repB.0.reg1 | repA_1_block1_repB_0_reg1 |
+| 0x0c-0x0f | BLOCK | repA.1.block1.repB.1 | repA_1_block1_repB_1 |
+| 0x0c | REG | repA.1.block1.repB.1.reg1 | repA_1_block1_repB_1_reg1 |
+| 0x10-0x17 | BLOCK | repA.2 | repA_2 |
+| 0x10-0x17 | BLOCK | repA.2.block1 | repA_2_block1 |
+| 0x10-0x17 | BLOCK | repA.2.block1.repB | repA_2_block1_repB |
+| 0x10-0x13 | BLOCK | repA.2.block1.repB.0 | repA_2_block1_repB_0 |
+| 0x10 | REG | repA.2.block1.repB.0.reg1 | repA_2_block1_repB_0_reg1 |
+| 0x14-0x17 | BLOCK | repA.2.block1.repB.1 | repA_2_block1_repB_1 |
+| 0x14 | REG | repA.2.block1.repB.1.reg1 | repA_2_block1_repB_1_reg1 |
+| 0x18-0x1f | BLOCK | repA.3 | repA_3 |
+| 0x18-0x1f | BLOCK | repA.3.block1 | repA_3_block1 |
+| 0x18-0x1f | BLOCK | repA.3.block1.repB | repA_3_block1_repB |
+| 0x18-0x1b | BLOCK | repA.3.block1.repB.0 | repA_3_block1_repB_0 |
+| 0x18 | REG | repA.3.block1.repB.0.reg1 | repA_3_block1_repB_0_reg1 |
+| 0x1c-0x1f | BLOCK | repA.3.block1.repB.1 | repA_3_block1_repB_1 |
+| 0x1c | REG | repA.3.block1.repB.1.reg1 | repA_3_block1_repB_1_reg1 |
 
-|===
-|HW address | Type | Name | HDL name
+## Registers Description
+### Register: repA.0.block1.repB.0.reg1
 
-|0x00-0x1f
-|BLOCK
-|repA
-|repA
+- **HDL name**: repA_0_block1_repB_0_reg1
+- **Address**: 0x0
+- **Block Offset**: 0x0
+- **Access Mode**: rw
 
-|0x00-0x07
-|BLOCK
-|repA.0
-|repA_0
+<table>
+  <tr>
+    <td><b>7</b></td>
+    <td><b>6</b></td>
+    <td><b>5</b></td>
+    <td><b>4</b></td>
+    <td><b>3</b></td>
+    <td><b>2</b></td>
+    <td><b>1</b></td>
+    <td><b>0</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">reg1[7:0]</td>
+  </tr>
+</table>
 
-|0x00-0x07
-|BLOCK
-|repA.0.block1
-|repA_0_block1
+### Register: repA.0.block1.repB.1.reg1
 
-|0x00-0x07
-|BLOCK
-|repA.0.block1.repB
-|repA_0_block1_repB
+- **HDL name**: repA_0_block1_repB_1_reg1
+- **Address**: 0x4
+- **Block Offset**: 0x0
+- **Access Mode**: rw
 
-|0x00-0x03
-|BLOCK
-|repA.0.block1.repB.0
-|repA_0_block1_repB_0
+<table>
+  <tr>
+    <td><b>7</b></td>
+    <td><b>6</b></td>
+    <td><b>5</b></td>
+    <td><b>4</b></td>
+    <td><b>3</b></td>
+    <td><b>2</b></td>
+    <td><b>1</b></td>
+    <td><b>0</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">reg1[7:0]</td>
+  </tr>
+</table>
 
-|0x00
-|REG
-|repA.0.block1.repB.0.reg1
-|repA_0_block1_repB_0_reg1
+### Register: repA.1.block1.repB.0.reg1
 
-|0x04-0x07
-|BLOCK
-|repA.0.block1.repB.1
-|repA_0_block1_repB_1
+- **HDL name**: repA_1_block1_repB_0_reg1
+- **Address**: 0x8
+- **Block Offset**: 0x0
+- **Access Mode**: rw
 
-|0x04
-|REG
-|repA.0.block1.repB.1.reg1
-|repA_0_block1_repB_1_reg1
+<table>
+  <tr>
+    <td><b>7</b></td>
+    <td><b>6</b></td>
+    <td><b>5</b></td>
+    <td><b>4</b></td>
+    <td><b>3</b></td>
+    <td><b>2</b></td>
+    <td><b>1</b></td>
+    <td><b>0</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">reg1[7:0]</td>
+  </tr>
+</table>
 
-|0x08-0x0f
-|BLOCK
-|repA.1
-|repA_1
+### Register: repA.1.block1.repB.1.reg1
 
-|0x08-0x0f
-|BLOCK
-|repA.1.block1
-|repA_1_block1
+- **HDL name**: repA_1_block1_repB_1_reg1
+- **Address**: 0xc
+- **Block Offset**: 0x0
+- **Access Mode**: rw
 
-|0x08-0x0f
-|BLOCK
-|repA.1.block1.repB
-|repA_1_block1_repB
+<table>
+  <tr>
+    <td><b>7</b></td>
+    <td><b>6</b></td>
+    <td><b>5</b></td>
+    <td><b>4</b></td>
+    <td><b>3</b></td>
+    <td><b>2</b></td>
+    <td><b>1</b></td>
+    <td><b>0</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">reg1[7:0]</td>
+  </tr>
+</table>
 
-|0x08-0x0b
-|BLOCK
-|repA.1.block1.repB.0
-|repA_1_block1_repB_0
+### Register: repA.2.block1.repB.0.reg1
 
-|0x08
-|REG
-|repA.1.block1.repB.0.reg1
-|repA_1_block1_repB_0_reg1
+- **HDL name**: repA_2_block1_repB_0_reg1
+- **Address**: 0x10
+- **Block Offset**: 0x0
+- **Access Mode**: rw
 
-|0x0c-0x0f
-|BLOCK
-|repA.1.block1.repB.1
-|repA_1_block1_repB_1
+<table>
+  <tr>
+    <td><b>7</b></td>
+    <td><b>6</b></td>
+    <td><b>5</b></td>
+    <td><b>4</b></td>
+    <td><b>3</b></td>
+    <td><b>2</b></td>
+    <td><b>1</b></td>
+    <td><b>0</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">reg1[7:0]</td>
+  </tr>
+</table>
 
-|0x0c
-|REG
-|repA.1.block1.repB.1.reg1
-|repA_1_block1_repB_1_reg1
+### Register: repA.2.block1.repB.1.reg1
 
-|0x10-0x17
-|BLOCK
-|repA.2
-|repA_2
+- **HDL name**: repA_2_block1_repB_1_reg1
+- **Address**: 0x14
+- **Block Offset**: 0x0
+- **Access Mode**: rw
 
-|0x10-0x17
-|BLOCK
-|repA.2.block1
-|repA_2_block1
+<table>
+  <tr>
+    <td><b>7</b></td>
+    <td><b>6</b></td>
+    <td><b>5</b></td>
+    <td><b>4</b></td>
+    <td><b>3</b></td>
+    <td><b>2</b></td>
+    <td><b>1</b></td>
+    <td><b>0</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">reg1[7:0]</td>
+  </tr>
+</table>
 
-|0x10-0x17
-|BLOCK
-|repA.2.block1.repB
-|repA_2_block1_repB
+### Register: repA.3.block1.repB.0.reg1
 
-|0x10-0x13
-|BLOCK
-|repA.2.block1.repB.0
-|repA_2_block1_repB_0
+- **HDL name**: repA_3_block1_repB_0_reg1
+- **Address**: 0x18
+- **Block Offset**: 0x0
+- **Access Mode**: rw
 
-|0x10
-|REG
-|repA.2.block1.repB.0.reg1
-|repA_2_block1_repB_0_reg1
+<table>
+  <tr>
+    <td><b>7</b></td>
+    <td><b>6</b></td>
+    <td><b>5</b></td>
+    <td><b>4</b></td>
+    <td><b>3</b></td>
+    <td><b>2</b></td>
+    <td><b>1</b></td>
+    <td><b>0</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">reg1[7:0]</td>
+  </tr>
+</table>
 
-|0x14-0x17
-|BLOCK
-|repA.2.block1.repB.1
-|repA_2_block1_repB_1
+### Register: repA.3.block1.repB.1.reg1
 
-|0x14
-|REG
-|repA.2.block1.repB.1.reg1
-|repA_2_block1_repB_1_reg1
+- **HDL name**: repA_3_block1_repB_1_reg1
+- **Address**: 0x1c
+- **Block Offset**: 0x0
+- **Access Mode**: rw
 
-|0x18-0x1f
-|BLOCK
-|repA.3
-|repA_3
+<table>
+  <tr>
+    <td><b>7</b></td>
+    <td><b>6</b></td>
+    <td><b>5</b></td>
+    <td><b>4</b></td>
+    <td><b>3</b></td>
+    <td><b>2</b></td>
+    <td><b>1</b></td>
+    <td><b>0</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">reg1[7:0]</td>
+  </tr>
+</table>
 
-|0x18-0x1f
-|BLOCK
-|repA.3.block1
-|repA_3_block1
-
-|0x18-0x1f
-|BLOCK
-|repA.3.block1.repB
-|repA_3_block1_repB
-
-|0x18-0x1b
-|BLOCK
-|repA.3.block1.repB.0
-|repA_3_block1_repB_0
-
-|0x18
-|REG
-|repA.3.block1.repB.0.reg1
-|repA_3_block1_repB_0_reg1
-
-|0x1c-0x1f
-|BLOCK
-|repA.3.block1.repB.1
-|repA_3_block1_repB_1
-
-|0x1c
-|REG
-|repA.3.block1.repB.1.reg1
-|repA_3_block1_repB_1_reg1
-|===
-
-== Registers description
-=== repA.0.block1.repB.0.reg1
-[horizontal]
-HDL name:: repA_0_block1_repB_0_reg1
-address:: 0x0
-block offset:: 0x0
-access mode:: rw
-
-[cols="8*^"]
-|===
-
-| 7
-| 6
-| 5
-| 4
-| 3
-| 2
-| 1
-| 0
-
-8+s| reg1[7:0]
-|===
-=== repA.0.block1.repB.1.reg1
-[horizontal]
-HDL name:: repA_0_block1_repB_1_reg1
-address:: 0x4
-block offset:: 0x0
-access mode:: rw
-
-[cols="8*^"]
-|===
-
-| 7
-| 6
-| 5
-| 4
-| 3
-| 2
-| 1
-| 0
-
-8+s| reg1[7:0]
-|===
-=== repA.1.block1.repB.0.reg1
-[horizontal]
-HDL name:: repA_1_block1_repB_0_reg1
-address:: 0x8
-block offset:: 0x0
-access mode:: rw
-
-[cols="8*^"]
-|===
-
-| 7
-| 6
-| 5
-| 4
-| 3
-| 2
-| 1
-| 0
-
-8+s| reg1[7:0]
-|===
-=== repA.1.block1.repB.1.reg1
-[horizontal]
-HDL name:: repA_1_block1_repB_1_reg1
-address:: 0xc
-block offset:: 0x0
-access mode:: rw
-
-[cols="8*^"]
-|===
-
-| 7
-| 6
-| 5
-| 4
-| 3
-| 2
-| 1
-| 0
-
-8+s| reg1[7:0]
-|===
-=== repA.2.block1.repB.0.reg1
-[horizontal]
-HDL name:: repA_2_block1_repB_0_reg1
-address:: 0x10
-block offset:: 0x0
-access mode:: rw
-
-[cols="8*^"]
-|===
-
-| 7
-| 6
-| 5
-| 4
-| 3
-| 2
-| 1
-| 0
-
-8+s| reg1[7:0]
-|===
-=== repA.2.block1.repB.1.reg1
-[horizontal]
-HDL name:: repA_2_block1_repB_1_reg1
-address:: 0x14
-block offset:: 0x0
-access mode:: rw
-
-[cols="8*^"]
-|===
-
-| 7
-| 6
-| 5
-| 4
-| 3
-| 2
-| 1
-| 0
-
-8+s| reg1[7:0]
-|===
-=== repA.3.block1.repB.0.reg1
-[horizontal]
-HDL name:: repA_3_block1_repB_0_reg1
-address:: 0x18
-block offset:: 0x0
-access mode:: rw
-
-[cols="8*^"]
-|===
-
-| 7
-| 6
-| 5
-| 4
-| 3
-| 2
-| 1
-| 0
-
-8+s| reg1[7:0]
-|===
-=== repA.3.block1.repB.1.reg1
-[horizontal]
-HDL name:: repA_3_block1_repB_1_reg1
-address:: 0x1c
-block offset:: 0x0
-access mode:: rw
-
-[cols="8*^"]
-|===
-
-| 7
-| 6
-| 5
-| 4
-| 3
-| 2
-| 1
-| 0
-
-8+s| reg1[7:0]
-|===

--- a/testfiles/issue84/sps200CavityControl_as.md
+++ b/testfiles/issue84/sps200CavityControl_as.md
@@ -48,10 +48,11 @@ Memory Map for SPS TWC200 Cavity Control
 
 ### Register: hwInfo.stdVersion
 
-- **HDL name**: hwInfo_stdVersion
-- **Address**: 0x0
-- **Block Offset**: 0x0
-- **Access Mode**: ro
+- **HW Prefix**: hwInfo_stdVersion
+- **HW Address**: 0x0
+- **C Prefix**: hwInfo.stdVersion
+- **C Block Offset**: 0x0
+- **Access**: read-only
 
 <table>
   <tr>
@@ -108,30 +109,22 @@ Memory Map for SPS TWC200 Cavity Control
   </tr>
 </table>
 
-#### Bit: platform
-
-Identifying which platform the version belongs to (i.e. pci, lhc_vme, vme64, ...)
-
-#### Bit: major
-
-Major version indicating incompatible changes
-
-#### Bit: minor
-
-Minor version indicating feature enhancements
-
-#### Bit: patch
-
-Patch indicating bug fixes
+| Bits | Name | Description |
+|------|------|------------|
+| 31:24 | platform | Identifying which platform the version belongs to (i.e. pci, lhc_vme, vme64, ...) |
+| 23:16 | major | Major version indicating incompatible changes |
+| 15:8 | minor | Minor version indicating feature enhancements |
+| 7:0 | patch | Patch indicating bug fixes |
 
 ### Register: hwInfo.serialNumber
 
-HW serial number
+- **HW Prefix**: hwInfo_serialNumber
+- **HW Address**: 0x8
+- **C Prefix**: hwInfo.serialNumber
+- **C Block Offset**: 0x8
+- **Access**: read-only
 
-- **HDL name**: hwInfo_serialNumber
-- **Address**: 0x8
-- **Block Offset**: 0x8
-- **Access Mode**: ro
+HW serial number
 
 <table>
   <tr>
@@ -240,15 +233,20 @@ HW serial number
   </tr>
 </table>
 
+| Bits | Name | Description |
+|------|------|------------|
+| 63:0 | serialNumber | HW serial number |
+
 ### Register: hwInfo.firmwareVersion
+
+- **HW Prefix**: hwInfo_firmwareVersion
+- **HW Address**: 0x10
+- **C Prefix**: hwInfo.firmwareVersion
+- **C Block Offset**: 0x10
+- **Access**: read-only
 
 Firmware Version
 
-- **HDL name**: hwInfo_firmwareVersion
-- **Address**: 0x10
-- **Block Offset**: 0x10
-- **Access Mode**: ro
-
 <table>
   <tr>
     <td><b>31</b></td>
@@ -311,26 +309,21 @@ Firmware Version
   </tr>
 </table>
 
-#### Bit: major
-
-Major version indicating incompatible changes
-
-#### Bit: minor
-
-Minor version indicating feature enhancements
-
-#### Bit: patch
-
-Patch indicating bug fixes
+| Bits | Name | Description |
+|------|------|------------|
+| 23:16 | major | Major version indicating incompatible changes |
+| 15:8 | minor | Minor version indicating feature enhancements |
+| 7:0 | patch | Patch indicating bug fixes |
 
 ### Register: hwInfo.memMapVersion
 
-Memory Map Version
+- **HW Prefix**: hwInfo_memMapVersion
+- **HW Address**: 0x14
+- **C Prefix**: hwInfo.memMapVersion
+- **C Block Offset**: 0x14
+- **Access**: read-only
 
-- **HDL name**: hwInfo_memMapVersion
-- **Address**: 0x14
-- **Block Offset**: 0x14
-- **Access Mode**: ro
+Memory Map Version
 
 <table>
   <tr>
@@ -394,19 +387,19 @@ Memory Map Version
   </tr>
 </table>
 
-#### Bit: major
-
-_(not documented)_
-
-#### Bit: minor
-
-_(not documented)_
-
-#### Bit: patch
-
-_(not documented)_
+| Bits | Name | Description |
+|------|------|------------|
+| 23:16 | major |  |
+| 15:8 | minor |  |
+| 7:0 | patch |  |
 
 ### Register: hwInfo.echo
+
+- **HW Prefix**: hwInfo_echo
+- **HW Address**: 0x18
+- **C Prefix**: hwInfo.echo
+- **C Block Offset**: 0x18
+- **Access**: read/write
 
 Echo register. This version of the standard foresees only 8bits linked to real memory
 
@@ -423,11 +416,6 @@ This is important for you to later one check if you can read this value back bef
 If your initialization failed but you want to continue anyway you should set the register to 0xC0 to indicate this error  +
  +
 This register is in particular useful if you have several entities interacting with the hardware. In this case several bits could be assigned to this entities (bits 5..0) to signalize that they have done there part successful and a main entity checks all the expected bits.
-
-- **HDL name**: hwInfo_echo
-- **Address**: 0x18
-- **Block Offset**: 0x18
-- **Access Mode**: rw
 
 <table>
   <tr>
@@ -484,12 +472,17 @@ This register is in particular useful if you have several entities interacting w
   </tr>
 </table>
 
+| Bits | Name | Description |
+|------|------|------------|
+| 31:0 | echo | Echo register. This version of the standard foresees only 8bits linked to real memory<br><br>Register used solely by software. No interaction with the firmware foreseen.<br>The idea is to use this register as "flag" in the hardware to remember your actions from the software side.<br><br>Reading 0xFF often happens when the board is not even reachable (i.e. bus problems on VME)<br><br>On the other hand if the board is reachable the usual state of flipflops are 0x00. Thus this would indicate that no initialization has been attempted yet.<br><br>At start of your software (FESA class) you should set the value 0x40 indicating that initialization is in progress. <br>This is important for you to later one check if you can read this value back before finally setting it to 0x80 (the value previously used with Cheburashka).<br><br>If your initialization failed but you want to continue anyway you should set the register to 0xC0 to indicate this error <br><br>This register is in particular useful if you have several entities interacting with the hardware. In this case several bits could be assigned to this entities (bits 5..0) to signalize that they have done there part successful and a main entity checks all the expected bits. |
+
 ### Register: app.modulation.ipInfo.stdVersion
 
-- **HDL name**: app_modulation_ipInfo_stdVersion
-- **Address**: 0x100000
-- **Block Offset**: 0x0
-- **Access Mode**: ro
+- **HW Prefix**: app_modulation_ipInfo_stdVersion
+- **HW Address**: 0x100000
+- **C Prefix**: app.modulation.ipInfo.stdVersion
+- **C Block Offset**: 0x0
+- **Access**: read-only
 
 <table>
   <tr>
@@ -553,26 +546,21 @@ This register is in particular useful if you have several entities interacting w
   </tr>
 </table>
 
-#### Bit: major
-
-Major version indicating incompatible changes
-
-#### Bit: minor
-
-Minor version indicating feature enhancements
-
-#### Bit: patch
-
-Patch indicating bug fixes
+| Bits | Name | Description |
+|------|------|------------|
+| 23:16 | major | Major version indicating incompatible changes |
+| 15:8 | minor | Minor version indicating feature enhancements |
+| 7:0 | patch | Patch indicating bug fixes |
 
 ### Register: app.modulation.ipInfo.ident
 
-IP Ident code
+- **HW Prefix**: app_modulation_ipInfo_ident
+- **HW Address**: 0x100004
+- **C Prefix**: app.modulation.ipInfo.ident
+- **C Block Offset**: 0x4
+- **Access**: read-only
 
-- **HDL name**: app_modulation_ipInfo_ident
-- **Address**: 0x100004
-- **Block Offset**: 0x4
-- **Access Mode**: ro
+IP Ident code
 
 <table>
   <tr>
@@ -629,15 +617,20 @@ IP Ident code
   </tr>
 </table>
 
+| Bits | Name | Description |
+|------|------|------------|
+| 31:0 | ident | IP Ident code |
+
 ### Register: app.modulation.ipInfo.firmwareVersion
+
+- **HW Prefix**: app_modulation_ipInfo_firmwareVersion
+- **HW Address**: 0x100008
+- **C Prefix**: app.modulation.ipInfo.firmwareVersion
+- **C Block Offset**: 0x8
+- **Access**: read-only
 
 Firmware Version
 
-- **HDL name**: app_modulation_ipInfo_firmwareVersion
-- **Address**: 0x100008
-- **Block Offset**: 0x8
-- **Access Mode**: ro
-
 <table>
   <tr>
     <td><b>31</b></td>
@@ -700,26 +693,21 @@ Firmware Version
   </tr>
 </table>
 
-#### Bit: major
-
-Major version indicating incompatible changes
-
-#### Bit: minor
-
-Minor version indicating feature enhancements
-
-#### Bit: patch
-
-Patch indicating bug fixes
+| Bits | Name | Description |
+|------|------|------------|
+| 23:16 | major | Major version indicating incompatible changes |
+| 15:8 | minor | Minor version indicating feature enhancements |
+| 7:0 | patch | Patch indicating bug fixes |
 
 ### Register: app.modulation.ipInfo.memMapVersion
 
-Memory Map Version
+- **HW Prefix**: app_modulation_ipInfo_memMapVersion
+- **HW Address**: 0x10000c
+- **C Prefix**: app.modulation.ipInfo.memMapVersion
+- **C Block Offset**: 0xc
+- **Access**: read-only
 
-- **HDL name**: app_modulation_ipInfo_memMapVersion
-- **Address**: 0x10000c
-- **Block Offset**: 0xc
-- **Access Mode**: ro
+Memory Map Version
 
 <table>
   <tr>
@@ -783,19 +771,19 @@ Memory Map Version
   </tr>
 </table>
 
-#### Bit: major
-
-Major version indicating incompatible changes
-
-#### Bit: minor
-
-Minor version indicating feature enhancements
-
-#### Bit: patch
-
-Patch indicating bug fixes
+| Bits | Name | Description |
+|------|------|------------|
+| 23:16 | major | Major version indicating incompatible changes |
+| 15:8 | minor | Minor version indicating feature enhancements |
+| 7:0 | patch | Patch indicating bug fixes |
 
 ### Register: app.modulation.ipInfo.echo
+
+- **HW Prefix**: app_modulation_ipInfo_echo
+- **HW Address**: 0x100010
+- **C Prefix**: app.modulation.ipInfo.echo
+- **C Block Offset**: 0x10
+- **Access**: read/write
 
 Echo register. This version of the standard foresees only 8bits linked to real memory
 
@@ -812,11 +800,6 @@ This is important for you to later one check if you can read this value back bef
 If your initialization failed but you want to continue anyway you should set the register to 0xC0 to indicate this error  +
  +
 This register is in particular useful if you have several entities interacting with the hardware. In this case several bits could be assigned to this entities (bits 5..0) to signalize that they have done there part successful and a main entity checks all the expected bits.
-
-- **HDL name**: app_modulation_ipInfo_echo
-- **Address**: 0x100010
-- **Block Offset**: 0x10
-- **Access Mode**: rw
 
 <table>
   <tr>
@@ -894,16 +877,17 @@ This register is in particular useful if you have several entities interacting w
   </tr>
 </table>
 
-#### Bit: echo
-
-This version of the standard foresees only 8bits linked to real memory
+| Bits | Name | Description |
+|------|------|------------|
+| 7:0 | echo | This version of the standard foresees only 8bits linked to real memory |
 
 ### Register: app.modulation.control
 
-- **HDL name**: app_modulation_control
-- **Address**: 0x100020
-- **Block Offset**: 0x20
-- **Access Mode**: rw
+- **HW Prefix**: app_modulation_control
+- **HW Address**: 0x100020
+- **C Prefix**: app.modulation.control
+- **C Block Offset**: 0x20
+- **Access**: read/write
 
 <table>
   <tr>
@@ -986,64 +970,30 @@ This version of the standard foresees only 8bits linked to real memory
   </tr>
 </table>
 
-#### Bit: useTestSignal
-
-Use DDS generated test signal instead of ADC input as demodulation input
-
-Test signal is synthezied with additional internal DDS, test signals frequency given by ftw_RF.
-
-#### Bit: useImpulse
-
-Use impulse instead of demodulation output
-
-#### Bit: useStaticSignal
-
-Use static signal from register instead of demodulation output
-
-#### Bit: bypassDemod
-
-Bypass demodulator
-
-#### Bit: bypassMod
-
-Bypass modulator
-
-#### Bit: wrInputsValid
-
-transmit WR frame
-
-#### Bit: wrInputsValidLatch
-
-transmit WR no autoclear
-
-#### Bit: wrResetNCO
-
-activate WR frame control bit
-
-#### Bit: wrResetSlip
-
-activate WR frame control bit
-
-#### Bit: wrRresetFSK
-
-activate WR frame control bit
-
-#### Bit: rate
-
-_(not documented)_
-
-#### Bit: clearBPLatches
-
-_(not documented)_
+| Bits | Name | Description |
+|------|------|------------|
+| 0 | useTestSignal | Use DDS generated test signal instead of ADC input as demodulation input<br><br>Test signal is synthezied with additional internal DDS, test signals frequency given by ftw_RF. |
+| 1 | useImpulse | Use impulse instead of demodulation output |
+| 2 | useStaticSignal | Use static signal from register instead of demodulation output |
+| 5 | bypassDemod | Bypass demodulator |
+| 6 | bypassMod | Bypass modulator |
+| 7 | wrInputsValid | transmit WR frame |
+| 11 | wrInputsValidLatch | transmit WR no autoclear |
+| 8 | wrResetNCO | activate WR frame control bit |
+| 9 | wrResetSlip | activate WR frame control bit |
+| 10 | wrRresetFSK | activate WR frame control bit |
+| 14:12 | rate |  |
+| 15 | clearBPLatches |  |
 
 ### Register: app.modulation.testSignal.amplitude
 
-Amplitude for the test signal
+- **HW Prefix**: app_modulation_testSignal_amplitude
+- **HW Address**: 0x100030
+- **C Prefix**: app.modulation.testSignal.amplitude
+- **C Block Offset**: 0x0
+- **Access**: read/write
 
-- **HDL name**: app_modulation_testSignal_amplitude
-- **Address**: 0x100030
-- **Block Offset**: 0x0
-- **Access Mode**: rw
+Amplitude for the test signal
 
 <table>
   <tr>
@@ -1074,14 +1024,19 @@ Amplitude for the test signal
   </tr>
 </table>
 
+| Bits | Name | Description |
+|------|------|------------|
+| 15:0 | amplitude | Amplitude for the test signal |
+
 ### Register: app.modulation.testSignal.ftw
 
-FTW of the test signal (frequency relative to fs)
+- **HW Prefix**: app_modulation_testSignal_ftw
+- **HW Address**: 0x100038
+- **C Prefix**: app.modulation.testSignal.ftw
+- **C Block Offset**: 0x8
+- **Access**: read/write
 
-- **HDL name**: app_modulation_testSignal_ftw
-- **Address**: 0x100038
-- **Block Offset**: 0x8
-- **Access Mode**: rw
+FTW of the test signal (frequency relative to fs)
 
 <table>
   <tr>
@@ -1190,14 +1145,19 @@ FTW of the test signal (frequency relative to fs)
   </tr>
 </table>
 
+| Bits | Name | Description |
+|------|------|------------|
+| 63:0 | ftw | FTW of the test signal (frequency relative to fs) |
+
 ### Register: app.modulation.staticSignal.i
 
-Constant to be used as OTF input for channel I
+- **HW Prefix**: app_modulation_staticSignal_i
+- **HW Address**: 0x100040
+- **C Prefix**: app.modulation.staticSignal.i
+- **C Block Offset**: 0x0
+- **Access**: read/write
 
-- **HDL name**: app_modulation_staticSignal_i
-- **Address**: 0x100040
-- **Block Offset**: 0x0
-- **Access Mode**: rw
+Constant to be used as OTF input for channel I
 
 <table>
   <tr>
@@ -1228,14 +1188,19 @@ Constant to be used as OTF input for channel I
   </tr>
 </table>
 
+| Bits | Name | Description |
+|------|------|------------|
+| 15:0 | i | Constant to be used as OTF input for channel I |
+
 ### Register: app.modulation.staticSignal.q
 
-Constant to be used as OTF input for channel Q
+- **HW Prefix**: app_modulation_staticSignal_q
+- **HW Address**: 0x100044
+- **C Prefix**: app.modulation.staticSignal.q
+- **C Block Offset**: 0x4
+- **Access**: read/write
 
-- **HDL name**: app_modulation_staticSignal_q
-- **Address**: 0x100044
-- **Block Offset**: 0x4
-- **Access Mode**: rw
+Constant to be used as OTF input for channel Q
 
 <table>
   <tr>
@@ -1266,12 +1231,17 @@ Constant to be used as OTF input for channel Q
   </tr>
 </table>
 
+| Bits | Name | Description |
+|------|------|------------|
+| 15:0 | q | Constant to be used as OTF input for channel Q |
+
 ### Register: app.modulation.ftwH1main
 
-- **HDL name**: app_modulation_ftwH1main
-- **Address**: 0x100050
-- **Block Offset**: 0x50
-- **Access Mode**: rw
+- **HW Prefix**: app_modulation_ftwH1main
+- **HW Address**: 0x100050
+- **C Prefix**: app.modulation.ftwH1main
+- **C Block Offset**: 0x50
+- **Access**: read/write
 
 <table>
   <tr>
@@ -1380,12 +1350,17 @@ Constant to be used as OTF input for channel Q
   </tr>
 </table>
 
+| Bits | Name | Description |
+|------|------|------------|
+| 63:0 | ftwH1main |  |
+
 ### Register: app.modulation.ftwH1on
 
-- **HDL name**: app_modulation_ftwH1on
-- **Address**: 0x100058
-- **Block Offset**: 0x58
-- **Access Mode**: rw
+- **HW Prefix**: app_modulation_ftwH1on
+- **HW Address**: 0x100058
+- **C Prefix**: app.modulation.ftwH1on
+- **C Block Offset**: 0x58
+- **Access**: read/write
 
 <table>
   <tr>
@@ -1494,12 +1469,17 @@ Constant to be used as OTF input for channel Q
   </tr>
 </table>
 
+| Bits | Name | Description |
+|------|------|------------|
+| 63:0 | ftwH1on |  |
+
 ### Register: app.modulation.dftwH1slip0
 
-- **HDL name**: app_modulation_dftwH1slip0
-- **Address**: 0x100060
-- **Block Offset**: 0x60
-- **Access Mode**: rw
+- **HW Prefix**: app_modulation_dftwH1slip0
+- **HW Address**: 0x100060
+- **C Prefix**: app.modulation.dftwH1slip0
+- **C Block Offset**: 0x60
+- **Access**: read/write
 
 <table>
   <tr>
@@ -1556,12 +1536,17 @@ Constant to be used as OTF input for channel Q
   </tr>
 </table>
 
+| Bits | Name | Description |
+|------|------|------------|
+| 31:0 | dftwH1slip0 |  |
+
 ### Register: app.modulation.dftwH1slip1
 
-- **HDL name**: app_modulation_dftwH1slip1
-- **Address**: 0x100064
-- **Block Offset**: 0x64
-- **Access Mode**: rw
+- **HW Prefix**: app_modulation_dftwH1slip1
+- **HW Address**: 0x100064
+- **C Prefix**: app.modulation.dftwH1slip1
+- **C Block Offset**: 0x64
+- **Access**: read/write
 
 <table>
   <tr>
@@ -1618,12 +1603,17 @@ Constant to be used as OTF input for channel Q
   </tr>
 </table>
 
+| Bits | Name | Description |
+|------|------|------------|
+| 31:0 | dftwH1slip1 |  |
+
 ### Register: app.modulation.latches
 
-- **HDL name**: app_modulation_latches
-- **Address**: 0x100068
-- **Block Offset**: 0x68
-- **Access Mode**: rw
+- **HW Prefix**: app_modulation_latches
+- **HW Address**: 0x100068
+- **C Prefix**: app.modulation.latches
+- **C Block Offset**: 0x68
+- **Access**: read/write
 
 <table>
   <tr>
@@ -1701,18 +1691,19 @@ Constant to be used as OTF input for channel Q
   </tr>
 </table>
 
-#### Bit: backplane
-
-_(not documented)_
+| Bits | Name | Description |
+|------|------|------------|
+| 7:0 | backplane |  |
 
 ## Registers Description for Space bar4
 
 ### Register: fgc_ddr.data64.data64
 
-- **HDL name**: fgc_ddr_data64_data64
-- **Address**: 0x0
-- **Block Offset**: 0x0
-- **Access Mode**: rw
+- **HW Prefix**: fgc_ddr_data64_data64
+- **HW Address**: 0x0
+- **C Prefix**: fgc_ddr.data64.data64
+- **C Block Offset**: 0x0
+- **Access**: read/write
 
 <table>
   <tr>
@@ -1821,20 +1812,18 @@ _(not documented)_
   </tr>
 </table>
 
-#### Bit: upper
-
-_(not documented)_
-
-#### Bit: lower
-
-_(not documented)_
+| Bits | Name | Description |
+|------|------|------------|
+| 63:32 | upper |  |
+| 31:0 | lower |  |
 
 ### Register: acq_ddr.data32.data32
 
-- **HDL name**: acq_ddr_data32_data32
-- **Address**: 0x20000000
-- **Block Offset**: 0x0
-- **Access Mode**: rw
+- **HW Prefix**: acq_ddr_data32_data32
+- **HW Address**: 0x20000000
+- **C Prefix**: acq_ddr.data32.data32
+- **C Block Offset**: 0x0
+- **Access**: read/write
 
 <table>
   <tr>
@@ -1891,20 +1880,18 @@ _(not documented)_
   </tr>
 </table>
 
-#### Bit: upper
-
-_(not documented)_
-
-#### Bit: lower
-
-_(not documented)_
+| Bits | Name | Description |
+|------|------|------------|
+| 31:16 | upper |  |
+| 15:0 | lower |  |
 
 ### Register: acq_ram.data32.data32
 
-- **HDL name**: acq_ram_data32_data32
-- **Address**: 0x80000000
-- **Block Offset**: 0x0
-- **Access Mode**: rw
+- **HW Prefix**: acq_ram_data32_data32
+- **HW Address**: 0x80000000
+- **C Prefix**: acq_ram.data32.data32
+- **C Block Offset**: 0x0
+- **Access**: read/write
 
 <table>
   <tr>
@@ -1961,11 +1948,8 @@ _(not documented)_
   </tr>
 </table>
 
-#### Bit: upper
-
-_(not documented)_
-
-#### Bit: lower
-
-_(not documented)_
+| Bits | Name | Description |
+|------|------|------------|
+| 31:16 | upper |  |
+| 15:0 | lower |  |
 

--- a/testfiles/issue84/sps200CavityControl_as.md
+++ b/testfiles/issue84/sps200CavityControl_as.md
@@ -1,505 +1,412 @@
-== Memory map summary
+## Memory Map Summary
 Memory Map for SPS TWC200 Cavity Control
 
-== For space bar0
-|===
-|HW address | Type | Name | HDL name
+## For Space bar0
+| HW address | Type | Name | HDL Name |
+|------------|------|------|----------|
+| 0x000000-0x00001f | SUBMAP | hwInfo | hwInfo |
+| 0x000000 | REG | hwInfo.stdVersion | hwInfo_stdVersion |
+| 0x000008 | REG | hwInfo.serialNumber | hwInfo_serialNumber |
+| 0x000010 | REG | hwInfo.firmwareVersion | hwInfo_firmwareVersion |
+| 0x000014 | REG | hwInfo.memMapVersion | hwInfo_memMapVersion |
+| 0x000018 | REG | hwInfo.echo | hwInfo_echo |
+| 0x100000-0x17ffff | SUBMAP | app | app |
+| 0x100000-0x1003ff | SUBMAP | app.modulation | app_modulation |
+| 0x100000-0x10001f | SUBMAP | app.modulation.ipInfo | app_modulation_ipInfo |
+| 0x100000 | REG | app.modulation.ipInfo.stdVersion | app_modulation_ipInfo_stdVersion |
+| 0x100004 | REG | app.modulation.ipInfo.ident | app_modulation_ipInfo_ident |
+| 0x100008 | REG | app.modulation.ipInfo.firmwareVersion | app_modulation_ipInfo_firmwareVersion |
+| 0x10000c | REG | app.modulation.ipInfo.memMapVersion | app_modulation_ipInfo_memMapVersion |
+| 0x100010 | REG | app.modulation.ipInfo.echo | app_modulation_ipInfo_echo |
+| 0x100020 | REG | app.modulation.control | app_modulation_control |
+| 0x100030-0x10003f | BLOCK | app.modulation.testSignal | app_modulation_testSignal |
+| 0x100030 | REG | app.modulation.testSignal.amplitude | app_modulation_testSignal_amplitude |
+| 0x100038 | REG | app.modulation.testSignal.ftw | app_modulation_testSignal_ftw |
+| 0x100040-0x10004f | BLOCK | app.modulation.staticSignal | app_modulation_staticSignal |
+| 0x100040 | REG | app.modulation.staticSignal.i | app_modulation_staticSignal_i |
+| 0x100044 | REG | app.modulation.staticSignal.q | app_modulation_staticSignal_q |
+| 0x100050 | REG | app.modulation.ftwH1main | app_modulation_ftwH1main |
+| 0x100058 | REG | app.modulation.ftwH1on | app_modulation_ftwH1on |
+| 0x100060 | REG | app.modulation.dftwH1slip0 | app_modulation_dftwH1slip0 |
+| 0x100064 | REG | app.modulation.dftwH1slip1 | app_modulation_dftwH1slip1 |
+| 0x100068 | REG | app.modulation.latches | app_modulation_latches |
 
-|0x000000-0x00001f
-|SUBMAP
-|hwInfo
-|hwInfo
+## For Space bar4
+| HW address | Type | Name | HDL Name |
+|------------|------|------|----------|
+| 0x00000000-0x000fffff | SUBMAP | fgc_ddr | fgc_ddr |
+| 0x00000000-0x000fffff | MEMORY | fgc_ddr.data64 | fgc_ddr_data64 |
+|  +0x00000000 | REG | fgc_ddr.data64.data64 | fgc_ddr_data64_data64 |
+| 0x20000000-0x3fffffff | SUBMAP | acq_ddr | acq_ddr |
+| 0x20000000-0x3fffffff | MEMORY | acq_ddr.data32 | acq_ddr_data32 |
+|  +0x20000000 | REG | acq_ddr.data32.data32 | acq_ddr_data32_data32 |
+| 0x80000000-0x8001ffff | SUBMAP | acq_ram | acq_ram |
+| 0x80000000-0x8001ffff | MEMORY | acq_ram.data32 | acq_ram_data32 |
+|  +0x80000000 | REG | acq_ram.data32.data32 | acq_ram_data32_data32 |
 
-|0x000000
-|REG
-|hwInfo.stdVersion
-|hwInfo_stdVersion
+## Registers Description for Space bar0
 
-|0x000008
-|REG
-|hwInfo.serialNumber
-|hwInfo_serialNumber
+### Register: hwInfo.stdVersion
 
-|0x000010
-|REG
-|hwInfo.firmwareVersion
-|hwInfo_firmwareVersion
+- **HDL name**: hwInfo_stdVersion
+- **Address**: 0x0
+- **Block Offset**: 0x0
+- **Access Mode**: ro
 
-|0x000014
-|REG
-|hwInfo.memMapVersion
-|hwInfo_memMapVersion
+<table>
+  <tr>
+    <td><b>31</b></td>
+    <td><b>30</b></td>
+    <td><b>29</b></td>
+    <td><b>28</b></td>
+    <td><b>27</b></td>
+    <td><b>26</b></td>
+    <td><b>25</b></td>
+    <td><b>24</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">platform[7:0]</td>
+  </tr>
+  <tr>
+    <td><b>23</b></td>
+    <td><b>22</b></td>
+    <td><b>21</b></td>
+    <td><b>20</b></td>
+    <td><b>19</b></td>
+    <td><b>18</b></td>
+    <td><b>17</b></td>
+    <td><b>16</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">major[7:0]</td>
+  </tr>
+  <tr>
+    <td><b>15</b></td>
+    <td><b>14</b></td>
+    <td><b>13</b></td>
+    <td><b>12</b></td>
+    <td><b>11</b></td>
+    <td><b>10</b></td>
+    <td><b>9</b></td>
+    <td><b>8</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">minor[7:0]</td>
+  </tr>
+  <tr>
+    <td><b>7</b></td>
+    <td><b>6</b></td>
+    <td><b>5</b></td>
+    <td><b>4</b></td>
+    <td><b>3</b></td>
+    <td><b>2</b></td>
+    <td><b>1</b></td>
+    <td><b>0</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">patch[7:0]</td>
+  </tr>
+</table>
 
-|0x000018
-|REG
-|hwInfo.echo
-|hwInfo_echo
+#### Bit: platform
 
-|0x100000-0x17ffff
-|SUBMAP
-|app
-|app
-
-|0x100000-0x1003ff
-|SUBMAP
-|app.modulation
-|app_modulation
-
-|0x100000-0x10001f
-|SUBMAP
-|app.modulation.ipInfo
-|app_modulation_ipInfo
-
-|0x100000
-|REG
-|app.modulation.ipInfo.stdVersion
-|app_modulation_ipInfo_stdVersion
-
-|0x100004
-|REG
-|app.modulation.ipInfo.ident
-|app_modulation_ipInfo_ident
-
-|0x100008
-|REG
-|app.modulation.ipInfo.firmwareVersion
-|app_modulation_ipInfo_firmwareVersion
-
-|0x10000c
-|REG
-|app.modulation.ipInfo.memMapVersion
-|app_modulation_ipInfo_memMapVersion
-
-|0x100010
-|REG
-|app.modulation.ipInfo.echo
-|app_modulation_ipInfo_echo
-
-|0x100020
-|REG
-|app.modulation.control
-|app_modulation_control
-
-|0x100030-0x10003f
-|BLOCK
-|app.modulation.testSignal
-|app_modulation_testSignal
-
-|0x100030
-|REG
-|app.modulation.testSignal.amplitude
-|app_modulation_testSignal_amplitude
-
-|0x100038
-|REG
-|app.modulation.testSignal.ftw
-|app_modulation_testSignal_ftw
-
-|0x100040-0x10004f
-|BLOCK
-|app.modulation.staticSignal
-|app_modulation_staticSignal
-
-|0x100040
-|REG
-|app.modulation.staticSignal.i
-|app_modulation_staticSignal_i
-
-|0x100044
-|REG
-|app.modulation.staticSignal.q
-|app_modulation_staticSignal_q
-
-|0x100050
-|REG
-|app.modulation.ftwH1main
-|app_modulation_ftwH1main
-
-|0x100058
-|REG
-|app.modulation.ftwH1on
-|app_modulation_ftwH1on
-
-|0x100060
-|REG
-|app.modulation.dftwH1slip0
-|app_modulation_dftwH1slip0
-
-|0x100064
-|REG
-|app.modulation.dftwH1slip1
-|app_modulation_dftwH1slip1
-
-|0x100068
-|REG
-|app.modulation.latches
-|app_modulation_latches
-|===
-
-== For space bar4
-|===
-|HW address | Type | Name | HDL name
-
-|0x00000000-0x000fffff
-|SUBMAP
-|fgc_ddr
-|fgc_ddr
-
-|0x00000000-0x000fffff
-|MEMORY
-|fgc_ddr.data64
-|fgc_ddr_data64
-
-| +0x00000000
-|REG
-|fgc_ddr.data64.data64
-|fgc_ddr_data64_data64
-
-|0x20000000-0x3fffffff
-|SUBMAP
-|acq_ddr
-|acq_ddr
-
-|0x20000000-0x3fffffff
-|MEMORY
-|acq_ddr.data32
-|acq_ddr_data32
-
-| +0x20000000
-|REG
-|acq_ddr.data32.data32
-|acq_ddr_data32_data32
-
-|0x80000000-0x8001ffff
-|SUBMAP
-|acq_ram
-|acq_ram
-
-|0x80000000-0x8001ffff
-|MEMORY
-|acq_ram.data32
-|acq_ram_data32
-
-| +0x80000000
-|REG
-|acq_ram.data32.data32
-|acq_ram_data32_data32
-|===
-
-== Registers description for space bar0
-
-=== hwInfo.stdVersion
-[horizontal]
-HDL name:: hwInfo_stdVersion
-address:: 0x0
-block offset:: 0x0
-access mode:: ro
-
-[cols="8*^"]
-|===
-
-| 31
-| 30
-| 29
-| 28
-| 27
-| 26
-| 25
-| 24
-
-8+s| platform[7:0]
-
-| 23
-| 22
-| 21
-| 20
-| 19
-| 18
-| 17
-| 16
-
-8+s| major[7:0]
-
-| 15
-| 14
-| 13
-| 12
-| 11
-| 10
-| 9
-| 8
-
-8+s| minor[7:0]
-
-| 7
-| 6
-| 5
-| 4
-| 3
-| 2
-| 1
-| 0
-
-8+s| patch[7:0]
-|===
-
-platform::
 Identifying which platform the version belongs to (i.e. pci, lhc_vme, vme64, ...)
-major::
+
+#### Bit: major
+
 Major version indicating incompatible changes
-minor::
+
+#### Bit: minor
+
 Minor version indicating feature enhancements
-patch::
+
+#### Bit: patch
+
 Patch indicating bug fixes
 
-=== hwInfo.serialNumber
-[horizontal]
-HDL name:: hwInfo_serialNumber
-address:: 0x8
-block offset:: 0x8
-access mode:: ro
+### Register: hwInfo.serialNumber
 
 HW serial number
 
-[cols="8*^"]
-|===
+- **HDL name**: hwInfo_serialNumber
+- **Address**: 0x8
+- **Block Offset**: 0x8
+- **Access Mode**: ro
 
-| 63
-| 62
-| 61
-| 60
-| 59
-| 58
-| 57
-| 56
+<table>
+  <tr>
+    <td><b>63</b></td>
+    <td><b>62</b></td>
+    <td><b>61</b></td>
+    <td><b>60</b></td>
+    <td><b>59</b></td>
+    <td><b>58</b></td>
+    <td><b>57</b></td>
+    <td><b>56</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">serialNumber[63:56]</td>
+  </tr>
+  <tr>
+    <td><b>55</b></td>
+    <td><b>54</b></td>
+    <td><b>53</b></td>
+    <td><b>52</b></td>
+    <td><b>51</b></td>
+    <td><b>50</b></td>
+    <td><b>49</b></td>
+    <td><b>48</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">serialNumber[55:48]</td>
+  </tr>
+  <tr>
+    <td><b>47</b></td>
+    <td><b>46</b></td>
+    <td><b>45</b></td>
+    <td><b>44</b></td>
+    <td><b>43</b></td>
+    <td><b>42</b></td>
+    <td><b>41</b></td>
+    <td><b>40</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">serialNumber[47:40]</td>
+  </tr>
+  <tr>
+    <td><b>39</b></td>
+    <td><b>38</b></td>
+    <td><b>37</b></td>
+    <td><b>36</b></td>
+    <td><b>35</b></td>
+    <td><b>34</b></td>
+    <td><b>33</b></td>
+    <td><b>32</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">serialNumber[39:32]</td>
+  </tr>
+  <tr>
+    <td><b>31</b></td>
+    <td><b>30</b></td>
+    <td><b>29</b></td>
+    <td><b>28</b></td>
+    <td><b>27</b></td>
+    <td><b>26</b></td>
+    <td><b>25</b></td>
+    <td><b>24</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">serialNumber[31:24]</td>
+  </tr>
+  <tr>
+    <td><b>23</b></td>
+    <td><b>22</b></td>
+    <td><b>21</b></td>
+    <td><b>20</b></td>
+    <td><b>19</b></td>
+    <td><b>18</b></td>
+    <td><b>17</b></td>
+    <td><b>16</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">serialNumber[23:16]</td>
+  </tr>
+  <tr>
+    <td><b>15</b></td>
+    <td><b>14</b></td>
+    <td><b>13</b></td>
+    <td><b>12</b></td>
+    <td><b>11</b></td>
+    <td><b>10</b></td>
+    <td><b>9</b></td>
+    <td><b>8</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">serialNumber[15:8]</td>
+  </tr>
+  <tr>
+    <td><b>7</b></td>
+    <td><b>6</b></td>
+    <td><b>5</b></td>
+    <td><b>4</b></td>
+    <td><b>3</b></td>
+    <td><b>2</b></td>
+    <td><b>1</b></td>
+    <td><b>0</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">serialNumber[7:0]</td>
+  </tr>
+</table>
 
-8+s| serialNumber[63:56]
-
-| 55
-| 54
-| 53
-| 52
-| 51
-| 50
-| 49
-| 48
-
-8+s| serialNumber[55:48]
-
-| 47
-| 46
-| 45
-| 44
-| 43
-| 42
-| 41
-| 40
-
-8+s| serialNumber[47:40]
-
-| 39
-| 38
-| 37
-| 36
-| 35
-| 34
-| 33
-| 32
-
-8+s| serialNumber[39:32]
-
-| 31
-| 30
-| 29
-| 28
-| 27
-| 26
-| 25
-| 24
-
-8+s| serialNumber[31:24]
-
-| 23
-| 22
-| 21
-| 20
-| 19
-| 18
-| 17
-| 16
-
-8+s| serialNumber[23:16]
-
-| 15
-| 14
-| 13
-| 12
-| 11
-| 10
-| 9
-| 8
-
-8+s| serialNumber[15:8]
-
-| 7
-| 6
-| 5
-| 4
-| 3
-| 2
-| 1
-| 0
-
-8+s| serialNumber[7:0]
-|===
-=== hwInfo.firmwareVersion
-[horizontal]
-HDL name:: hwInfo_firmwareVersion
-address:: 0x10
-block offset:: 0x10
-access mode:: ro
+### Register: hwInfo.firmwareVersion
 
 Firmware Version
 
-[cols="8*^"]
-|===
+- **HDL name**: hwInfo_firmwareVersion
+- **Address**: 0x10
+- **Block Offset**: 0x10
+- **Access Mode**: ro
 
-| 31
-| 30
-| 29
-| 28
-| 27
-| 26
-| 25
-| 24
+<table>
+  <tr>
+    <td><b>31</b></td>
+    <td><b>30</b></td>
+    <td><b>29</b></td>
+    <td><b>28</b></td>
+    <td><b>27</b></td>
+    <td><b>26</b></td>
+    <td><b>25</b></td>
+    <td><b>24</b></td>
+  </tr>
+  <tr>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+  </tr>
+  <tr>
+    <td><b>23</b></td>
+    <td><b>22</b></td>
+    <td><b>21</b></td>
+    <td><b>20</b></td>
+    <td><b>19</b></td>
+    <td><b>18</b></td>
+    <td><b>17</b></td>
+    <td><b>16</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">major[7:0]</td>
+  </tr>
+  <tr>
+    <td><b>15</b></td>
+    <td><b>14</b></td>
+    <td><b>13</b></td>
+    <td><b>12</b></td>
+    <td><b>11</b></td>
+    <td><b>10</b></td>
+    <td><b>9</b></td>
+    <td><b>8</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">minor[7:0]</td>
+  </tr>
+  <tr>
+    <td><b>7</b></td>
+    <td><b>6</b></td>
+    <td><b>5</b></td>
+    <td><b>4</b></td>
+    <td><b>3</b></td>
+    <td><b>2</b></td>
+    <td><b>1</b></td>
+    <td><b>0</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">patch[7:0]</td>
+  </tr>
+</table>
 
-| -
-| -
-| -
-| -
-| -
-| -
-| -
-| -
+#### Bit: major
 
-| 23
-| 22
-| 21
-| 20
-| 19
-| 18
-| 17
-| 16
-
-8+s| major[7:0]
-
-| 15
-| 14
-| 13
-| 12
-| 11
-| 10
-| 9
-| 8
-
-8+s| minor[7:0]
-
-| 7
-| 6
-| 5
-| 4
-| 3
-| 2
-| 1
-| 0
-
-8+s| patch[7:0]
-|===
-
-major::
 Major version indicating incompatible changes
-minor::
+
+#### Bit: minor
+
 Minor version indicating feature enhancements
-patch::
+
+#### Bit: patch
+
 Patch indicating bug fixes
 
-=== hwInfo.memMapVersion
-[horizontal]
-HDL name:: hwInfo_memMapVersion
-address:: 0x14
-block offset:: 0x14
-access mode:: ro
+### Register: hwInfo.memMapVersion
 
 Memory Map Version
 
-[cols="8*^"]
-|===
+- **HDL name**: hwInfo_memMapVersion
+- **Address**: 0x14
+- **Block Offset**: 0x14
+- **Access Mode**: ro
 
-| 31
-| 30
-| 29
-| 28
-| 27
-| 26
-| 25
-| 24
+<table>
+  <tr>
+    <td><b>31</b></td>
+    <td><b>30</b></td>
+    <td><b>29</b></td>
+    <td><b>28</b></td>
+    <td><b>27</b></td>
+    <td><b>26</b></td>
+    <td><b>25</b></td>
+    <td><b>24</b></td>
+  </tr>
+  <tr>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+  </tr>
+  <tr>
+    <td><b>23</b></td>
+    <td><b>22</b></td>
+    <td><b>21</b></td>
+    <td><b>20</b></td>
+    <td><b>19</b></td>
+    <td><b>18</b></td>
+    <td><b>17</b></td>
+    <td><b>16</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">major[7:0]</td>
+  </tr>
+  <tr>
+    <td><b>15</b></td>
+    <td><b>14</b></td>
+    <td><b>13</b></td>
+    <td><b>12</b></td>
+    <td><b>11</b></td>
+    <td><b>10</b></td>
+    <td><b>9</b></td>
+    <td><b>8</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">minor[7:0]</td>
+  </tr>
+  <tr>
+    <td><b>7</b></td>
+    <td><b>6</b></td>
+    <td><b>5</b></td>
+    <td><b>4</b></td>
+    <td><b>3</b></td>
+    <td><b>2</b></td>
+    <td><b>1</b></td>
+    <td><b>0</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">patch[7:0]</td>
+  </tr>
+</table>
 
-| -
-| -
-| -
-| -
-| -
-| -
-| -
-| -
+#### Bit: major
 
-| 23
-| 22
-| 21
-| 20
-| 19
-| 18
-| 17
-| 16
+_(not documented)_
 
-8+s| major[7:0]
+#### Bit: minor
 
-| 15
-| 14
-| 13
-| 12
-| 11
-| 10
-| 9
-| 8
+_(not documented)_
 
-8+s| minor[7:0]
+#### Bit: patch
 
-| 7
-| 6
-| 5
-| 4
-| 3
-| 2
-| 1
-| 0
+_(not documented)_
 
-8+s| patch[7:0]
-|===
-
-major::
-(not documented)
-minor::
-(not documented)
-patch::
-(not documented)
-
-=== hwInfo.echo
-[horizontal]
-HDL name:: hwInfo_echo
-address:: 0x18
-block offset:: 0x18
-access mode:: rw
+### Register: hwInfo.echo
 
 Echo register. This version of the standard foresees only 8bits linked to real memory
 
@@ -517,326 +424,378 @@ If your initialization failed but you want to continue anyway you should set the
  +
 This register is in particular useful if you have several entities interacting with the hardware. In this case several bits could be assigned to this entities (bits 5..0) to signalize that they have done there part successful and a main entity checks all the expected bits.
 
-[cols="8*^"]
-|===
+- **HDL name**: hwInfo_echo
+- **Address**: 0x18
+- **Block Offset**: 0x18
+- **Access Mode**: rw
 
-| 31
-| 30
-| 29
-| 28
-| 27
-| 26
-| 25
-| 24
+<table>
+  <tr>
+    <td><b>31</b></td>
+    <td><b>30</b></td>
+    <td><b>29</b></td>
+    <td><b>28</b></td>
+    <td><b>27</b></td>
+    <td><b>26</b></td>
+    <td><b>25</b></td>
+    <td><b>24</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">echo[31:24]</td>
+  </tr>
+  <tr>
+    <td><b>23</b></td>
+    <td><b>22</b></td>
+    <td><b>21</b></td>
+    <td><b>20</b></td>
+    <td><b>19</b></td>
+    <td><b>18</b></td>
+    <td><b>17</b></td>
+    <td><b>16</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">echo[23:16]</td>
+  </tr>
+  <tr>
+    <td><b>15</b></td>
+    <td><b>14</b></td>
+    <td><b>13</b></td>
+    <td><b>12</b></td>
+    <td><b>11</b></td>
+    <td><b>10</b></td>
+    <td><b>9</b></td>
+    <td><b>8</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">echo[15:8]</td>
+  </tr>
+  <tr>
+    <td><b>7</b></td>
+    <td><b>6</b></td>
+    <td><b>5</b></td>
+    <td><b>4</b></td>
+    <td><b>3</b></td>
+    <td><b>2</b></td>
+    <td><b>1</b></td>
+    <td><b>0</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">echo[7:0]</td>
+  </tr>
+</table>
 
-8+s| echo[31:24]
+### Register: app.modulation.ipInfo.stdVersion
 
-| 23
-| 22
-| 21
-| 20
-| 19
-| 18
-| 17
-| 16
+- **HDL name**: app_modulation_ipInfo_stdVersion
+- **Address**: 0x100000
+- **Block Offset**: 0x0
+- **Access Mode**: ro
 
-8+s| echo[23:16]
+<table>
+  <tr>
+    <td><b>31</b></td>
+    <td><b>30</b></td>
+    <td><b>29</b></td>
+    <td><b>28</b></td>
+    <td><b>27</b></td>
+    <td><b>26</b></td>
+    <td><b>25</b></td>
+    <td><b>24</b></td>
+  </tr>
+  <tr>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+  </tr>
+  <tr>
+    <td><b>23</b></td>
+    <td><b>22</b></td>
+    <td><b>21</b></td>
+    <td><b>20</b></td>
+    <td><b>19</b></td>
+    <td><b>18</b></td>
+    <td><b>17</b></td>
+    <td><b>16</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">major[7:0]</td>
+  </tr>
+  <tr>
+    <td><b>15</b></td>
+    <td><b>14</b></td>
+    <td><b>13</b></td>
+    <td><b>12</b></td>
+    <td><b>11</b></td>
+    <td><b>10</b></td>
+    <td><b>9</b></td>
+    <td><b>8</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">minor[7:0]</td>
+  </tr>
+  <tr>
+    <td><b>7</b></td>
+    <td><b>6</b></td>
+    <td><b>5</b></td>
+    <td><b>4</b></td>
+    <td><b>3</b></td>
+    <td><b>2</b></td>
+    <td><b>1</b></td>
+    <td><b>0</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">patch[7:0]</td>
+  </tr>
+</table>
 
-| 15
-| 14
-| 13
-| 12
-| 11
-| 10
-| 9
-| 8
+#### Bit: major
 
-8+s| echo[15:8]
-
-| 7
-| 6
-| 5
-| 4
-| 3
-| 2
-| 1
-| 0
-
-8+s| echo[7:0]
-|===
-=== app.modulation.ipInfo.stdVersion
-[horizontal]
-HDL name:: app_modulation_ipInfo_stdVersion
-address:: 0x100000
-block offset:: 0x0
-access mode:: ro
-
-[cols="8*^"]
-|===
-
-| 31
-| 30
-| 29
-| 28
-| 27
-| 26
-| 25
-| 24
-
-| -
-| -
-| -
-| -
-| -
-| -
-| -
-| -
-
-| 23
-| 22
-| 21
-| 20
-| 19
-| 18
-| 17
-| 16
-
-8+s| major[7:0]
-
-| 15
-| 14
-| 13
-| 12
-| 11
-| 10
-| 9
-| 8
-
-8+s| minor[7:0]
-
-| 7
-| 6
-| 5
-| 4
-| 3
-| 2
-| 1
-| 0
-
-8+s| patch[7:0]
-|===
-
-major::
 Major version indicating incompatible changes
-minor::
+
+#### Bit: minor
+
 Minor version indicating feature enhancements
-patch::
+
+#### Bit: patch
+
 Patch indicating bug fixes
 
-=== app.modulation.ipInfo.ident
-[horizontal]
-HDL name:: app_modulation_ipInfo_ident
-address:: 0x100004
-block offset:: 0x4
-access mode:: ro
+### Register: app.modulation.ipInfo.ident
 
 IP Ident code
 
-[cols="8*^"]
-|===
+- **HDL name**: app_modulation_ipInfo_ident
+- **Address**: 0x100004
+- **Block Offset**: 0x4
+- **Access Mode**: ro
 
-| 31
-| 30
-| 29
-| 28
-| 27
-| 26
-| 25
-| 24
+<table>
+  <tr>
+    <td><b>31</b></td>
+    <td><b>30</b></td>
+    <td><b>29</b></td>
+    <td><b>28</b></td>
+    <td><b>27</b></td>
+    <td><b>26</b></td>
+    <td><b>25</b></td>
+    <td><b>24</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">ident[31:24]</td>
+  </tr>
+  <tr>
+    <td><b>23</b></td>
+    <td><b>22</b></td>
+    <td><b>21</b></td>
+    <td><b>20</b></td>
+    <td><b>19</b></td>
+    <td><b>18</b></td>
+    <td><b>17</b></td>
+    <td><b>16</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">ident[23:16]</td>
+  </tr>
+  <tr>
+    <td><b>15</b></td>
+    <td><b>14</b></td>
+    <td><b>13</b></td>
+    <td><b>12</b></td>
+    <td><b>11</b></td>
+    <td><b>10</b></td>
+    <td><b>9</b></td>
+    <td><b>8</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">ident[15:8]</td>
+  </tr>
+  <tr>
+    <td><b>7</b></td>
+    <td><b>6</b></td>
+    <td><b>5</b></td>
+    <td><b>4</b></td>
+    <td><b>3</b></td>
+    <td><b>2</b></td>
+    <td><b>1</b></td>
+    <td><b>0</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">ident[7:0]</td>
+  </tr>
+</table>
 
-8+s| ident[31:24]
-
-| 23
-| 22
-| 21
-| 20
-| 19
-| 18
-| 17
-| 16
-
-8+s| ident[23:16]
-
-| 15
-| 14
-| 13
-| 12
-| 11
-| 10
-| 9
-| 8
-
-8+s| ident[15:8]
-
-| 7
-| 6
-| 5
-| 4
-| 3
-| 2
-| 1
-| 0
-
-8+s| ident[7:0]
-|===
-=== app.modulation.ipInfo.firmwareVersion
-[horizontal]
-HDL name:: app_modulation_ipInfo_firmwareVersion
-address:: 0x100008
-block offset:: 0x8
-access mode:: ro
+### Register: app.modulation.ipInfo.firmwareVersion
 
 Firmware Version
 
-[cols="8*^"]
-|===
+- **HDL name**: app_modulation_ipInfo_firmwareVersion
+- **Address**: 0x100008
+- **Block Offset**: 0x8
+- **Access Mode**: ro
 
-| 31
-| 30
-| 29
-| 28
-| 27
-| 26
-| 25
-| 24
+<table>
+  <tr>
+    <td><b>31</b></td>
+    <td><b>30</b></td>
+    <td><b>29</b></td>
+    <td><b>28</b></td>
+    <td><b>27</b></td>
+    <td><b>26</b></td>
+    <td><b>25</b></td>
+    <td><b>24</b></td>
+  </tr>
+  <tr>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+  </tr>
+  <tr>
+    <td><b>23</b></td>
+    <td><b>22</b></td>
+    <td><b>21</b></td>
+    <td><b>20</b></td>
+    <td><b>19</b></td>
+    <td><b>18</b></td>
+    <td><b>17</b></td>
+    <td><b>16</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">major[7:0]</td>
+  </tr>
+  <tr>
+    <td><b>15</b></td>
+    <td><b>14</b></td>
+    <td><b>13</b></td>
+    <td><b>12</b></td>
+    <td><b>11</b></td>
+    <td><b>10</b></td>
+    <td><b>9</b></td>
+    <td><b>8</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">minor[7:0]</td>
+  </tr>
+  <tr>
+    <td><b>7</b></td>
+    <td><b>6</b></td>
+    <td><b>5</b></td>
+    <td><b>4</b></td>
+    <td><b>3</b></td>
+    <td><b>2</b></td>
+    <td><b>1</b></td>
+    <td><b>0</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">patch[7:0]</td>
+  </tr>
+</table>
 
-| -
-| -
-| -
-| -
-| -
-| -
-| -
-| -
+#### Bit: major
 
-| 23
-| 22
-| 21
-| 20
-| 19
-| 18
-| 17
-| 16
-
-8+s| major[7:0]
-
-| 15
-| 14
-| 13
-| 12
-| 11
-| 10
-| 9
-| 8
-
-8+s| minor[7:0]
-
-| 7
-| 6
-| 5
-| 4
-| 3
-| 2
-| 1
-| 0
-
-8+s| patch[7:0]
-|===
-
-major::
 Major version indicating incompatible changes
-minor::
+
+#### Bit: minor
+
 Minor version indicating feature enhancements
-patch::
+
+#### Bit: patch
+
 Patch indicating bug fixes
 
-=== app.modulation.ipInfo.memMapVersion
-[horizontal]
-HDL name:: app_modulation_ipInfo_memMapVersion
-address:: 0x10000c
-block offset:: 0xc
-access mode:: ro
+### Register: app.modulation.ipInfo.memMapVersion
 
 Memory Map Version
 
-[cols="8*^"]
-|===
+- **HDL name**: app_modulation_ipInfo_memMapVersion
+- **Address**: 0x10000c
+- **Block Offset**: 0xc
+- **Access Mode**: ro
 
-| 31
-| 30
-| 29
-| 28
-| 27
-| 26
-| 25
-| 24
+<table>
+  <tr>
+    <td><b>31</b></td>
+    <td><b>30</b></td>
+    <td><b>29</b></td>
+    <td><b>28</b></td>
+    <td><b>27</b></td>
+    <td><b>26</b></td>
+    <td><b>25</b></td>
+    <td><b>24</b></td>
+  </tr>
+  <tr>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+  </tr>
+  <tr>
+    <td><b>23</b></td>
+    <td><b>22</b></td>
+    <td><b>21</b></td>
+    <td><b>20</b></td>
+    <td><b>19</b></td>
+    <td><b>18</b></td>
+    <td><b>17</b></td>
+    <td><b>16</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">major[7:0]</td>
+  </tr>
+  <tr>
+    <td><b>15</b></td>
+    <td><b>14</b></td>
+    <td><b>13</b></td>
+    <td><b>12</b></td>
+    <td><b>11</b></td>
+    <td><b>10</b></td>
+    <td><b>9</b></td>
+    <td><b>8</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">minor[7:0]</td>
+  </tr>
+  <tr>
+    <td><b>7</b></td>
+    <td><b>6</b></td>
+    <td><b>5</b></td>
+    <td><b>4</b></td>
+    <td><b>3</b></td>
+    <td><b>2</b></td>
+    <td><b>1</b></td>
+    <td><b>0</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">patch[7:0]</td>
+  </tr>
+</table>
 
-| -
-| -
-| -
-| -
-| -
-| -
-| -
-| -
+#### Bit: major
 
-| 23
-| 22
-| 21
-| 20
-| 19
-| 18
-| 17
-| 16
-
-8+s| major[7:0]
-
-| 15
-| 14
-| 13
-| 12
-| 11
-| 10
-| 9
-| 8
-
-8+s| minor[7:0]
-
-| 7
-| 6
-| 5
-| 4
-| 3
-| 2
-| 1
-| 0
-
-8+s| patch[7:0]
-|===
-
-major::
 Major version indicating incompatible changes
-minor::
+
+#### Bit: minor
+
 Minor version indicating feature enhancements
-patch::
+
+#### Bit: patch
+
 Patch indicating bug fixes
 
-=== app.modulation.ipInfo.echo
-[horizontal]
-HDL name:: app_modulation_ipInfo_echo
-address:: 0x100010
-block offset:: 0x10
-access mode:: rw
+### Register: app.modulation.ipInfo.echo
 
 Echo register. This version of the standard foresees only 8bits linked to real memory
 
@@ -854,994 +813,1159 @@ If your initialization failed but you want to continue anyway you should set the
  +
 This register is in particular useful if you have several entities interacting with the hardware. In this case several bits could be assigned to this entities (bits 5..0) to signalize that they have done there part successful and a main entity checks all the expected bits.
 
-[cols="8*^"]
-|===
+- **HDL name**: app_modulation_ipInfo_echo
+- **Address**: 0x100010
+- **Block Offset**: 0x10
+- **Access Mode**: rw
 
-| 31
-| 30
-| 29
-| 28
-| 27
-| 26
-| 25
-| 24
+<table>
+  <tr>
+    <td><b>31</b></td>
+    <td><b>30</b></td>
+    <td><b>29</b></td>
+    <td><b>28</b></td>
+    <td><b>27</b></td>
+    <td><b>26</b></td>
+    <td><b>25</b></td>
+    <td><b>24</b></td>
+  </tr>
+  <tr>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+  </tr>
+  <tr>
+    <td><b>23</b></td>
+    <td><b>22</b></td>
+    <td><b>21</b></td>
+    <td><b>20</b></td>
+    <td><b>19</b></td>
+    <td><b>18</b></td>
+    <td><b>17</b></td>
+    <td><b>16</b></td>
+  </tr>
+  <tr>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+  </tr>
+  <tr>
+    <td><b>15</b></td>
+    <td><b>14</b></td>
+    <td><b>13</b></td>
+    <td><b>12</b></td>
+    <td><b>11</b></td>
+    <td><b>10</b></td>
+    <td><b>9</b></td>
+    <td><b>8</b></td>
+  </tr>
+  <tr>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+  </tr>
+  <tr>
+    <td><b>7</b></td>
+    <td><b>6</b></td>
+    <td><b>5</b></td>
+    <td><b>4</b></td>
+    <td><b>3</b></td>
+    <td><b>2</b></td>
+    <td><b>1</b></td>
+    <td><b>0</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">echo[7:0]</td>
+  </tr>
+</table>
 
-| -
-| -
-| -
-| -
-| -
-| -
-| -
-| -
+#### Bit: echo
 
-| 23
-| 22
-| 21
-| 20
-| 19
-| 18
-| 17
-| 16
-
-| -
-| -
-| -
-| -
-| -
-| -
-| -
-| -
-
-| 15
-| 14
-| 13
-| 12
-| 11
-| 10
-| 9
-| 8
-
-| -
-| -
-| -
-| -
-| -
-| -
-| -
-| -
-
-| 7
-| 6
-| 5
-| 4
-| 3
-| 2
-| 1
-| 0
-
-8+s| echo[7:0]
-|===
-
-echo::
 This version of the standard foresees only 8bits linked to real memory
 
-=== app.modulation.control
-[horizontal]
-HDL name:: app_modulation_control
-address:: 0x100020
-block offset:: 0x20
-access mode:: rw
+### Register: app.modulation.control
 
-[cols="8*^"]
-|===
+- **HDL name**: app_modulation_control
+- **Address**: 0x100020
+- **Block Offset**: 0x20
+- **Access Mode**: rw
 
-| 31
-| 30
-| 29
-| 28
-| 27
-| 26
-| 25
-| 24
+<table>
+  <tr>
+    <td><b>31</b></td>
+    <td><b>30</b></td>
+    <td><b>29</b></td>
+    <td><b>28</b></td>
+    <td><b>27</b></td>
+    <td><b>26</b></td>
+    <td><b>25</b></td>
+    <td><b>24</b></td>
+  </tr>
+  <tr>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+  </tr>
+  <tr>
+    <td><b>23</b></td>
+    <td><b>22</b></td>
+    <td><b>21</b></td>
+    <td><b>20</b></td>
+    <td><b>19</b></td>
+    <td><b>18</b></td>
+    <td><b>17</b></td>
+    <td><b>16</b></td>
+  </tr>
+  <tr>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+  </tr>
+  <tr>
+    <td><b>15</b></td>
+    <td><b>14</b></td>
+    <td><b>13</b></td>
+    <td><b>12</b></td>
+    <td><b>11</b></td>
+    <td><b>10</b></td>
+    <td><b>9</b></td>
+    <td><b>8</b></td>
+  </tr>
+  <tr>
+    <td>clearBPLatches</td>
+    <td colspan="3" style="text-align: center;">rate[2:0]</td>
+    <td>wrInputsValidLatch</td>
+    <td>wrRresetFSK</td>
+    <td>wrResetSlip</td>
+    <td>wrResetNCO</td>
+  </tr>
+  <tr>
+    <td><b>7</b></td>
+    <td><b>6</b></td>
+    <td><b>5</b></td>
+    <td><b>4</b></td>
+    <td><b>3</b></td>
+    <td><b>2</b></td>
+    <td><b>1</b></td>
+    <td><b>0</b></td>
+  </tr>
+  <tr>
+    <td>wrInputsValid</td>
+    <td>bypassMod</td>
+    <td>bypassDemod</td>
+    <td>-</td>
+    <td>-</td>
+    <td>useStaticSignal</td>
+    <td>useImpulse</td>
+    <td>useTestSignal</td>
+  </tr>
+</table>
 
-| -
-| -
-| -
-| -
-| -
-| -
-| -
-| -
+#### Bit: useTestSignal
 
-| 23
-| 22
-| 21
-| 20
-| 19
-| 18
-| 17
-| 16
-
-| -
-| -
-| -
-| -
-| -
-| -
-| -
-| -
-
-| 15
-| 14
-| 13
-| 12
-| 11
-| 10
-| 9
-| 8
-
-s| clearBPLatches
-3+s| rate[2:0]
-s| wrInputsValidLatch
-s| wrRresetFSK
-s| wrResetSlip
-s| wrResetNCO
-
-| 7
-| 6
-| 5
-| 4
-| 3
-| 2
-| 1
-| 0
-
-s| wrInputsValid
-s| bypassMod
-s| bypassDemod
-| -
-| -
-s| useStaticSignal
-s| useImpulse
-s| useTestSignal
-|===
-
-useTestSignal::
 Use DDS generated test signal instead of ADC input as demodulation input
-+
-Test signal is synthezied with additional internal DDS, test signals frequency given by ftw_RF.
-useImpulse::
-Use impulse instead of demodulation output
-useStaticSignal::
-Use static signal from register instead of demodulation output
-bypassDemod::
-Bypass demodulator
-bypassMod::
-Bypass modulator
-wrInputsValid::
-transmit WR frame
-wrInputsValidLatch::
-transmit WR no autoclear
-wrResetNCO::
-activate WR frame control bit
-wrResetSlip::
-activate WR frame control bit
-wrRresetFSK::
-activate WR frame control bit
-rate::
-(not documented)
-clearBPLatches::
-(not documented)
 
-=== app.modulation.testSignal.amplitude
-[horizontal]
-HDL name:: app_modulation_testSignal_amplitude
-address:: 0x100030
-block offset:: 0x0
-access mode:: rw
+Test signal is synthezied with additional internal DDS, test signals frequency given by ftw_RF.
+
+#### Bit: useImpulse
+
+Use impulse instead of demodulation output
+
+#### Bit: useStaticSignal
+
+Use static signal from register instead of demodulation output
+
+#### Bit: bypassDemod
+
+Bypass demodulator
+
+#### Bit: bypassMod
+
+Bypass modulator
+
+#### Bit: wrInputsValid
+
+transmit WR frame
+
+#### Bit: wrInputsValidLatch
+
+transmit WR no autoclear
+
+#### Bit: wrResetNCO
+
+activate WR frame control bit
+
+#### Bit: wrResetSlip
+
+activate WR frame control bit
+
+#### Bit: wrRresetFSK
+
+activate WR frame control bit
+
+#### Bit: rate
+
+_(not documented)_
+
+#### Bit: clearBPLatches
+
+_(not documented)_
+
+### Register: app.modulation.testSignal.amplitude
 
 Amplitude for the test signal
 
-[cols="8*^"]
-|===
+- **HDL name**: app_modulation_testSignal_amplitude
+- **Address**: 0x100030
+- **Block Offset**: 0x0
+- **Access Mode**: rw
 
-| 15
-| 14
-| 13
-| 12
-| 11
-| 10
-| 9
-| 8
+<table>
+  <tr>
+    <td><b>15</b></td>
+    <td><b>14</b></td>
+    <td><b>13</b></td>
+    <td><b>12</b></td>
+    <td><b>11</b></td>
+    <td><b>10</b></td>
+    <td><b>9</b></td>
+    <td><b>8</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">amplitude[15:8]</td>
+  </tr>
+  <tr>
+    <td><b>7</b></td>
+    <td><b>6</b></td>
+    <td><b>5</b></td>
+    <td><b>4</b></td>
+    <td><b>3</b></td>
+    <td><b>2</b></td>
+    <td><b>1</b></td>
+    <td><b>0</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">amplitude[7:0]</td>
+  </tr>
+</table>
 
-8+s| amplitude[15:8]
-
-| 7
-| 6
-| 5
-| 4
-| 3
-| 2
-| 1
-| 0
-
-8+s| amplitude[7:0]
-|===
-=== app.modulation.testSignal.ftw
-[horizontal]
-HDL name:: app_modulation_testSignal_ftw
-address:: 0x100038
-block offset:: 0x8
-access mode:: rw
+### Register: app.modulation.testSignal.ftw
 
 FTW of the test signal (frequency relative to fs)
 
-[cols="8*^"]
-|===
+- **HDL name**: app_modulation_testSignal_ftw
+- **Address**: 0x100038
+- **Block Offset**: 0x8
+- **Access Mode**: rw
 
-| 63
-| 62
-| 61
-| 60
-| 59
-| 58
-| 57
-| 56
+<table>
+  <tr>
+    <td><b>63</b></td>
+    <td><b>62</b></td>
+    <td><b>61</b></td>
+    <td><b>60</b></td>
+    <td><b>59</b></td>
+    <td><b>58</b></td>
+    <td><b>57</b></td>
+    <td><b>56</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">ftw[63:56]</td>
+  </tr>
+  <tr>
+    <td><b>55</b></td>
+    <td><b>54</b></td>
+    <td><b>53</b></td>
+    <td><b>52</b></td>
+    <td><b>51</b></td>
+    <td><b>50</b></td>
+    <td><b>49</b></td>
+    <td><b>48</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">ftw[55:48]</td>
+  </tr>
+  <tr>
+    <td><b>47</b></td>
+    <td><b>46</b></td>
+    <td><b>45</b></td>
+    <td><b>44</b></td>
+    <td><b>43</b></td>
+    <td><b>42</b></td>
+    <td><b>41</b></td>
+    <td><b>40</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">ftw[47:40]</td>
+  </tr>
+  <tr>
+    <td><b>39</b></td>
+    <td><b>38</b></td>
+    <td><b>37</b></td>
+    <td><b>36</b></td>
+    <td><b>35</b></td>
+    <td><b>34</b></td>
+    <td><b>33</b></td>
+    <td><b>32</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">ftw[39:32]</td>
+  </tr>
+  <tr>
+    <td><b>31</b></td>
+    <td><b>30</b></td>
+    <td><b>29</b></td>
+    <td><b>28</b></td>
+    <td><b>27</b></td>
+    <td><b>26</b></td>
+    <td><b>25</b></td>
+    <td><b>24</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">ftw[31:24]</td>
+  </tr>
+  <tr>
+    <td><b>23</b></td>
+    <td><b>22</b></td>
+    <td><b>21</b></td>
+    <td><b>20</b></td>
+    <td><b>19</b></td>
+    <td><b>18</b></td>
+    <td><b>17</b></td>
+    <td><b>16</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">ftw[23:16]</td>
+  </tr>
+  <tr>
+    <td><b>15</b></td>
+    <td><b>14</b></td>
+    <td><b>13</b></td>
+    <td><b>12</b></td>
+    <td><b>11</b></td>
+    <td><b>10</b></td>
+    <td><b>9</b></td>
+    <td><b>8</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">ftw[15:8]</td>
+  </tr>
+  <tr>
+    <td><b>7</b></td>
+    <td><b>6</b></td>
+    <td><b>5</b></td>
+    <td><b>4</b></td>
+    <td><b>3</b></td>
+    <td><b>2</b></td>
+    <td><b>1</b></td>
+    <td><b>0</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">ftw[7:0]</td>
+  </tr>
+</table>
 
-8+s| ftw[63:56]
-
-| 55
-| 54
-| 53
-| 52
-| 51
-| 50
-| 49
-| 48
-
-8+s| ftw[55:48]
-
-| 47
-| 46
-| 45
-| 44
-| 43
-| 42
-| 41
-| 40
-
-8+s| ftw[47:40]
-
-| 39
-| 38
-| 37
-| 36
-| 35
-| 34
-| 33
-| 32
-
-8+s| ftw[39:32]
-
-| 31
-| 30
-| 29
-| 28
-| 27
-| 26
-| 25
-| 24
-
-8+s| ftw[31:24]
-
-| 23
-| 22
-| 21
-| 20
-| 19
-| 18
-| 17
-| 16
-
-8+s| ftw[23:16]
-
-| 15
-| 14
-| 13
-| 12
-| 11
-| 10
-| 9
-| 8
-
-8+s| ftw[15:8]
-
-| 7
-| 6
-| 5
-| 4
-| 3
-| 2
-| 1
-| 0
-
-8+s| ftw[7:0]
-|===
-=== app.modulation.staticSignal.i
-[horizontal]
-HDL name:: app_modulation_staticSignal_i
-address:: 0x100040
-block offset:: 0x0
-access mode:: rw
+### Register: app.modulation.staticSignal.i
 
 Constant to be used as OTF input for channel I
 
-[cols="8*^"]
-|===
+- **HDL name**: app_modulation_staticSignal_i
+- **Address**: 0x100040
+- **Block Offset**: 0x0
+- **Access Mode**: rw
 
-| 15
-| 14
-| 13
-| 12
-| 11
-| 10
-| 9
-| 8
+<table>
+  <tr>
+    <td><b>15</b></td>
+    <td><b>14</b></td>
+    <td><b>13</b></td>
+    <td><b>12</b></td>
+    <td><b>11</b></td>
+    <td><b>10</b></td>
+    <td><b>9</b></td>
+    <td><b>8</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">i[15:8]</td>
+  </tr>
+  <tr>
+    <td><b>7</b></td>
+    <td><b>6</b></td>
+    <td><b>5</b></td>
+    <td><b>4</b></td>
+    <td><b>3</b></td>
+    <td><b>2</b></td>
+    <td><b>1</b></td>
+    <td><b>0</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">i[7:0]</td>
+  </tr>
+</table>
 
-8+s| i[15:8]
-
-| 7
-| 6
-| 5
-| 4
-| 3
-| 2
-| 1
-| 0
-
-8+s| i[7:0]
-|===
-=== app.modulation.staticSignal.q
-[horizontal]
-HDL name:: app_modulation_staticSignal_q
-address:: 0x100044
-block offset:: 0x4
-access mode:: rw
+### Register: app.modulation.staticSignal.q
 
 Constant to be used as OTF input for channel Q
 
-[cols="8*^"]
-|===
-
-| 15
-| 14
-| 13
-| 12
-| 11
-| 10
-| 9
-| 8
-
-8+s| q[15:8]
-
-| 7
-| 6
-| 5
-| 4
-| 3
-| 2
-| 1
-| 0
-
-8+s| q[7:0]
-|===
-=== app.modulation.ftwH1main
-[horizontal]
-HDL name:: app_modulation_ftwH1main
-address:: 0x100050
-block offset:: 0x50
-access mode:: rw
-
-[cols="8*^"]
-|===
-
-| 63
-| 62
-| 61
-| 60
-| 59
-| 58
-| 57
-| 56
-
-8+s| ftwH1main[63:56]
-
-| 55
-| 54
-| 53
-| 52
-| 51
-| 50
-| 49
-| 48
-
-8+s| ftwH1main[55:48]
-
-| 47
-| 46
-| 45
-| 44
-| 43
-| 42
-| 41
-| 40
-
-8+s| ftwH1main[47:40]
-
-| 39
-| 38
-| 37
-| 36
-| 35
-| 34
-| 33
-| 32
-
-8+s| ftwH1main[39:32]
-
-| 31
-| 30
-| 29
-| 28
-| 27
-| 26
-| 25
-| 24
-
-8+s| ftwH1main[31:24]
-
-| 23
-| 22
-| 21
-| 20
-| 19
-| 18
-| 17
-| 16
-
-8+s| ftwH1main[23:16]
-
-| 15
-| 14
-| 13
-| 12
-| 11
-| 10
-| 9
-| 8
-
-8+s| ftwH1main[15:8]
-
-| 7
-| 6
-| 5
-| 4
-| 3
-| 2
-| 1
-| 0
-
-8+s| ftwH1main[7:0]
-|===
-=== app.modulation.ftwH1on
-[horizontal]
-HDL name:: app_modulation_ftwH1on
-address:: 0x100058
-block offset:: 0x58
-access mode:: rw
-
-[cols="8*^"]
-|===
-
-| 63
-| 62
-| 61
-| 60
-| 59
-| 58
-| 57
-| 56
-
-8+s| ftwH1on[63:56]
-
-| 55
-| 54
-| 53
-| 52
-| 51
-| 50
-| 49
-| 48
-
-8+s| ftwH1on[55:48]
-
-| 47
-| 46
-| 45
-| 44
-| 43
-| 42
-| 41
-| 40
-
-8+s| ftwH1on[47:40]
-
-| 39
-| 38
-| 37
-| 36
-| 35
-| 34
-| 33
-| 32
-
-8+s| ftwH1on[39:32]
-
-| 31
-| 30
-| 29
-| 28
-| 27
-| 26
-| 25
-| 24
-
-8+s| ftwH1on[31:24]
-
-| 23
-| 22
-| 21
-| 20
-| 19
-| 18
-| 17
-| 16
-
-8+s| ftwH1on[23:16]
-
-| 15
-| 14
-| 13
-| 12
-| 11
-| 10
-| 9
-| 8
-
-8+s| ftwH1on[15:8]
-
-| 7
-| 6
-| 5
-| 4
-| 3
-| 2
-| 1
-| 0
-
-8+s| ftwH1on[7:0]
-|===
-=== app.modulation.dftwH1slip0
-[horizontal]
-HDL name:: app_modulation_dftwH1slip0
-address:: 0x100060
-block offset:: 0x60
-access mode:: rw
-
-[cols="8*^"]
-|===
-
-| 31
-| 30
-| 29
-| 28
-| 27
-| 26
-| 25
-| 24
-
-8+s| dftwH1slip0[31:24]
-
-| 23
-| 22
-| 21
-| 20
-| 19
-| 18
-| 17
-| 16
-
-8+s| dftwH1slip0[23:16]
-
-| 15
-| 14
-| 13
-| 12
-| 11
-| 10
-| 9
-| 8
-
-8+s| dftwH1slip0[15:8]
-
-| 7
-| 6
-| 5
-| 4
-| 3
-| 2
-| 1
-| 0
-
-8+s| dftwH1slip0[7:0]
-|===
-=== app.modulation.dftwH1slip1
-[horizontal]
-HDL name:: app_modulation_dftwH1slip1
-address:: 0x100064
-block offset:: 0x64
-access mode:: rw
-
-[cols="8*^"]
-|===
-
-| 31
-| 30
-| 29
-| 28
-| 27
-| 26
-| 25
-| 24
-
-8+s| dftwH1slip1[31:24]
-
-| 23
-| 22
-| 21
-| 20
-| 19
-| 18
-| 17
-| 16
-
-8+s| dftwH1slip1[23:16]
-
-| 15
-| 14
-| 13
-| 12
-| 11
-| 10
-| 9
-| 8
-
-8+s| dftwH1slip1[15:8]
-
-| 7
-| 6
-| 5
-| 4
-| 3
-| 2
-| 1
-| 0
-
-8+s| dftwH1slip1[7:0]
-|===
-=== app.modulation.latches
-[horizontal]
-HDL name:: app_modulation_latches
-address:: 0x100068
-block offset:: 0x68
-access mode:: rw
-
-[cols="8*^"]
-|===
-
-| 31
-| 30
-| 29
-| 28
-| 27
-| 26
-| 25
-| 24
-
-| -
-| -
-| -
-| -
-| -
-| -
-| -
-| -
-
-| 23
-| 22
-| 21
-| 20
-| 19
-| 18
-| 17
-| 16
-
-| -
-| -
-| -
-| -
-| -
-| -
-| -
-| -
-
-| 15
-| 14
-| 13
-| 12
-| 11
-| 10
-| 9
-| 8
-
-| -
-| -
-| -
-| -
-| -
-| -
-| -
-| -
-
-| 7
-| 6
-| 5
-| 4
-| 3
-| 2
-| 1
-| 0
-
-8+s| backplane[7:0]
-|===
-
-backplane::
-(not documented)
-
-== Registers description for space bar4
-
-=== fgc_ddr.data64.data64
-[horizontal]
-HDL name:: fgc_ddr_data64_data64
-address:: 0x0
-block offset:: 0x0
-access mode:: rw
-
-[cols="8*^"]
-|===
-
-| 63
-| 62
-| 61
-| 60
-| 59
-| 58
-| 57
-| 56
-
-8+s| upper[31:24]
-
-| 55
-| 54
-| 53
-| 52
-| 51
-| 50
-| 49
-| 48
-
-8+s| upper[23:16]
-
-| 47
-| 46
-| 45
-| 44
-| 43
-| 42
-| 41
-| 40
-
-8+s| upper[15:8]
-
-| 39
-| 38
-| 37
-| 36
-| 35
-| 34
-| 33
-| 32
-
-8+s| upper[7:0]
-
-| 31
-| 30
-| 29
-| 28
-| 27
-| 26
-| 25
-| 24
-
-8+s| lower[31:24]
-
-| 23
-| 22
-| 21
-| 20
-| 19
-| 18
-| 17
-| 16
-
-8+s| lower[23:16]
-
-| 15
-| 14
-| 13
-| 12
-| 11
-| 10
-| 9
-| 8
-
-8+s| lower[15:8]
-
-| 7
-| 6
-| 5
-| 4
-| 3
-| 2
-| 1
-| 0
-
-8+s| lower[7:0]
-|===
-
-upper::
-(not documented)
-lower::
-(not documented)
-
-=== acq_ddr.data32.data32
-[horizontal]
-HDL name:: acq_ddr_data32_data32
-address:: 0x20000000
-block offset:: 0x0
-access mode:: rw
-
-[cols="8*^"]
-|===
-
-| 31
-| 30
-| 29
-| 28
-| 27
-| 26
-| 25
-| 24
-
-8+s| upper[15:8]
-
-| 23
-| 22
-| 21
-| 20
-| 19
-| 18
-| 17
-| 16
-
-8+s| upper[7:0]
-
-| 15
-| 14
-| 13
-| 12
-| 11
-| 10
-| 9
-| 8
-
-8+s| lower[15:8]
-
-| 7
-| 6
-| 5
-| 4
-| 3
-| 2
-| 1
-| 0
-
-8+s| lower[7:0]
-|===
-
-upper::
-(not documented)
-lower::
-(not documented)
-
-=== acq_ram.data32.data32
-[horizontal]
-HDL name:: acq_ram_data32_data32
-address:: 0x80000000
-block offset:: 0x0
-access mode:: rw
-
-[cols="8*^"]
-|===
-
-| 31
-| 30
-| 29
-| 28
-| 27
-| 26
-| 25
-| 24
-
-8+s| upper[15:8]
-
-| 23
-| 22
-| 21
-| 20
-| 19
-| 18
-| 17
-| 16
-
-8+s| upper[7:0]
-
-| 15
-| 14
-| 13
-| 12
-| 11
-| 10
-| 9
-| 8
-
-8+s| lower[15:8]
-
-| 7
-| 6
-| 5
-| 4
-| 3
-| 2
-| 1
-| 0
-
-8+s| lower[7:0]
-|===
-
-upper::
-(not documented)
-lower::
-(not documented)
+- **HDL name**: app_modulation_staticSignal_q
+- **Address**: 0x100044
+- **Block Offset**: 0x4
+- **Access Mode**: rw
+
+<table>
+  <tr>
+    <td><b>15</b></td>
+    <td><b>14</b></td>
+    <td><b>13</b></td>
+    <td><b>12</b></td>
+    <td><b>11</b></td>
+    <td><b>10</b></td>
+    <td><b>9</b></td>
+    <td><b>8</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">q[15:8]</td>
+  </tr>
+  <tr>
+    <td><b>7</b></td>
+    <td><b>6</b></td>
+    <td><b>5</b></td>
+    <td><b>4</b></td>
+    <td><b>3</b></td>
+    <td><b>2</b></td>
+    <td><b>1</b></td>
+    <td><b>0</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">q[7:0]</td>
+  </tr>
+</table>
+
+### Register: app.modulation.ftwH1main
+
+- **HDL name**: app_modulation_ftwH1main
+- **Address**: 0x100050
+- **Block Offset**: 0x50
+- **Access Mode**: rw
+
+<table>
+  <tr>
+    <td><b>63</b></td>
+    <td><b>62</b></td>
+    <td><b>61</b></td>
+    <td><b>60</b></td>
+    <td><b>59</b></td>
+    <td><b>58</b></td>
+    <td><b>57</b></td>
+    <td><b>56</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">ftwH1main[63:56]</td>
+  </tr>
+  <tr>
+    <td><b>55</b></td>
+    <td><b>54</b></td>
+    <td><b>53</b></td>
+    <td><b>52</b></td>
+    <td><b>51</b></td>
+    <td><b>50</b></td>
+    <td><b>49</b></td>
+    <td><b>48</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">ftwH1main[55:48]</td>
+  </tr>
+  <tr>
+    <td><b>47</b></td>
+    <td><b>46</b></td>
+    <td><b>45</b></td>
+    <td><b>44</b></td>
+    <td><b>43</b></td>
+    <td><b>42</b></td>
+    <td><b>41</b></td>
+    <td><b>40</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">ftwH1main[47:40]</td>
+  </tr>
+  <tr>
+    <td><b>39</b></td>
+    <td><b>38</b></td>
+    <td><b>37</b></td>
+    <td><b>36</b></td>
+    <td><b>35</b></td>
+    <td><b>34</b></td>
+    <td><b>33</b></td>
+    <td><b>32</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">ftwH1main[39:32]</td>
+  </tr>
+  <tr>
+    <td><b>31</b></td>
+    <td><b>30</b></td>
+    <td><b>29</b></td>
+    <td><b>28</b></td>
+    <td><b>27</b></td>
+    <td><b>26</b></td>
+    <td><b>25</b></td>
+    <td><b>24</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">ftwH1main[31:24]</td>
+  </tr>
+  <tr>
+    <td><b>23</b></td>
+    <td><b>22</b></td>
+    <td><b>21</b></td>
+    <td><b>20</b></td>
+    <td><b>19</b></td>
+    <td><b>18</b></td>
+    <td><b>17</b></td>
+    <td><b>16</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">ftwH1main[23:16]</td>
+  </tr>
+  <tr>
+    <td><b>15</b></td>
+    <td><b>14</b></td>
+    <td><b>13</b></td>
+    <td><b>12</b></td>
+    <td><b>11</b></td>
+    <td><b>10</b></td>
+    <td><b>9</b></td>
+    <td><b>8</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">ftwH1main[15:8]</td>
+  </tr>
+  <tr>
+    <td><b>7</b></td>
+    <td><b>6</b></td>
+    <td><b>5</b></td>
+    <td><b>4</b></td>
+    <td><b>3</b></td>
+    <td><b>2</b></td>
+    <td><b>1</b></td>
+    <td><b>0</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">ftwH1main[7:0]</td>
+  </tr>
+</table>
+
+### Register: app.modulation.ftwH1on
+
+- **HDL name**: app_modulation_ftwH1on
+- **Address**: 0x100058
+- **Block Offset**: 0x58
+- **Access Mode**: rw
+
+<table>
+  <tr>
+    <td><b>63</b></td>
+    <td><b>62</b></td>
+    <td><b>61</b></td>
+    <td><b>60</b></td>
+    <td><b>59</b></td>
+    <td><b>58</b></td>
+    <td><b>57</b></td>
+    <td><b>56</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">ftwH1on[63:56]</td>
+  </tr>
+  <tr>
+    <td><b>55</b></td>
+    <td><b>54</b></td>
+    <td><b>53</b></td>
+    <td><b>52</b></td>
+    <td><b>51</b></td>
+    <td><b>50</b></td>
+    <td><b>49</b></td>
+    <td><b>48</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">ftwH1on[55:48]</td>
+  </tr>
+  <tr>
+    <td><b>47</b></td>
+    <td><b>46</b></td>
+    <td><b>45</b></td>
+    <td><b>44</b></td>
+    <td><b>43</b></td>
+    <td><b>42</b></td>
+    <td><b>41</b></td>
+    <td><b>40</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">ftwH1on[47:40]</td>
+  </tr>
+  <tr>
+    <td><b>39</b></td>
+    <td><b>38</b></td>
+    <td><b>37</b></td>
+    <td><b>36</b></td>
+    <td><b>35</b></td>
+    <td><b>34</b></td>
+    <td><b>33</b></td>
+    <td><b>32</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">ftwH1on[39:32]</td>
+  </tr>
+  <tr>
+    <td><b>31</b></td>
+    <td><b>30</b></td>
+    <td><b>29</b></td>
+    <td><b>28</b></td>
+    <td><b>27</b></td>
+    <td><b>26</b></td>
+    <td><b>25</b></td>
+    <td><b>24</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">ftwH1on[31:24]</td>
+  </tr>
+  <tr>
+    <td><b>23</b></td>
+    <td><b>22</b></td>
+    <td><b>21</b></td>
+    <td><b>20</b></td>
+    <td><b>19</b></td>
+    <td><b>18</b></td>
+    <td><b>17</b></td>
+    <td><b>16</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">ftwH1on[23:16]</td>
+  </tr>
+  <tr>
+    <td><b>15</b></td>
+    <td><b>14</b></td>
+    <td><b>13</b></td>
+    <td><b>12</b></td>
+    <td><b>11</b></td>
+    <td><b>10</b></td>
+    <td><b>9</b></td>
+    <td><b>8</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">ftwH1on[15:8]</td>
+  </tr>
+  <tr>
+    <td><b>7</b></td>
+    <td><b>6</b></td>
+    <td><b>5</b></td>
+    <td><b>4</b></td>
+    <td><b>3</b></td>
+    <td><b>2</b></td>
+    <td><b>1</b></td>
+    <td><b>0</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">ftwH1on[7:0]</td>
+  </tr>
+</table>
+
+### Register: app.modulation.dftwH1slip0
+
+- **HDL name**: app_modulation_dftwH1slip0
+- **Address**: 0x100060
+- **Block Offset**: 0x60
+- **Access Mode**: rw
+
+<table>
+  <tr>
+    <td><b>31</b></td>
+    <td><b>30</b></td>
+    <td><b>29</b></td>
+    <td><b>28</b></td>
+    <td><b>27</b></td>
+    <td><b>26</b></td>
+    <td><b>25</b></td>
+    <td><b>24</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">dftwH1slip0[31:24]</td>
+  </tr>
+  <tr>
+    <td><b>23</b></td>
+    <td><b>22</b></td>
+    <td><b>21</b></td>
+    <td><b>20</b></td>
+    <td><b>19</b></td>
+    <td><b>18</b></td>
+    <td><b>17</b></td>
+    <td><b>16</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">dftwH1slip0[23:16]</td>
+  </tr>
+  <tr>
+    <td><b>15</b></td>
+    <td><b>14</b></td>
+    <td><b>13</b></td>
+    <td><b>12</b></td>
+    <td><b>11</b></td>
+    <td><b>10</b></td>
+    <td><b>9</b></td>
+    <td><b>8</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">dftwH1slip0[15:8]</td>
+  </tr>
+  <tr>
+    <td><b>7</b></td>
+    <td><b>6</b></td>
+    <td><b>5</b></td>
+    <td><b>4</b></td>
+    <td><b>3</b></td>
+    <td><b>2</b></td>
+    <td><b>1</b></td>
+    <td><b>0</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">dftwH1slip0[7:0]</td>
+  </tr>
+</table>
+
+### Register: app.modulation.dftwH1slip1
+
+- **HDL name**: app_modulation_dftwH1slip1
+- **Address**: 0x100064
+- **Block Offset**: 0x64
+- **Access Mode**: rw
+
+<table>
+  <tr>
+    <td><b>31</b></td>
+    <td><b>30</b></td>
+    <td><b>29</b></td>
+    <td><b>28</b></td>
+    <td><b>27</b></td>
+    <td><b>26</b></td>
+    <td><b>25</b></td>
+    <td><b>24</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">dftwH1slip1[31:24]</td>
+  </tr>
+  <tr>
+    <td><b>23</b></td>
+    <td><b>22</b></td>
+    <td><b>21</b></td>
+    <td><b>20</b></td>
+    <td><b>19</b></td>
+    <td><b>18</b></td>
+    <td><b>17</b></td>
+    <td><b>16</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">dftwH1slip1[23:16]</td>
+  </tr>
+  <tr>
+    <td><b>15</b></td>
+    <td><b>14</b></td>
+    <td><b>13</b></td>
+    <td><b>12</b></td>
+    <td><b>11</b></td>
+    <td><b>10</b></td>
+    <td><b>9</b></td>
+    <td><b>8</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">dftwH1slip1[15:8]</td>
+  </tr>
+  <tr>
+    <td><b>7</b></td>
+    <td><b>6</b></td>
+    <td><b>5</b></td>
+    <td><b>4</b></td>
+    <td><b>3</b></td>
+    <td><b>2</b></td>
+    <td><b>1</b></td>
+    <td><b>0</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">dftwH1slip1[7:0]</td>
+  </tr>
+</table>
+
+### Register: app.modulation.latches
+
+- **HDL name**: app_modulation_latches
+- **Address**: 0x100068
+- **Block Offset**: 0x68
+- **Access Mode**: rw
+
+<table>
+  <tr>
+    <td><b>31</b></td>
+    <td><b>30</b></td>
+    <td><b>29</b></td>
+    <td><b>28</b></td>
+    <td><b>27</b></td>
+    <td><b>26</b></td>
+    <td><b>25</b></td>
+    <td><b>24</b></td>
+  </tr>
+  <tr>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+  </tr>
+  <tr>
+    <td><b>23</b></td>
+    <td><b>22</b></td>
+    <td><b>21</b></td>
+    <td><b>20</b></td>
+    <td><b>19</b></td>
+    <td><b>18</b></td>
+    <td><b>17</b></td>
+    <td><b>16</b></td>
+  </tr>
+  <tr>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+  </tr>
+  <tr>
+    <td><b>15</b></td>
+    <td><b>14</b></td>
+    <td><b>13</b></td>
+    <td><b>12</b></td>
+    <td><b>11</b></td>
+    <td><b>10</b></td>
+    <td><b>9</b></td>
+    <td><b>8</b></td>
+  </tr>
+  <tr>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+  </tr>
+  <tr>
+    <td><b>7</b></td>
+    <td><b>6</b></td>
+    <td><b>5</b></td>
+    <td><b>4</b></td>
+    <td><b>3</b></td>
+    <td><b>2</b></td>
+    <td><b>1</b></td>
+    <td><b>0</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">backplane[7:0]</td>
+  </tr>
+</table>
+
+#### Bit: backplane
+
+_(not documented)_
+
+## Registers Description for Space bar4
+
+### Register: fgc_ddr.data64.data64
+
+- **HDL name**: fgc_ddr_data64_data64
+- **Address**: 0x0
+- **Block Offset**: 0x0
+- **Access Mode**: rw
+
+<table>
+  <tr>
+    <td><b>63</b></td>
+    <td><b>62</b></td>
+    <td><b>61</b></td>
+    <td><b>60</b></td>
+    <td><b>59</b></td>
+    <td><b>58</b></td>
+    <td><b>57</b></td>
+    <td><b>56</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">upper[31:24]</td>
+  </tr>
+  <tr>
+    <td><b>55</b></td>
+    <td><b>54</b></td>
+    <td><b>53</b></td>
+    <td><b>52</b></td>
+    <td><b>51</b></td>
+    <td><b>50</b></td>
+    <td><b>49</b></td>
+    <td><b>48</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">upper[23:16]</td>
+  </tr>
+  <tr>
+    <td><b>47</b></td>
+    <td><b>46</b></td>
+    <td><b>45</b></td>
+    <td><b>44</b></td>
+    <td><b>43</b></td>
+    <td><b>42</b></td>
+    <td><b>41</b></td>
+    <td><b>40</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">upper[15:8]</td>
+  </tr>
+  <tr>
+    <td><b>39</b></td>
+    <td><b>38</b></td>
+    <td><b>37</b></td>
+    <td><b>36</b></td>
+    <td><b>35</b></td>
+    <td><b>34</b></td>
+    <td><b>33</b></td>
+    <td><b>32</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">upper[7:0]</td>
+  </tr>
+  <tr>
+    <td><b>31</b></td>
+    <td><b>30</b></td>
+    <td><b>29</b></td>
+    <td><b>28</b></td>
+    <td><b>27</b></td>
+    <td><b>26</b></td>
+    <td><b>25</b></td>
+    <td><b>24</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">lower[31:24]</td>
+  </tr>
+  <tr>
+    <td><b>23</b></td>
+    <td><b>22</b></td>
+    <td><b>21</b></td>
+    <td><b>20</b></td>
+    <td><b>19</b></td>
+    <td><b>18</b></td>
+    <td><b>17</b></td>
+    <td><b>16</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">lower[23:16]</td>
+  </tr>
+  <tr>
+    <td><b>15</b></td>
+    <td><b>14</b></td>
+    <td><b>13</b></td>
+    <td><b>12</b></td>
+    <td><b>11</b></td>
+    <td><b>10</b></td>
+    <td><b>9</b></td>
+    <td><b>8</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">lower[15:8]</td>
+  </tr>
+  <tr>
+    <td><b>7</b></td>
+    <td><b>6</b></td>
+    <td><b>5</b></td>
+    <td><b>4</b></td>
+    <td><b>3</b></td>
+    <td><b>2</b></td>
+    <td><b>1</b></td>
+    <td><b>0</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">lower[7:0]</td>
+  </tr>
+</table>
+
+#### Bit: upper
+
+_(not documented)_
+
+#### Bit: lower
+
+_(not documented)_
+
+### Register: acq_ddr.data32.data32
+
+- **HDL name**: acq_ddr_data32_data32
+- **Address**: 0x20000000
+- **Block Offset**: 0x0
+- **Access Mode**: rw
+
+<table>
+  <tr>
+    <td><b>31</b></td>
+    <td><b>30</b></td>
+    <td><b>29</b></td>
+    <td><b>28</b></td>
+    <td><b>27</b></td>
+    <td><b>26</b></td>
+    <td><b>25</b></td>
+    <td><b>24</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">upper[15:8]</td>
+  </tr>
+  <tr>
+    <td><b>23</b></td>
+    <td><b>22</b></td>
+    <td><b>21</b></td>
+    <td><b>20</b></td>
+    <td><b>19</b></td>
+    <td><b>18</b></td>
+    <td><b>17</b></td>
+    <td><b>16</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">upper[7:0]</td>
+  </tr>
+  <tr>
+    <td><b>15</b></td>
+    <td><b>14</b></td>
+    <td><b>13</b></td>
+    <td><b>12</b></td>
+    <td><b>11</b></td>
+    <td><b>10</b></td>
+    <td><b>9</b></td>
+    <td><b>8</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">lower[15:8]</td>
+  </tr>
+  <tr>
+    <td><b>7</b></td>
+    <td><b>6</b></td>
+    <td><b>5</b></td>
+    <td><b>4</b></td>
+    <td><b>3</b></td>
+    <td><b>2</b></td>
+    <td><b>1</b></td>
+    <td><b>0</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">lower[7:0]</td>
+  </tr>
+</table>
+
+#### Bit: upper
+
+_(not documented)_
+
+#### Bit: lower
+
+_(not documented)_
+
+### Register: acq_ram.data32.data32
+
+- **HDL name**: acq_ram_data32_data32
+- **Address**: 0x80000000
+- **Block Offset**: 0x0
+- **Access Mode**: rw
+
+<table>
+  <tr>
+    <td><b>31</b></td>
+    <td><b>30</b></td>
+    <td><b>29</b></td>
+    <td><b>28</b></td>
+    <td><b>27</b></td>
+    <td><b>26</b></td>
+    <td><b>25</b></td>
+    <td><b>24</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">upper[15:8]</td>
+  </tr>
+  <tr>
+    <td><b>23</b></td>
+    <td><b>22</b></td>
+    <td><b>21</b></td>
+    <td><b>20</b></td>
+    <td><b>19</b></td>
+    <td><b>18</b></td>
+    <td><b>17</b></td>
+    <td><b>16</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">upper[7:0]</td>
+  </tr>
+  <tr>
+    <td><b>15</b></td>
+    <td><b>14</b></td>
+    <td><b>13</b></td>
+    <td><b>12</b></td>
+    <td><b>11</b></td>
+    <td><b>10</b></td>
+    <td><b>9</b></td>
+    <td><b>8</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">lower[15:8]</td>
+  </tr>
+  <tr>
+    <td><b>7</b></td>
+    <td><b>6</b></td>
+    <td><b>5</b></td>
+    <td><b>4</b></td>
+    <td><b>3</b></td>
+    <td><b>2</b></td>
+    <td><b>1</b></td>
+    <td><b>0</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">lower[7:0]</td>
+  </tr>
+</table>
+
+#### Bit: upper
+
+_(not documented)_
+
+#### Bit: lower
+
+_(not documented)_
 

--- a/testfiles/issue9/test.md
+++ b/testfiles/issue9/test.md
@@ -13,12 +13,13 @@ Test AXI4-Lite interface
 ## Registers Description
 ### Register: register1
 
-Test register 1
+- **HW Prefix**: register1
+- **HW Address**: 0x0
+- **C Prefix**: register1
+- **C Block Offset**: 0x0
+- **Access**: write-only
 
-- **HDL name**: register1
-- **Address**: 0x0
-- **Block Offset**: 0x0
-- **Access Mode**: wo
+Test register 1
 
 <table>
   <tr>
@@ -75,14 +76,19 @@ Test register 1
   </tr>
 </table>
 
+| Bits | Name | Description |
+|------|------|------------|
+| 31:0 | register1 | Test register 1 |
+
 ### Register: block1.register2
 
-Test register 2
+- **HW Prefix**: block1_register2
+- **HW Address**: 0x10
+- **C Prefix**: block1.register2
+- **C Block Offset**: 0x0
+- **Access**: read-only
 
-- **HDL name**: block1_register2
-- **Address**: 0x10
-- **Block Offset**: 0x0
-- **Access Mode**: ro
+Test register 2
 
 <table>
   <tr>
@@ -165,22 +171,20 @@ Test register 2
   </tr>
 </table>
 
-#### Bit: field1
-
-Test field 1
-
-#### Bit: field2
-
-Test field 2
+| Bits | Name | Description |
+|------|------|------------|
+| 0 | field1 | Test field 1 |
+| 3:1 | field2 | Test field 2 |
 
 ### Register: block1.register3
 
-Test register 3
+- **HW Prefix**: block1_register3
+- **HW Address**: 0x14
+- **C Prefix**: block1.register3
+- **C Block Offset**: 0x4
+- **Access**: read/write
 
-- **HDL name**: block1_register3
-- **Address**: 0x14
-- **Block Offset**: 0x4
-- **Access Mode**: rw
+Test register 3
 
 <table>
   <tr>
@@ -237,14 +241,19 @@ Test register 3
   </tr>
 </table>
 
+| Bits | Name | Description |
+|------|------|------------|
+| 31:0 | register3 | Test register 3 |
+
 ### Register: block1.block2.register4
 
-Test register 4
+- **HW Prefix**: block1_block2_register4
+- **HW Address**: 0x18
+- **C Prefix**: block1.block2.register4
+- **C Block Offset**: 0x0
+- **Access**: read-only
 
-- **HDL name**: block1_block2_register4
-- **Address**: 0x18
-- **Block Offset**: 0x0
-- **Access Mode**: ro
+Test register 4
 
 <table>
   <tr>
@@ -327,11 +336,8 @@ Test register 4
   </tr>
 </table>
 
-#### Bit: field3
-
-Test field 3
-
-#### Bit: field4
-
-Test field 4
+| Bits | Name | Description |
+|------|------|------------|
+| 0 | field3 | Test field 3 |
+| 3:1 | field4 | Test field 4 |
 

--- a/testfiles/issue9/test.md
+++ b/testfiles/issue9/test.md
@@ -1,326 +1,337 @@
-== Memory map summary
+## Memory Map Summary
 Test AXI4-Lite interface
 
-|===
-|HW address | Type | Name | HDL name
+| HW address | Type | Name | HDL Name |
+|------------|------|------|----------|
+| 0x00 | REG | register1 | register1 |
+| 0x10-0x1f | BLOCK | block1 | block1 |
+| 0x10 | REG | block1.register2 | block1_register2 |
+| 0x14 | REG | block1.register3 | block1_register3 |
+| 0x18-0x1b | BLOCK | block1.block2 | block1_block2 |
+| 0x18 | REG | block1.block2.register4 | block1_block2_register4 |
 
-|0x00
-|REG
-|register1
-|register1
-
-|0x10-0x1f
-|BLOCK
-|block1
-|block1
-
-|0x10
-|REG
-|block1.register2
-|block1_register2
-
-|0x14
-|REG
-|block1.register3
-|block1_register3
-
-|0x18-0x1b
-|BLOCK
-|block1.block2
-|block1_block2
-
-|0x18
-|REG
-|block1.block2.register4
-|block1_block2_register4
-|===
-
-== Registers description
-=== register1
-[horizontal]
-HDL name:: register1
-address:: 0x0
-block offset:: 0x0
-access mode:: wo
+## Registers Description
+### Register: register1
 
 Test register 1
 
-[cols="8*^"]
-|===
+- **HDL name**: register1
+- **Address**: 0x0
+- **Block Offset**: 0x0
+- **Access Mode**: wo
 
-| 31
-| 30
-| 29
-| 28
-| 27
-| 26
-| 25
-| 24
+<table>
+  <tr>
+    <td><b>31</b></td>
+    <td><b>30</b></td>
+    <td><b>29</b></td>
+    <td><b>28</b></td>
+    <td><b>27</b></td>
+    <td><b>26</b></td>
+    <td><b>25</b></td>
+    <td><b>24</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">register1[31:24]</td>
+  </tr>
+  <tr>
+    <td><b>23</b></td>
+    <td><b>22</b></td>
+    <td><b>21</b></td>
+    <td><b>20</b></td>
+    <td><b>19</b></td>
+    <td><b>18</b></td>
+    <td><b>17</b></td>
+    <td><b>16</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">register1[23:16]</td>
+  </tr>
+  <tr>
+    <td><b>15</b></td>
+    <td><b>14</b></td>
+    <td><b>13</b></td>
+    <td><b>12</b></td>
+    <td><b>11</b></td>
+    <td><b>10</b></td>
+    <td><b>9</b></td>
+    <td><b>8</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">register1[15:8]</td>
+  </tr>
+  <tr>
+    <td><b>7</b></td>
+    <td><b>6</b></td>
+    <td><b>5</b></td>
+    <td><b>4</b></td>
+    <td><b>3</b></td>
+    <td><b>2</b></td>
+    <td><b>1</b></td>
+    <td><b>0</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">register1[7:0]</td>
+  </tr>
+</table>
 
-8+s| register1[31:24]
-
-| 23
-| 22
-| 21
-| 20
-| 19
-| 18
-| 17
-| 16
-
-8+s| register1[23:16]
-
-| 15
-| 14
-| 13
-| 12
-| 11
-| 10
-| 9
-| 8
-
-8+s| register1[15:8]
-
-| 7
-| 6
-| 5
-| 4
-| 3
-| 2
-| 1
-| 0
-
-8+s| register1[7:0]
-|===
-=== block1.register2
-[horizontal]
-HDL name:: block1_register2
-address:: 0x10
-block offset:: 0x0
-access mode:: ro
+### Register: block1.register2
 
 Test register 2
 
-[cols="8*^"]
-|===
+- **HDL name**: block1_register2
+- **Address**: 0x10
+- **Block Offset**: 0x0
+- **Access Mode**: ro
 
-| 31
-| 30
-| 29
-| 28
-| 27
-| 26
-| 25
-| 24
+<table>
+  <tr>
+    <td><b>31</b></td>
+    <td><b>30</b></td>
+    <td><b>29</b></td>
+    <td><b>28</b></td>
+    <td><b>27</b></td>
+    <td><b>26</b></td>
+    <td><b>25</b></td>
+    <td><b>24</b></td>
+  </tr>
+  <tr>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+  </tr>
+  <tr>
+    <td><b>23</b></td>
+    <td><b>22</b></td>
+    <td><b>21</b></td>
+    <td><b>20</b></td>
+    <td><b>19</b></td>
+    <td><b>18</b></td>
+    <td><b>17</b></td>
+    <td><b>16</b></td>
+  </tr>
+  <tr>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+  </tr>
+  <tr>
+    <td><b>15</b></td>
+    <td><b>14</b></td>
+    <td><b>13</b></td>
+    <td><b>12</b></td>
+    <td><b>11</b></td>
+    <td><b>10</b></td>
+    <td><b>9</b></td>
+    <td><b>8</b></td>
+  </tr>
+  <tr>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+  </tr>
+  <tr>
+    <td><b>7</b></td>
+    <td><b>6</b></td>
+    <td><b>5</b></td>
+    <td><b>4</b></td>
+    <td><b>3</b></td>
+    <td><b>2</b></td>
+    <td><b>1</b></td>
+    <td><b>0</b></td>
+  </tr>
+  <tr>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td colspan="3" style="text-align: center;">field2[2:0]</td>
+    <td>field1</td>
+  </tr>
+</table>
 
-| -
-| -
-| -
-| -
-| -
-| -
-| -
-| -
+#### Bit: field1
 
-| 23
-| 22
-| 21
-| 20
-| 19
-| 18
-| 17
-| 16
-
-| -
-| -
-| -
-| -
-| -
-| -
-| -
-| -
-
-| 15
-| 14
-| 13
-| 12
-| 11
-| 10
-| 9
-| 8
-
-| -
-| -
-| -
-| -
-| -
-| -
-| -
-| -
-
-| 7
-| 6
-| 5
-| 4
-| 3
-| 2
-| 1
-| 0
-
-| -
-| -
-| -
-| -
-3+s| field2[2:0]
-s| field1
-|===
-
-field1::
 Test field 1
-field2::
+
+#### Bit: field2
+
 Test field 2
 
-=== block1.register3
-[horizontal]
-HDL name:: block1_register3
-address:: 0x14
-block offset:: 0x4
-access mode:: rw
+### Register: block1.register3
 
 Test register 3
 
-[cols="8*^"]
-|===
+- **HDL name**: block1_register3
+- **Address**: 0x14
+- **Block Offset**: 0x4
+- **Access Mode**: rw
 
-| 31
-| 30
-| 29
-| 28
-| 27
-| 26
-| 25
-| 24
+<table>
+  <tr>
+    <td><b>31</b></td>
+    <td><b>30</b></td>
+    <td><b>29</b></td>
+    <td><b>28</b></td>
+    <td><b>27</b></td>
+    <td><b>26</b></td>
+    <td><b>25</b></td>
+    <td><b>24</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">register3[31:24]</td>
+  </tr>
+  <tr>
+    <td><b>23</b></td>
+    <td><b>22</b></td>
+    <td><b>21</b></td>
+    <td><b>20</b></td>
+    <td><b>19</b></td>
+    <td><b>18</b></td>
+    <td><b>17</b></td>
+    <td><b>16</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">register3[23:16]</td>
+  </tr>
+  <tr>
+    <td><b>15</b></td>
+    <td><b>14</b></td>
+    <td><b>13</b></td>
+    <td><b>12</b></td>
+    <td><b>11</b></td>
+    <td><b>10</b></td>
+    <td><b>9</b></td>
+    <td><b>8</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">register3[15:8]</td>
+  </tr>
+  <tr>
+    <td><b>7</b></td>
+    <td><b>6</b></td>
+    <td><b>5</b></td>
+    <td><b>4</b></td>
+    <td><b>3</b></td>
+    <td><b>2</b></td>
+    <td><b>1</b></td>
+    <td><b>0</b></td>
+  </tr>
+  <tr>
+    <td colspan="8" style="text-align: center;">register3[7:0]</td>
+  </tr>
+</table>
 
-8+s| register3[31:24]
-
-| 23
-| 22
-| 21
-| 20
-| 19
-| 18
-| 17
-| 16
-
-8+s| register3[23:16]
-
-| 15
-| 14
-| 13
-| 12
-| 11
-| 10
-| 9
-| 8
-
-8+s| register3[15:8]
-
-| 7
-| 6
-| 5
-| 4
-| 3
-| 2
-| 1
-| 0
-
-8+s| register3[7:0]
-|===
-=== block1.block2.register4
-[horizontal]
-HDL name:: block1_block2_register4
-address:: 0x18
-block offset:: 0x0
-access mode:: ro
+### Register: block1.block2.register4
 
 Test register 4
 
-[cols="8*^"]
-|===
+- **HDL name**: block1_block2_register4
+- **Address**: 0x18
+- **Block Offset**: 0x0
+- **Access Mode**: ro
 
-| 31
-| 30
-| 29
-| 28
-| 27
-| 26
-| 25
-| 24
+<table>
+  <tr>
+    <td><b>31</b></td>
+    <td><b>30</b></td>
+    <td><b>29</b></td>
+    <td><b>28</b></td>
+    <td><b>27</b></td>
+    <td><b>26</b></td>
+    <td><b>25</b></td>
+    <td><b>24</b></td>
+  </tr>
+  <tr>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+  </tr>
+  <tr>
+    <td><b>23</b></td>
+    <td><b>22</b></td>
+    <td><b>21</b></td>
+    <td><b>20</b></td>
+    <td><b>19</b></td>
+    <td><b>18</b></td>
+    <td><b>17</b></td>
+    <td><b>16</b></td>
+  </tr>
+  <tr>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+  </tr>
+  <tr>
+    <td><b>15</b></td>
+    <td><b>14</b></td>
+    <td><b>13</b></td>
+    <td><b>12</b></td>
+    <td><b>11</b></td>
+    <td><b>10</b></td>
+    <td><b>9</b></td>
+    <td><b>8</b></td>
+  </tr>
+  <tr>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+  </tr>
+  <tr>
+    <td><b>7</b></td>
+    <td><b>6</b></td>
+    <td><b>5</b></td>
+    <td><b>4</b></td>
+    <td><b>3</b></td>
+    <td><b>2</b></td>
+    <td><b>1</b></td>
+    <td><b>0</b></td>
+  </tr>
+  <tr>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td>-</td>
+    <td colspan="3" style="text-align: center;">field4[2:0]</td>
+    <td>field3</td>
+  </tr>
+</table>
 
-| -
-| -
-| -
-| -
-| -
-| -
-| -
-| -
+#### Bit: field3
 
-| 23
-| 22
-| 21
-| 20
-| 19
-| 18
-| 17
-| 16
-
-| -
-| -
-| -
-| -
-| -
-| -
-| -
-| -
-
-| 15
-| 14
-| 13
-| 12
-| 11
-| 10
-| 9
-| 8
-
-| -
-| -
-| -
-| -
-| -
-| -
-| -
-| -
-
-| 7
-| 6
-| 5
-| 4
-| 3
-| 2
-| 1
-| 0
-
-| -
-| -
-| -
-| -
-3+s| field4[2:0]
-s| field3
-|===
-
-field3::
 Test field 3
-field4::
+
+#### Bit: field4
+
 Test field 4
 


### PR DESCRIPTION
The overall goal of this PR is to improve the Markdown documentation generation such that it can easily be displayed in GitLab and GitHub. Since some of the tables in the Markdown documentation are generated based on AsciiDoc, GitLab and GitHub failed to display them properly. Overall, the following points have been addressed:

- Match Markdown output to LaTeX documentation
- Generate HTML tables instead of AsciiDoc tables for register drawings (showing which bit field is placed where in the register)