### PR TITLE
AXI4-Lite: hold BVALID/RVALID until ready in bus-error mode

### DIFF
--- a/proto/cheby/hdl/axi4litebus.py
+++ b/proto/cheby/hdl/axi4litebus.py
@@ -121,20 +121,29 @@ class AXI4LiteBus(BusGen):
         axi_werr = self.module.new_HDLSignal('axi_werr', 2)
         self.module.stmts.append(HDLAssign(self.root.h_bus['awready'], HDLNot(axi_awset)))
         self.module.stmts.append(HDLAssign(self.root.h_bus['wready'], HDLNot(axi_wset)))
-        self.module.stmts.append(HDLAssign(self.root.h_bus['bvalid'], axi_wdone))
+        if opts.bus_error:
+            # In bus-error mode BVALID is forced high while in reset (via the
+            # reset signal) so that a write issued during reset is completed with
+            # SLVERR instead of stalling.  Out of reset it is driven solely by
+            # axi_wdone, which is held until BREADY (AXI4-Lite A3.2.1).
+            self.module.stmts.append(HDLAssign(self.root.h_bus['bvalid'],
+                HDLOr(axi_wdone, HDLNot(self.root.h_bus['brst']))))
+        else:
+            self.module.stmts.append(HDLAssign(self.root.h_bus['bvalid'], axi_wdone))
 
         proc = HDLSync(self.root.h_bus['clk'], self.root.h_bus['brst'], rst_sync=gconfig.rst_sync)
         proc.rst_stmts.append(HDLAssign(ibus.wr_req, bit_0))
         proc.rst_stmts.append(HDLAssign(axi_awset, bit_0))
         proc.rst_stmts.append(HDLAssign(axi_wset, bit_0))
         if opts.bus_error:
-            # During reset, all handshaking signals are set in a way to accept
-            # all handshakes while returning an error on the BRESP signal.
-            # This allows the bus to remain accessible despite being in reset
-            # and without stalling the bus.
+            # During reset, BVALID is forced high by the reset signal (see the
+            # bvalid assignment) and BRESP returns SLVERR, so accesses issued
+            # during reset are completed with an error instead of stalling the
+            # bus.  axi_wdone itself stays 0, so out of reset BVALID reflects a
+            # real response and is held until BREADY.
             proc.rst_stmts.append(HDLComment(
-                "During reset, accept all handshakes and return error"))
-            proc.rst_stmts.append(HDLAssign(axi_wdone, bit_1))
+                "During reset, return error (BVALID is forced by the reset signal)"))
+            proc.rst_stmts.append(HDLAssign(axi_wdone, bit_0))
             proc.rst_stmts.append(HDLAssign(axi_werr, RESP_SLVERR))
         else:
             # Without bus error, use behaviour of original implementation
@@ -143,11 +152,6 @@ class AXI4LiteBus(BusGen):
             self.module.stmts.append(HDLAssign(axi_werr, RESP_OKAY))
 
         proc.sync_stmts.append(HDLAssign(ibus.wr_req, bit_0))
-        if opts.bus_error:
-            # Stop accepting handshake as soon as reset is over
-            proc.sync_stmts.append(HDLAssign(axi_wdone, bit_0))
-            # Reset BRESP signal
-            proc.sync_stmts.append(HDLAssign(axi_werr, RESP_OKAY))
 
         # Load AWADDR (and acknowledge the AW request)
         proc_if = HDLIfElse(HDLAnd(HDLEq(self.root.h_bus['awvalid'], bit_1),
@@ -189,8 +193,9 @@ class AXI4LiteBus(BusGen):
         proc_if = HDLIfElse(HDLEq(HDLParen(HDLAnd(axi_wdone, self.root.h_bus['bready'])), bit_1))
         proc_if.then_stmts.append(HDLAssign(axi_wset, bit_0))
         proc_if.then_stmts.append(HDLAssign(axi_awset, bit_0))
-        if not opts.bus_error:
-            proc_if.then_stmts.append(HDLAssign(axi_wdone, bit_0))
+        # Clear WDONE on the handshake so BVALID is held until BREADY is sampled
+        # high, in bus-error mode as well as without it (AXI4-Lite A3.2.1).
+        proc_if.then_stmts.append(HDLAssign(axi_wdone, bit_0))
         proc_if.else_stmts = None
         proc.sync_stmts.append(proc_if)
 
@@ -238,19 +243,28 @@ class AXI4LiteBus(BusGen):
         axi_rdone = self.module.new_HDLSignal('axi_rdone')
         axi_rerr = self.module.new_HDLSignal('axi_rerr', 2)
         self.module.stmts.append(HDLAssign(self.root.h_bus['arready'], HDLNot(axi_arset)))
-        self.module.stmts.append(HDLAssign(self.root.h_bus['rvalid'], axi_rdone))
+        if opts.bus_error:
+            # In bus-error mode RVALID is forced high while in reset (via the
+            # reset signal) so that a read issued during reset is completed with
+            # SLVERR instead of stalling.  Out of reset it is driven solely by
+            # axi_rdone, which is held until RREADY (AXI4-Lite A3.2.1).
+            self.module.stmts.append(HDLAssign(self.root.h_bus['rvalid'],
+                HDLOr(axi_rdone, HDLNot(self.root.h_bus['brst']))))
+        else:
+            self.module.stmts.append(HDLAssign(self.root.h_bus['rvalid'], axi_rdone))
 
         proc = HDLSync(self.root.h_bus['clk'], self.root.h_bus['brst'], rst_sync=gconfig.rst_sync)
         proc.rst_stmts.append(HDLAssign(ibus.rd_req, bit_0))
         proc.rst_stmts.append(HDLAssign(axi_arset, bit_0))
         if opts.bus_error:
-            # During reset, all handshaking signals are set in a way to accept
-            # all handshakes while returning an error on the BRESP signal.
-            # This allows the bus to remain accessible despite being in reset
-            # and without stalling the bus.
+            # During reset, RVALID is forced high by the reset signal (see the
+            # rvalid assignment) and RRESP returns SLVERR, so accesses issued
+            # during reset are completed with an error instead of stalling the
+            # bus.  axi_rdone itself stays 0, so out of reset RVALID reflects a
+            # real response and is held until RREADY.
             proc.rst_stmts.append(HDLComment(
-                "During reset, accept all handshakes and return error"))
-            proc.rst_stmts.append(HDLAssign(axi_rdone, bit_1))
+                "During reset, return error (RVALID is forced by the reset signal)"))
+            proc.rst_stmts.append(HDLAssign(axi_rdone, bit_0))
             proc.rst_stmts.append(HDLAssign(axi_rerr, RESP_SLVERR))
         else:
             # Without bus error, use behaviour of original implementation
@@ -261,11 +275,6 @@ class AXI4LiteBus(BusGen):
             HDLAssign(self.root.h_bus['rdata'], HDLReplicate(bit_0, self.root.c_word_bits)))
 
         proc.sync_stmts.append(HDLAssign(ibus.rd_req, bit_0))
-        if opts.bus_error:
-            # Stop accepting handshake as soon as reset is over
-            proc.sync_stmts.append(HDLAssign(axi_rdone, bit_0))
-            # Reset RRESP signal
-            proc.sync_stmts.append(HDLAssign(axi_rerr, RESP_OKAY))
 
         # Load ARADDR (and acknowledge the AR request)
         proc_if = HDLIfElse(HDLAnd(HDLEq(self.root.h_bus['arvalid'], bit_1),
@@ -281,8 +290,9 @@ class AXI4LiteBus(BusGen):
         # Clear 'set' bit at the end of the transaction
         proc_if = HDLIfElse(HDLEq(HDLParen(HDLAnd(axi_rdone, self.root.h_bus['rready'])), bit_1))
         proc_if.then_stmts.append(HDLAssign(axi_arset, bit_0))
-        if not opts.bus_error:
-            proc_if.then_stmts.append(HDLAssign(axi_rdone, bit_0))
+        # Clear RDONE on the handshake so RVALID is held until RREADY is sampled
+        # high, in bus-error mode as well as without it (AXI4-Lite A3.2.1).
+        proc_if.then_stmts.append(HDLAssign(axi_rdone, bit_0))
         proc_if.else_stmts = None
         proc.sync_stmts.append(proc_if)
 

--- a/testfiles/tb/buserr_axi4_tb.vhdl
+++ b/testfiles/tb/buserr_axi4_tb.vhdl
@@ -143,6 +143,68 @@ begin
     report "Testing erroneous read to write-only register" severity note;
     axi4lite_read(clk, rd_out, rd_in, x"0000_0010", v, C_AXI4_RESP_SLVERR);
 
+    --  Regression for issue #86: with bus-error enabled, RVALID must stay
+    --  asserted (with stable RDATA/RRESP) until RREADY is sampled high, and
+    --  must not be a one-cycle pulse.  The always-ready BFM above cannot catch
+    --  this, so drive RREADY low by hand for several cycles.
+    report "Testing read with delayed RREADY (issue #86)" severity note;
+    rd_out.araddr  <= x"0000_0000";
+    rd_out.arvalid <= '1';
+    rd_out.rready  <= '0';
+    wait until rising_edge(clk);
+    loop
+      if rd_in.arready = '1' then
+        rd_out.arvalid <= '0';
+      end if;
+      exit when rd_in.rvalid = '1';
+      wait until rising_edge(clk);
+    end loop;
+    for i in 0 to 4 loop
+      assert rd_in.rvalid = '1'
+        report "RVALID dropped before RREADY (issue #86)" severity error;
+      assert rd_in.rdata = x"1234_5678"
+        report "RDATA not stable while RVALID held (issue #86)" severity error;
+      assert rd_in.rresp = C_AXI4_RESP_OK
+        report "RRESP not stable while RVALID held (issue #86)" severity error;
+      wait until rising_edge(clk);
+    end loop;
+    rd_out.rready <= '1';
+    wait until rising_edge(clk);
+    rd_out.rready <= '0';
+
+    --  Regression for issue #86: BVALID must stay asserted (with stable BRESP)
+    --  until BREADY is sampled high.
+    report "Testing write with delayed BREADY (issue #86)" severity note;
+    wr_out.awaddr  <= x"0000_0008";
+    wr_out.wdata   <= x"cafe_babe";
+    wr_out.awvalid <= '1';
+    wr_out.wvalid  <= '1';
+    wr_out.bready  <= '0';
+    wait until rising_edge(clk);
+    loop
+      if wr_in.awready = '1' then
+        wr_out.awvalid <= '0';
+      end if;
+      if wr_in.wready = '1' then
+        wr_out.wvalid <= '0';
+      end if;
+      exit when wr_in.bvalid = '1';
+      wait until rising_edge(clk);
+    end loop;
+    for i in 0 to 4 loop
+      assert wr_in.bvalid = '1'
+        report "BVALID dropped before BREADY (issue #86)" severity error;
+      assert wr_in.bresp = C_AXI4_RESP_OK
+        report "BRESP not stable while BVALID held (issue #86)" severity error;
+      wait until rising_edge(clk);
+    end loop;
+    wr_out.bready <= '1';
+    wait until rising_edge(clk);
+    wr_out.bready <= '0';
+    assert reg_rw2 = x"cafe_babe"
+      report "write with delayed BREADY did not update the register (issue #86)"
+      severity error;
+
     wait until rising_edge(clk);
     wait until rising_edge(clk);
     report "End of test" severity note;

--- a/testfiles/tb/golden_files/buserr_axi4.vhdl
+++ b/testfiles/tb/golden_files/buserr_axi4.vhdl
@@ -84,20 +84,18 @@ begin
   -- AW, W and B channels
   awready <= not axi_awset;
   wready <= not axi_wset;
-  bvalid <= axi_wdone;
+  bvalid <= axi_wdone or not areset_n;
   process (aclk) begin
     if rising_edge(aclk) then
       if areset_n = '0' then
         wr_req <= '0';
         axi_awset <= '0';
         axi_wset <= '0';
-        -- During reset, accept all handshakes and return error
-        axi_wdone <= '1';
+        -- During reset, return error (BVALID is forced by the reset signal)
+        axi_wdone <= '0';
         axi_werr <= "10";
       else
         wr_req <= '0';
-        axi_wdone <= '0';
-        axi_werr <= "00";
         if awvalid = '1' and axi_awset = '0' then
           wr_addr <= awaddr;
           axi_awset <= '1';
@@ -111,6 +109,7 @@ begin
         if (axi_wdone and bready) = '1' then
           axi_wset <= '0';
           axi_awset <= '0';
+          axi_wdone <= '0';
         end if;
         if wr_ack = '1' then
           axi_wdone <= '1';
@@ -127,20 +126,18 @@ begin
 
   -- AR and R channels
   arready <= not axi_arset;
-  rvalid <= axi_rdone;
+  rvalid <= axi_rdone or not areset_n;
   process (aclk) begin
     if rising_edge(aclk) then
       if areset_n = '0' then
         rd_req <= '0';
         axi_arset <= '0';
-        -- During reset, accept all handshakes and return error
-        axi_rdone <= '1';
+        -- During reset, return error (RVALID is forced by the reset signal)
+        axi_rdone <= '0';
         axi_rerr <= "10";
         rdata <= (others => '0');
       else
         rd_req <= '0';
-        axi_rdone <= '0';
-        axi_rerr <= "00";
         if arvalid = '1' and axi_arset = '0' then
           rd_addr <= araddr;
           axi_arset <= '1';
@@ -148,6 +145,7 @@ begin
         end if;
         if (axi_rdone and rready) = '1' then
           axi_arset <= '0';
+          axi_rdone <= '0';
         end if;
         if rd_ack = '1' then
           axi_rdone <= '1';


### PR DESCRIPTION
## Summary

Fixes #86.

With `bus-error` enabled, the AXI4-Lite write and read response channels made `BVALID`/`RVALID` a **one-cycle pulse** and could **deadlock** the slave:

- The sync process cleared `axi_wdone`/`axi_rdone` unconditionally every cycle, and the clear-on-handshake was gated behind `if not opts.bus_error`, so it was dropped.
- `BVALID`/`RVALID` therefore asserted for a single cycle after the internal ack, instead of being held until the master asserted `BREADY`/`RREADY` (AXI4-Lite A3.2.1).
- A master that was not immediately ready lost the response. And since `AWREADY`/`WREADY` (resp. `ARREADY`) are only re-asserted once the response is accepted (`axi_wdone & bready`), the slave then wedged permanently.

## Fix

Drive the handshake in bus-error mode exactly as without it:

- Hold `axi_wdone`/`axi_rdone` until the handshake (restore the clear on `VALID & READY`, remove the unconditional per-cycle clear).
- Register `BRESP`/`RRESP` (set on ack, held until accepted) so the response value is stable while `VALID` is high — the previous per-cycle reset of `axi_werr`/`axi_rerr` would otherwise change the response while `VALID` was held.

The existing reset-time behaviour is preserved: accesses issued while in reset are still completed with `SLVERR` rather than stalling. `BVALID`/`RVALID` are forced high from the reset signal during reset, so out of reset `VALID` reflects only a real, held response (no phantom response leaks past reset).

Non-bus-error output is unchanged.

## Testing

- `cd proto && python tests.py` — all generation tests pass (output unchanged except the bus-error golden).
- `testfiles/tb/buserr_axi4_tb.vhdl`: the existing testbench used an always-ready master, so it could never observe the pulse/deadlock. Extended it to hold `BREADY`/`RREADY` low for several cycles and assert that `VALID` stays high with stable `DATA`/`RESP`.
- Verified under GHDL:
  - Against **this** change: the full testbench (including the new delayed-ready cases) passes.
  - Against the **previous** generator output: the new assertions fail (`RVALID dropped before RREADY`), i.e. the test genuinely catches the bug.
