### PR TITLE
Fix C struct Padding

### DIFF
--- a/proto/cheby/gen_c.py
+++ b/proto/cheby/gen_c.py
@@ -1,7 +1,57 @@
 """Print as a C structure."""
 import cheby.tree as tree
 import cheby.print_consts as print_consts
+from cheby.parser import error
 from operator import attrgetter
+
+
+C_KEYWORDS = [
+    "alignas",
+    "alignof",
+    "auto",
+    "bool",
+    "break",
+    "case",
+    "char",
+    "const",
+    "constexpr",
+    "continue",
+    "default",
+    "do",
+    "double",
+    "else",
+    "enum",
+    "extern",
+    "false",
+    "float",
+    "for",
+    "goto",
+    "if",
+    "inline",
+    "int",
+    "long",
+    "nullptr",
+    "register",
+    "restrict",
+    "return",
+    "short",
+    "signed",
+    "sizeof",
+    "static",
+    "static_assert",
+    "struct",
+    "switch",
+    "thread_local",
+    "true",
+    "typedef",
+    "typeof",
+    "typeof_unqual",
+    "union",
+    "unsigned",
+    "void",
+    "volatile",
+    "while",
+]
 
 
 class CPrinter(tree.Visitor):
@@ -90,6 +140,12 @@ class CPrinter(tree.Visitor):
                 name = "_bits_{}_to_{}".format(idx, idx + width - 1)
             else:
                 name = "_bit_{}".format(idx)
+
+        elif name in C_KEYWORDS:
+            error(
+                "The bit field name '{}' is a reserved C keyword and ".format(name)
+                + "cannot be used when generating C struct header files."
+            )
 
         self.bit_struct_txt("{} {}: {};".format(self.utypes[n.c_size], name, width))
 

--- a/proto/cheby/gen_c.py
+++ b/proto/cheby/gen_c.py
@@ -83,7 +83,14 @@ class CPrinter(tree.Visitor):
         self.bit_struct_txt("typedef struct {")
         self._bit_struct_indent += 1
 
-    def bit_struct_field(self, n, name, width):
+    def bit_struct_field(self, n, name, width, idx=0):
+        if not name:
+            # Used for padding fields
+            if width > 1:
+                name = "_bits_{}_to_{}".format(idx, idx + width - 1)
+            else:
+                name = "_bit_{}".format(idx)
+
         self.bit_struct_txt("{} {}: {};".format(self.utypes[n.c_size], name, width))
 
     def bit_struct_txt(self, txt=""):
@@ -187,7 +194,7 @@ def cprint_reg(cp, n):
             if bit_idx < n_child.lo:
                 # Insert padding
                 pad_width = n_child.lo - bit_idx
-                cp.bit_struct_field(n, "", pad_width)
+                cp.bit_struct_field(n, "", pad_width, bit_idx)
                 bit_idx += pad_width
 
             cp.bit_struct_field(n, n_child.name, n_child.c_rwidth)
@@ -195,7 +202,7 @@ def cprint_reg(cp, n):
 
         if bit_idx < 8 * n.c_size:
             # Insert padding at the end
-            cp.bit_struct_field(n, "", 8 * n.c_size - bit_idx)
+            cp.bit_struct_field(n, "", 8 * n.c_size - bit_idx, bit_idx)
 
         cp.bit_struct_end(n)
 

--- a/proto/cheby/hdl/axi4litebus.py
+++ b/proto/cheby/hdl/axi4litebus.py
@@ -18,11 +18,10 @@ from cheby.hdltree import (
     HDLParen,
     HDLPackage,
     HDLInterface,
-    HDLInterfaceSelect
+    HDLInterfaceSelect,
 )
 from cheby.hdl.busgen import BusGen
 import cheby.tree as tree
-import cheby.parser as parser
 from cheby.hdl.globals import gconfig, dirname, libname
 from cheby.hdl.ibus import add_bus
 from cheby.hdl.busparams import BusOptions

--- a/proto/cheby/hdl/axi4litebus.py
+++ b/proto/cheby/hdl/axi4litebus.py
@@ -26,6 +26,7 @@ import cheby.parser as parser
 from cheby.hdl.globals import gconfig, dirname, libname
 from cheby.hdl.ibus import add_bus
 from cheby.hdl.busparams import BusOptions
+from typing import List, Tuple
 
 # AXI Lite response codes (BRESP, RRESP)
 RESP_OKAY = HDLBinConst(0, 2)
@@ -44,7 +45,7 @@ class AXI4LiteBus(BusGen):
     def gen_axi4lite_bus(self, module, ports, name, build_port,
                          addr_bits, lo_addr, data_bits, comment,
                          is_master=False, is_group=False, libname = libname) -> \
-                         list[tuple[str, HDLNode]]:
+                         List[Tuple[str, HDLNode]]:
         if is_group:
             if AXI4LiteBus.axi4l_pkg is None:
                 self.gen_axi4l_pkg(module, ports, name, comment, data_bits)

--- a/proto/cheby/hdl/wbbus.py
+++ b/proto/cheby/hdl/wbbus.py
@@ -10,6 +10,7 @@ from cheby.hdl.busgen import BusGen
 import cheby.tree as tree
 from cheby.hdl.globals import gconfig, dirname, libname
 from cheby.hdl.busparams import BusOptions
+from typing import Dict
 
 class WBBus(BusGen):
     # Package wishbone_pkg that contains the wishbone interface
@@ -133,7 +134,7 @@ class WBBus(BusGen):
 
 
     def gen_wishbone_bus(self, build_port, addr_bits, lo_addr,
-                         data_bits, is_master) -> dict[str, HDLNode]:
+                         data_bits, is_master) -> Dict[str, HDLNode]:
         # FIXME: 'dat' is used both as an input and as an output.
         #  This is not a problem in general as a suffix is appended,
         #  except for system verilog interfaces...
@@ -161,7 +162,7 @@ class WBBus(BusGen):
         return res
 
     def gen_wishbone(self, module, ports, name, addr_bits, lo_addr,
-                     data_bits, comment, is_master, is_group, libname = libname) -> dict[str, HDLPort]:
+                     data_bits, comment, is_master, is_group, libname = libname) -> Dict[str, HDLPort]:
         if is_group:
             if WBBus.wb_pkg is None:
                 self.gen_wishbone_pkg()

--- a/proto/cheby/hdl/wbbus.py
+++ b/proto/cheby/hdl/wbbus.py
@@ -1,11 +1,24 @@
-from cheby.hdltree import (HDLPackage,
-                           HDLInterface, HDLInterfaceSelect,
-                           HDLAssign, HDLSync, HDLComb, HDLComment,
-                           HDLIfElse,
-                           bit_1, bit_0,
-                           HDLAnd, HDLOr, HDLNot, HDLEq, HDLConcat,
-                           HDLSlice, HDLReplicate,
-                           HDLParen, HDLPort, HDLNode)
+from cheby.hdltree import (
+    HDLPackage,
+    HDLInterface,
+    HDLInterfaceSelect,
+    HDLAssign,
+    HDLSync,
+    HDLComb,
+    HDLComment,
+    HDLIfElse,
+    bit_1,
+    bit_0,
+    HDLAnd,
+    HDLOr,
+    HDLNot,
+    HDLEq,
+    HDLSlice,
+    HDLReplicate,
+    HDLParen,
+    HDLPort,
+    HDLNode,
+)
 from cheby.hdl.busgen import BusGen
 import cheby.tree as tree
 from cheby.hdl.globals import gconfig, dirname, libname

--- a/proto/tests.py
+++ b/proto/tests.py
@@ -96,7 +96,7 @@ def elab_sv(sv_file, top_entity):
 
 def check_c_syntax(c_file):
     """Function to check C syntax using gcc"""
-    res = subprocess.run(['gcc', '-fsyntax-only', '-Wall', '-Werror', c_file])
+    res = subprocess.run(['gcc', '-fsyntax-only', '-include', 'stdint.h', '-Wall', '-Werror', c_file])
     if res.returncode != 0:
         error('C syntax check failed for {}'.format(c_file))
 
@@ -1185,7 +1185,7 @@ def main():
     args = aparser.parse_args()
 
     try:
-        
+
         test_self()
         test_parser()
         test_layout()

--- a/testfiles/bug-gen-c-02/fip_urv_regs_union.h
+++ b/testfiles/bug-gen-c-02/fip_urv_regs_union.h
@@ -73,7 +73,7 @@
 /* [0x0]: REG plc_ctrl */
 typedef struct {
   uint32_t rstn: 1;
-  uint32_t : 31;
+  uint32_t _bits_1_to_31: 31;
 } plc_ctrl_s;
 
 typedef union {
@@ -85,7 +85,7 @@ typedef union {
 typedef struct {
   uint32_t var1_rdy: 1;
   uint32_t var3_rdy: 1;
-  uint32_t : 30;
+  uint32_t _bits_2_to_31: 30;
 } fip_status_s;
 
 typedef union {
@@ -96,7 +96,7 @@ typedef union {
 /* [0x8]: REG fip_var1 */
 typedef struct {
   uint32_t acc: 1;
-  uint32_t : 31;
+  uint32_t _bits_1_to_31: 31;
 } fip_var1_s;
 
 typedef union {
@@ -107,7 +107,7 @@ typedef union {
 /* [0xc]: REG fip_var3 */
 typedef struct {
   uint32_t acc: 1;
-  uint32_t : 31;
+  uint32_t _bits_1_to_31: 31;
 } fip_var3_s;
 
 typedef union {
@@ -118,7 +118,7 @@ typedef union {
 /* [0x20]: REG presence */
 typedef struct {
   uint32_t en: 8;
-  uint32_t : 24;
+  uint32_t _bits_8_to_31: 24;
 } presence_s;
 
 typedef union {
@@ -129,7 +129,7 @@ typedef union {
 /* [0x24]: REG leds */
 typedef struct {
   uint32_t val: 6;
-  uint32_t : 26;
+  uint32_t _bits_6_to_31: 26;
 } leds_s;
 
 typedef union {

--- a/testfiles/bug-gen-c-02/mbox_regs_union.h
+++ b/testfiles/bug-gen-c-02/mbox_regs_union.h
@@ -24,7 +24,7 @@
 typedef struct {
   uint32_t mbin: 1;
   uint32_t mbout: 1;
-  uint32_t : 30;
+  uint32_t _bits_2_to_31: 30;
 } status_s;
 
 typedef union {

--- a/testfiles/bug-same-label/same_label_union.h
+++ b/testfiles/bug-same-label/same_label_union.h
@@ -28,7 +28,7 @@
 /* [0x4]: REG same_name */
 typedef struct {
   uint32_t same_name: 1;
-  uint32_t : 31;
+  uint32_t _bits_1_to_31: 31;
 } same_name_s;
 
 typedef union {
@@ -39,7 +39,7 @@ typedef union {
 /* [0x8]: REG same_name_multi */
 typedef struct {
   uint32_t same_name_multi: 12;
-  uint32_t : 20;
+  uint32_t _bits_12_to_31: 20;
 } same_name_multi_s;
 
 typedef union {
@@ -50,7 +50,7 @@ typedef union {
 /* [0xc]: REG not_same_reg */
 typedef struct {
   uint32_t not_same: 1;
-  uint32_t : 31;
+  uint32_t _bits_1_to_31: 31;
 } not_same_reg_s;
 
 typedef union {

--- a/testfiles/features/blkprefix3_union.h
+++ b/testfiles/features/blkprefix3_union.h
@@ -41,9 +41,9 @@
 /* [0x0]: REG r2 */
 typedef struct {
   uint32_t f1: 3;
-  uint32_t : 1;
+  uint32_t _bit_3: 1;
   uint32_t f2: 1;
-  uint32_t : 27;
+  uint32_t _bits_5_to_31: 27;
 } b1_r2_s;
 
 typedef union {
@@ -54,9 +54,9 @@ typedef union {
 /* [0x0]: REG r3 */
 typedef struct {
   uint32_t f1: 3;
-  uint32_t : 1;
+  uint32_t _bit_3: 1;
   uint32_t f2: 1;
-  uint32_t : 27;
+  uint32_t _bits_5_to_31: 27;
 } b1_r3_s;
 
 typedef union {
@@ -67,7 +67,7 @@ typedef union {
 /* [0x0]: REG r3 */
 typedef struct {
   uint32_t f1: 3;
-  uint32_t : 29;
+  uint32_t _bits_3_to_31: 29;
 } b2_r3_s;
 
 typedef union {

--- a/testfiles/features/blkprefix5_union.h
+++ b/testfiles/features/blkprefix5_union.h
@@ -50,9 +50,9 @@
 /* [0x0]: REG r1 */
 typedef struct {
   uint32_t f1: 3;
-  uint32_t : 1;
+  uint32_t _bit_3: 1;
   uint32_t f2: 1;
-  uint32_t : 27;
+  uint32_t _bits_5_to_31: 27;
 } b1_r1_s;
 
 typedef union {
@@ -63,9 +63,9 @@ typedef union {
 /* [0x0]: REG r3 */
 typedef struct {
   uint32_t f1: 3;
-  uint32_t : 1;
+  uint32_t _bit_3: 1;
   uint32_t f2: 1;
-  uint32_t : 27;
+  uint32_t _bits_5_to_31: 27;
 } b1_r3_s;
 
 typedef union {
@@ -76,7 +76,7 @@ typedef union {
 /* [0x0]: REG r1 */
 typedef struct {
   uint32_t f1: 3;
-  uint32_t : 29;
+  uint32_t _bits_3_to_31: 29;
 } b2_r1_s;
 
 typedef union {

--- a/testfiles/issue143/map-consts.sv
+++ b/testfiles/issue143/map-consts.sv
@@ -1,4 +1,4 @@
-package top_Consts;
+package pkg_top_consts;
   localparam TOP_SIZE = 32;
   localparam ADDR_TOP_ARRAY_OF_SUBMAPS = 'h0;
   localparam ADDR_MASK_TOP_ARRAY_OF_SUBMAPS = 'h0;

--- a/testfiles/issue143/map-consts.sv
+++ b/testfiles/issue143/map-consts.sv
@@ -1,4 +1,4 @@
-package pkg_top_consts;
+package top_Consts;
   localparam TOP_SIZE = 32;
   localparam ADDR_TOP_ARRAY_OF_SUBMAPS = 'h0;
   localparam ADDR_MASK_TOP_ARRAY_OF_SUBMAPS = 'h0;

--- a/testfiles/issue143/map-consts.vhdl
+++ b/testfiles/issue143/map-consts.vhdl
@@ -1,7 +1,7 @@
 library ieee;
 use ieee.std_logic_1164.all;
 
-package pkg_top_consts is
+package top_Consts is
   constant TOP_SIZE : Natural := 32;
   constant ADDR_TOP_ARRAY_OF_SUBMAPS : Natural := 16#0#;
   constant ADDR_MASK_TOP_ARRAY_OF_SUBMAPS : Natural := 16#0#;
@@ -47,4 +47,4 @@ package pkg_top_consts is
   constant ADDR_MASK_TOP_ARRAY_OF_SUBMAPS_4_SUBMAP : Natural := 16#1c#;
   constant ADDR_FMASK_TOP_ARRAY_OF_SUBMAPS_4_SUBMAP : Natural := 16#1c#;
   constant TOP_ARRAY_OF_SUBMAPS_4_SUBMAP_SIZE : Natural := 4;
-end package pkg_top_consts;
+end package top_Consts;

--- a/testfiles/issue143/map-consts.vhdl
+++ b/testfiles/issue143/map-consts.vhdl
@@ -1,7 +1,7 @@
 library ieee;
 use ieee.std_logic_1164.all;
 
-package top_Consts is
+package pkg_top_consts is
   constant TOP_SIZE : Natural := 32;
   constant ADDR_TOP_ARRAY_OF_SUBMAPS : Natural := 16#0#;
   constant ADDR_MASK_TOP_ARRAY_OF_SUBMAPS : Natural := 16#0#;
@@ -47,4 +47,4 @@ package top_Consts is
   constant ADDR_MASK_TOP_ARRAY_OF_SUBMAPS_4_SUBMAP : Natural := 16#1c#;
   constant ADDR_FMASK_TOP_ARRAY_OF_SUBMAPS_4_SUBMAP : Natural := 16#1c#;
   constant TOP_ARRAY_OF_SUBMAPS_4_SUBMAP_SIZE : Natural := 4;
-end package top_Consts;
+end package pkg_top_consts;

--- a/testfiles/mr67/top-consts.sv
+++ b/testfiles/mr67/top-consts.sv
@@ -1,4 +1,4 @@
-package fid_top_axi_Consts;
+package pkg_fid_top_axi_consts;
   localparam FID_TOP_AXI_MEMMAP_VERSION = 'h100;
   localparam ADDR_FID_TOP_AXI_IP = 'h0;
   localparam ADDR_MASK_FID_TOP_AXI_IP = 'h0;

--- a/testfiles/mr67/top-consts.sv
+++ b/testfiles/mr67/top-consts.sv
@@ -1,4 +1,4 @@
-package pkg_fid_top_axi_consts;
+package fid_top_axi_Consts;
   localparam FID_TOP_AXI_MEMMAP_VERSION = 'h100;
   localparam ADDR_FID_TOP_AXI_IP = 'h0;
   localparam ADDR_MASK_FID_TOP_AXI_IP = 'h0;

--- a/testfiles/mr67/top-consts.vhdl
+++ b/testfiles/mr67/top-consts.vhdl
@@ -1,10 +1,10 @@
 library ieee;
 use ieee.std_logic_1164.all;
 
-package pkg_fid_top_axi_consts is
+package fid_top_axi_Consts is
   constant FID_TOP_AXI_MEMMAP_VERSION : Natural := 16#100#;
   constant ADDR_FID_TOP_AXI_IP : Natural := 16#0#;
   constant ADDR_MASK_FID_TOP_AXI_IP : Natural := 16#0#;
   constant ADDR_FMASK_FID_TOP_AXI_IP : Natural := 16#0#;
   constant FID_TOP_AXI_IP_SIZE : Natural := 4;
-end package pkg_fid_top_axi_consts;
+end package fid_top_axi_Consts;

--- a/testfiles/mr67/top-consts.vhdl
+++ b/testfiles/mr67/top-consts.vhdl
@@ -1,10 +1,10 @@
 library ieee;
 use ieee.std_logic_1164.all;
 
-package fid_top_axi_Consts is
+package pkg_fid_top_axi_consts is
   constant FID_TOP_AXI_MEMMAP_VERSION : Natural := 16#100#;
   constant ADDR_FID_TOP_AXI_IP : Natural := 16#0#;
   constant ADDR_MASK_FID_TOP_AXI_IP : Natural := 16#0#;
   constant ADDR_FMASK_FID_TOP_AXI_IP : Natural := 16#0#;
   constant FID_TOP_AXI_IP_SIZE : Natural := 4;
-end package fid_top_axi_Consts;
+end package pkg_fid_top_axi_consts;


### PR DESCRIPTION
Fixes empty name for padding fields in C typdef structure. Error was introduced in initial commit for C typdef structures in #63.

e.g.
```c
typedef struct {
  uint32_t rstn: 1;
  uint32_t : 31;
} plc_ctrl_s;
```
where the second field has no name and hence, is invalid, becomes
```c
typedef struct {
  uint32_t rstn: 1;
  uint32_t _bits_1_to_31: 31;
} plc_ctrl_s;
```
Furthermore, this PR signals an error, if C structures are generated and a bit field uses a reserved C keyword.