### PR TITLE
Print addresses for submaps in struct constant files

### DIFF
--- a/proto/cheby/print_consts.py
+++ b/proto/cheby/print_consts.py
@@ -451,8 +451,9 @@ class StructVisitor(ConstsVisitor):
         self.printer.pr_ident = lambda *args: None
 
     def pr_address(self, n):
-        # Avoid printing of properties on nodes that are not leaves (i.e., fields)
-        pass
+        # Avoid printing address properties on nodes that are not submaps
+        if isinstance(n, tree.Submap):
+            self.printer.pr_address(n)
 
     def pr_address_mask(self, n):
         # Avoid printing of properties on nodes that are not leaves (i.e., fields)


### PR DESCRIPTION
Currently, there are two types of constant files that can be generated in `proto/cheby/print_consts.py`:
- `ConstsVisitor`
- `StructVisitor`

For the later, each bit field is generated as a structure linked to its parent elements, e.g. in Matlab we get for a single field:
```matlab
REG_TOP.status.idle.WIDTH = 1;
REG_TOP.status.idle.OFFSET = 0;
REG_TOP.status.idle.WIDTH = 1;
```

For any entry that is not a bit field such as submaps, no structure or constant is generated. This is particularly a problem when using nested register maps. This PR proposes now to include as the very least the address for submaps, e.g.
```matlab
REG_TOP.submap.ADDR = 256;
```