### PR TITLE
AXI4-Lite: drive rd_err/wr_err in memory decode to avoid a latch

### DIFF
--- a/proto/cheby/hdl/genmemory.py
+++ b/proto/cheby/hdl/genmemory.py
@@ -278,6 +278,10 @@ class GenMemory(ElGen):
         n = self.n
         reg = n.children[0]
         self.foreach_word(s, reg, ibus, gen_read_word)
+        # A memory access is always in range, so it never reports an address
+        # error.  Drive rd_err explicitly so the read decode has no branch that
+        # leaves it unassigned (which would infer a latch).
+        s.append(HDLAssign(ibus.rd_err, bit_0))
 
     def gen_write(self, s, off, ibus, wrproc):
         def gen_write_word(stmt, reg, i):
@@ -292,3 +296,7 @@ class GenMemory(ElGen):
             self.foreach_word(s, reg, ibus, gen_write_word)
         # Always ack the request, even if ignored.
         s.append(HDLAssign(ibus.wr_ack, ibus.wr_req))
+        # A memory access is always in range, so it never reports an address
+        # error.  Drive wr_err explicitly so the write decode has no branch that
+        # leaves it unassigned (which would infer a latch).
+        s.append(HDLAssign(ibus.wr_err, bit_0))

--- a/proto/cheby/hdl/srambus.py
+++ b/proto/cheby/hdl/srambus.py
@@ -96,6 +96,10 @@ class SRAMBus(BusGen):
         else:
             # Avoid deadlock (or latches)
             stmts.append(HDLAssign(ibus.wr_ack, ibus.wr_req))
+        # An SRAM access is always in range, so it never reports an address
+        # error.  Drive wr_err explicitly, otherwise the write decode leaves it
+        # unassigned in this branch and infers a latch (with bus-error enabled).
+        stmts.append(HDLAssign(ibus.wr_err, bit_0))
 
     def read_bus_slave(self, stmts, n, proc, ibus, rd_data):
         if n.c_bus_access in ('ro', 'rw'):
@@ -107,3 +111,7 @@ class SRAMBus(BusGen):
         else:
             # Avoid deadlock (or latches)
             stmts.append(HDLAssign(ibus.rd_ack, ibus.rd_req))
+        # An SRAM access is always in range, so it never reports an address
+        # error.  Drive rd_err explicitly, otherwise the read decode leaves it
+        # unassigned in this branch and infers a latch (with bus-error enabled).
+        stmts.append(HDLAssign(ibus.rd_err, bit_0))

--- a/proto/tests.py
+++ b/proto/tests.py
@@ -460,6 +460,7 @@ def test_hdl_ref():
               'features/blkprefix4', 'features/blkprefix5',
               'features/regprefix1', 'features/regprefix2', 'features/regprefix3',
               'features/mem64ro', 'features/mem64rodual',
+              'features/buserr_mem_int', 'features/buserr_mem_sram',
               'features/iogroup1', 'features/iogroup2', 'features/repeat-iogroup1',
               'features/repeat-iogroup2', 'features/repeat-iogroup3',
               'features/repeat-iogroup4', 'features/nested-iogroup1',

--- a/testfiles/features/buserr_mem_int.cheby
+++ b/testfiles/features/buserr_mem_int.cheby
@@ -1,0 +1,19 @@
+memory-map:
+  bus: axi4-lite-32
+  name: buserr_mem_int
+  description: Internal (dpssram) memory together with bus-error enabled.  Regression for the memory-decode latch (issue #87) - the memory branch of the read/write decode must drive rd_err/wr_err so no latch is inferred.
+  x-hdl:
+    bus-error: True
+  children:
+    - reg:
+        name: scratch
+        width: 32
+        access: rw
+    - memory:
+        name: lut
+        memsize: 128
+        children:
+          - reg:
+              name: value
+              width: 32
+              access: rw

--- a/testfiles/features/buserr_mem_int.sv
+++ b/testfiles/features/buserr_mem_int.sv
@@ -1,0 +1,327 @@
+
+module buserr_mem_int
+  (
+    input   wire aclk,
+    input   wire areset_n,
+    input   wire awvalid,
+    output  wire awready,
+    input   wire [7:2] awaddr,
+    input   wire [2:0] awprot,
+    input   wire wvalid,
+    output  wire wready,
+    input   wire [31:0] wdata,
+    input   wire [3:0] wstrb,
+    output  wire bvalid,
+    input   wire bready,
+    output  wire [1:0] bresp,
+    input   wire arvalid,
+    output  wire arready,
+    input   wire [7:2] araddr,
+    input   wire [2:0] arprot,
+    output  wire rvalid,
+    input   wire rready,
+    output  reg [31:0] rdata,
+    output  wire [1:0] rresp,
+
+    // REG scratch
+    output  wire [31:0] scratch_o,
+
+    // RAM port for lut
+    input   wire [4:0] lut_adr_i,
+    input   wire lut_value_rd_i,
+    output  wire [31:0] lut_value_dat_o
+  );
+  reg wr_req;
+  reg wr_ack;
+  reg wr_err;
+  reg [7:2] wr_addr;
+  reg [31:0] wr_data;
+  reg [31:0] wr_sel;
+  reg axi_awset;
+  reg axi_wset;
+  reg axi_wdone;
+  reg [1:0] axi_werr;
+  reg rd_req;
+  reg rd_ack;
+  reg rd_err;
+  reg [7:2] rd_addr;
+  reg [31:0] rd_data;
+  reg axi_arset;
+  reg axi_rdone;
+  reg [1:0] axi_rerr;
+  reg [31:0] scratch_reg;
+  reg scratch_wreq;
+  wire scratch_wack;
+  wire [31:0] lut_value_int_dato;
+  wire [31:0] lut_value_ext_dat;
+  reg lut_value_rreq;
+  reg lut_value_rack;
+  reg lut_value_int_wr;
+  reg rd_ack_d0;
+  reg rd_err_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [7:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+  reg [31:0] wr_sel_d0;
+  wire lut_wr;
+  wire lut_wreq;
+  reg [4:0] lut_adr_int;
+  reg [3:0] lut_sel_int;
+
+  // AW, W and B channels
+  assign awready = ~axi_awset;
+  assign wready = ~axi_wset;
+  assign bvalid = axi_wdone | ~areset_n;
+  always_ff @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        wr_req <= 1'b0;
+        axi_awset <= 1'b0;
+        axi_wset <= 1'b0;
+        // During reset, return error (BVALID is forced by the reset signal)
+        axi_wdone <= 1'b0;
+        axi_werr <= 2'b10;
+      end
+    else
+      begin
+        wr_req <= 1'b0;
+        if (awvalid == 1'b1 & axi_awset == 1'b0)
+          begin
+            wr_addr <= awaddr;
+            axi_awset <= 1'b1;
+            wr_req <= axi_wset;
+          end
+        if (wvalid == 1'b1 & axi_wset == 1'b0)
+          begin
+            wr_data <= wdata;
+            wr_sel[7:0] <= {8{wstrb[0]}};
+            wr_sel[15:8] <= {8{wstrb[1]}};
+            wr_sel[23:16] <= {8{wstrb[2]}};
+            wr_sel[31:24] <= {8{wstrb[3]}};
+            axi_wset <= 1'b1;
+            wr_req <= axi_awset | awvalid;
+          end
+        if ((axi_wdone & bready) == 1'b1)
+          begin
+            axi_wset <= 1'b0;
+            axi_awset <= 1'b0;
+            axi_wdone <= 1'b0;
+          end
+        if (wr_ack == 1'b1)
+          begin
+            axi_wdone <= 1'b1;
+            if (wr_err == 1'b0)
+              axi_werr <= 2'b00;
+            else
+              axi_werr <= 2'b10;
+          end
+      end
+  end
+  assign bresp = axi_werr;
+
+  // AR and R channels
+  assign arready = ~axi_arset;
+  assign rvalid = axi_rdone | ~areset_n;
+  always_ff @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        rd_req <= 1'b0;
+        axi_arset <= 1'b0;
+        // During reset, return error (RVALID is forced by the reset signal)
+        axi_rdone <= 1'b0;
+        axi_rerr <= 2'b10;
+        rdata <= 32'b0;
+      end
+    else
+      begin
+        rd_req <= 1'b0;
+        if (arvalid == 1'b1 & axi_arset == 1'b0)
+          begin
+            rd_addr <= araddr;
+            axi_arset <= 1'b1;
+            rd_req <= 1'b1;
+          end
+        if ((axi_rdone & rready) == 1'b1)
+          begin
+            axi_arset <= 1'b0;
+            axi_rdone <= 1'b0;
+          end
+        if (rd_ack == 1'b1)
+          begin
+            axi_rdone <= 1'b1;
+            rdata <= rd_data;
+            if (rd_err == 1'b0)
+              axi_rerr <= 2'b00;
+            else
+              axi_rerr <= 2'b10;
+          end
+      end
+  end
+  assign rresp = axi_rerr;
+
+  // pipelining for wr-in+rd-out
+  always_ff @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        rd_ack <= 1'b0;
+        rd_err <= 1'b0;
+        rd_data <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 6'b000000;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+        wr_sel_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack <= rd_ack_d0;
+        rd_err <= rd_err_d0;
+        rd_data <= rd_dat_d0;
+        wr_req_d0 <= wr_req;
+        wr_adr_d0 <= wr_addr;
+        wr_dat_d0 <= wr_data;
+        wr_sel_d0 <= wr_sel;
+      end
+  end
+
+  // Register scratch
+  assign scratch_o = scratch_reg;
+  assign scratch_wack = scratch_wreq;
+  always_ff @(posedge(aclk))
+  begin
+    if (!areset_n)
+      scratch_reg <= 32'b00000000000000000000000000000000;
+    else
+      if (scratch_wreq == 1'b1)
+        scratch_reg <= wr_dat_d0;
+  end
+
+  // Memory lut
+  always_comb
+  if (lut_wr == 1'b1)
+    lut_adr_int = wr_adr_d0[6:2];
+  else
+    lut_adr_int = rd_addr[6:2];
+  assign lut_wreq = lut_value_int_wr;
+  assign lut_wr = lut_wreq;
+  cheby_dpssram #(
+      .g_data_width(32),
+      .g_size(32),
+      .g_addr_width(5),
+      .g_dual_clock(1'b0),
+      .g_use_bwsel(1'b1)
+    )
+  lut_value_raminst (
+      .clk_a_i(aclk),
+      .clk_b_i(aclk),
+      .addr_a_i(lut_adr_int),
+      .bwsel_a_i(lut_sel_int),
+      .data_a_i(wr_dat_d0),
+      .data_a_o(lut_value_int_dato),
+      .rd_a_i(lut_value_rreq),
+      .wr_a_i(lut_value_int_wr),
+      .addr_b_i(lut_adr_i),
+      .bwsel_b_i({4{1'b1}}),
+      .data_b_i(lut_value_ext_dat),
+      .data_b_o(lut_value_dat_o),
+      .rd_b_i(lut_value_rd_i),
+      .wr_b_i(1'b0)
+    );
+  
+  always_comb
+  begin
+    lut_sel_int = 4'b0;
+    if (~(wr_sel_d0[7:0] == 8'b0))
+      lut_sel_int[0] = 1'b1;
+    if (~(wr_sel_d0[15:8] == 8'b0))
+      lut_sel_int[1] = 1'b1;
+    if (~(wr_sel_d0[23:16] == 8'b0))
+      lut_sel_int[2] = 1'b1;
+    if (~(wr_sel_d0[31:24] == 8'b0))
+      lut_sel_int[3] = 1'b1;
+  end
+  always_ff @(posedge(aclk))
+  begin
+    if (!areset_n)
+      lut_value_rack <= 1'b0;
+    else
+      lut_value_rack <= (lut_value_rreq & ~lut_wreq) & ~lut_value_rack;
+  end
+
+  // Process for write requests.
+  always_comb
+  begin
+    scratch_wreq = 1'b0;
+    lut_value_int_wr = 1'b0;
+    case (wr_adr_d0[7:7])
+    1'b0:
+      case (wr_adr_d0[6:2])
+      5'b00000:
+        begin
+          // Reg scratch
+          scratch_wreq = wr_req_d0;
+          wr_ack = scratch_wack;
+          wr_err = 1'b0;
+        end
+      default:
+        begin
+          wr_ack = wr_req_d0;
+          wr_err = wr_req_d0;
+        end
+      endcase
+    1'b1:
+      begin
+        // Memory lut
+        lut_value_int_wr = wr_req_d0;
+        wr_ack = wr_req_d0;
+        wr_err = 1'b0;
+      end
+    default:
+      begin
+        wr_ack = wr_req_d0;
+        wr_err = wr_req_d0;
+      end
+    endcase
+  end
+
+  // Process for read requests.
+  always_comb
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    lut_value_rreq = 1'b0;
+    case (rd_addr[7:7])
+    1'b0:
+      case (rd_addr[6:2])
+      5'b00000:
+        begin
+          // Reg scratch
+          rd_ack_d0 = rd_req;
+          rd_err_d0 = 1'b0;
+          rd_dat_d0 = scratch_reg;
+        end
+      default:
+        begin
+          rd_ack_d0 = rd_req;
+          rd_err_d0 = rd_req;
+        end
+      endcase
+    1'b1:
+      begin
+        // Memory lut
+        rd_dat_d0 = lut_value_int_dato;
+        lut_value_rreq = rd_req & ~lut_wreq;
+        rd_ack_d0 = lut_value_rack;
+        rd_err_d0 = 1'b0;
+      end
+    default:
+      begin
+        rd_ack_d0 = rd_req;
+        rd_err_d0 = rd_req;
+      end
+    endcase
+  end
+endmodule

--- a/testfiles/features/buserr_mem_int.v
+++ b/testfiles/features/buserr_mem_int.v
@@ -1,0 +1,327 @@
+
+module buserr_mem_int
+  (
+    input   wire aclk,
+    input   wire areset_n,
+    input   wire awvalid,
+    output  wire awready,
+    input   wire [7:2] awaddr,
+    input   wire [2:0] awprot,
+    input   wire wvalid,
+    output  wire wready,
+    input   wire [31:0] wdata,
+    input   wire [3:0] wstrb,
+    output  wire bvalid,
+    input   wire bready,
+    output  wire [1:0] bresp,
+    input   wire arvalid,
+    output  wire arready,
+    input   wire [7:2] araddr,
+    input   wire [2:0] arprot,
+    output  wire rvalid,
+    input   wire rready,
+    output  reg [31:0] rdata,
+    output  wire [1:0] rresp,
+
+    // REG scratch
+    output  wire [31:0] scratch_o,
+
+    // RAM port for lut
+    input   wire [4:0] lut_adr_i,
+    input   wire lut_value_rd_i,
+    output  wire [31:0] lut_value_dat_o
+  );
+  reg wr_req;
+  reg wr_ack;
+  reg wr_err;
+  reg [7:2] wr_addr;
+  reg [31:0] wr_data;
+  reg [31:0] wr_sel;
+  reg axi_awset;
+  reg axi_wset;
+  reg axi_wdone;
+  reg [1:0] axi_werr;
+  reg rd_req;
+  reg rd_ack;
+  reg rd_err;
+  reg [7:2] rd_addr;
+  reg [31:0] rd_data;
+  reg axi_arset;
+  reg axi_rdone;
+  reg [1:0] axi_rerr;
+  reg [31:0] scratch_reg;
+  reg scratch_wreq;
+  wire scratch_wack;
+  wire [31:0] lut_value_int_dato;
+  wire [31:0] lut_value_ext_dat;
+  reg lut_value_rreq;
+  reg lut_value_rack;
+  reg lut_value_int_wr;
+  reg rd_ack_d0;
+  reg rd_err_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [7:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+  reg [31:0] wr_sel_d0;
+  wire lut_wr;
+  wire lut_wreq;
+  reg [4:0] lut_adr_int;
+  reg [3:0] lut_sel_int;
+
+  // AW, W and B channels
+  assign awready = ~axi_awset;
+  assign wready = ~axi_wset;
+  assign bvalid = axi_wdone | ~areset_n;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        wr_req <= 1'b0;
+        axi_awset <= 1'b0;
+        axi_wset <= 1'b0;
+        // During reset, return error (BVALID is forced by the reset signal)
+        axi_wdone <= 1'b0;
+        axi_werr <= 2'b10;
+      end
+    else
+      begin
+        wr_req <= 1'b0;
+        if (awvalid == 1'b1 & axi_awset == 1'b0)
+          begin
+            wr_addr <= awaddr;
+            axi_awset <= 1'b1;
+            wr_req <= axi_wset;
+          end
+        if (wvalid == 1'b1 & axi_wset == 1'b0)
+          begin
+            wr_data <= wdata;
+            wr_sel[7:0] <= {8{wstrb[0]}};
+            wr_sel[15:8] <= {8{wstrb[1]}};
+            wr_sel[23:16] <= {8{wstrb[2]}};
+            wr_sel[31:24] <= {8{wstrb[3]}};
+            axi_wset <= 1'b1;
+            wr_req <= axi_awset | awvalid;
+          end
+        if ((axi_wdone & bready) == 1'b1)
+          begin
+            axi_wset <= 1'b0;
+            axi_awset <= 1'b0;
+            axi_wdone <= 1'b0;
+          end
+        if (wr_ack == 1'b1)
+          begin
+            axi_wdone <= 1'b1;
+            if (wr_err == 1'b0)
+              axi_werr <= 2'b00;
+            else
+              axi_werr <= 2'b10;
+          end
+      end
+  end
+  assign bresp = axi_werr;
+
+  // AR and R channels
+  assign arready = ~axi_arset;
+  assign rvalid = axi_rdone | ~areset_n;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        rd_req <= 1'b0;
+        axi_arset <= 1'b0;
+        // During reset, return error (RVALID is forced by the reset signal)
+        axi_rdone <= 1'b0;
+        axi_rerr <= 2'b10;
+        rdata <= 32'b0;
+      end
+    else
+      begin
+        rd_req <= 1'b0;
+        if (arvalid == 1'b1 & axi_arset == 1'b0)
+          begin
+            rd_addr <= araddr;
+            axi_arset <= 1'b1;
+            rd_req <= 1'b1;
+          end
+        if ((axi_rdone & rready) == 1'b1)
+          begin
+            axi_arset <= 1'b0;
+            axi_rdone <= 1'b0;
+          end
+        if (rd_ack == 1'b1)
+          begin
+            axi_rdone <= 1'b1;
+            rdata <= rd_data;
+            if (rd_err == 1'b0)
+              axi_rerr <= 2'b00;
+            else
+              axi_rerr <= 2'b10;
+          end
+      end
+  end
+  assign rresp = axi_rerr;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        rd_ack <= 1'b0;
+        rd_err <= 1'b0;
+        rd_data <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 6'b000000;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+        wr_sel_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack <= rd_ack_d0;
+        rd_err <= rd_err_d0;
+        rd_data <= rd_dat_d0;
+        wr_req_d0 <= wr_req;
+        wr_adr_d0 <= wr_addr;
+        wr_dat_d0 <= wr_data;
+        wr_sel_d0 <= wr_sel;
+      end
+  end
+
+  // Register scratch
+  assign scratch_o = scratch_reg;
+  assign scratch_wack = scratch_wreq;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      scratch_reg <= 32'b00000000000000000000000000000000;
+    else
+      if (scratch_wreq == 1'b1)
+        scratch_reg <= wr_dat_d0;
+  end
+
+  // Memory lut
+  always @(rd_addr, wr_adr_d0, lut_wr)
+  if (lut_wr == 1'b1)
+    lut_adr_int = wr_adr_d0[6:2];
+  else
+    lut_adr_int = rd_addr[6:2];
+  assign lut_wreq = lut_value_int_wr;
+  assign lut_wr = lut_wreq;
+  cheby_dpssram #(
+      .g_data_width(32),
+      .g_size(32),
+      .g_addr_width(5),
+      .g_dual_clock(1'b0),
+      .g_use_bwsel(1'b1)
+    )
+  lut_value_raminst (
+      .clk_a_i(aclk),
+      .clk_b_i(aclk),
+      .addr_a_i(lut_adr_int),
+      .bwsel_a_i(lut_sel_int),
+      .data_a_i(wr_dat_d0),
+      .data_a_o(lut_value_int_dato),
+      .rd_a_i(lut_value_rreq),
+      .wr_a_i(lut_value_int_wr),
+      .addr_b_i(lut_adr_i),
+      .bwsel_b_i({4{1'b1}}),
+      .data_b_i(lut_value_ext_dat),
+      .data_b_o(lut_value_dat_o),
+      .rd_b_i(lut_value_rd_i),
+      .wr_b_i(1'b0)
+    );
+  
+  always @(wr_sel_d0)
+  begin
+    lut_sel_int = 4'b0;
+    if (~(wr_sel_d0[7:0] == 8'b0))
+      lut_sel_int[0] = 1'b1;
+    if (~(wr_sel_d0[15:8] == 8'b0))
+      lut_sel_int[1] = 1'b1;
+    if (~(wr_sel_d0[23:16] == 8'b0))
+      lut_sel_int[2] = 1'b1;
+    if (~(wr_sel_d0[31:24] == 8'b0))
+      lut_sel_int[3] = 1'b1;
+  end
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      lut_value_rack <= 1'b0;
+    else
+      lut_value_rack <= (lut_value_rreq & ~lut_wreq) & ~lut_value_rack;
+  end
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, scratch_wack)
+  begin
+    scratch_wreq = 1'b0;
+    lut_value_int_wr = 1'b0;
+    case (wr_adr_d0[7:7])
+    1'b0:
+      case (wr_adr_d0[6:2])
+      5'b00000:
+        begin
+          // Reg scratch
+          scratch_wreq = wr_req_d0;
+          wr_ack = scratch_wack;
+          wr_err = 1'b0;
+        end
+      default:
+        begin
+          wr_ack = wr_req_d0;
+          wr_err = wr_req_d0;
+        end
+      endcase
+    1'b1:
+      begin
+        // Memory lut
+        lut_value_int_wr = wr_req_d0;
+        wr_ack = wr_req_d0;
+        wr_err = 1'b0;
+      end
+    default:
+      begin
+        wr_ack = wr_req_d0;
+        wr_err = wr_req_d0;
+      end
+    endcase
+  end
+
+  // Process for read requests.
+  always @(rd_addr, rd_req, scratch_reg, lut_value_int_dato, lut_wreq, lut_value_rack)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    lut_value_rreq = 1'b0;
+    case (rd_addr[7:7])
+    1'b0:
+      case (rd_addr[6:2])
+      5'b00000:
+        begin
+          // Reg scratch
+          rd_ack_d0 = rd_req;
+          rd_err_d0 = 1'b0;
+          rd_dat_d0 = scratch_reg;
+        end
+      default:
+        begin
+          rd_ack_d0 = rd_req;
+          rd_err_d0 = rd_req;
+        end
+      endcase
+    1'b1:
+      begin
+        // Memory lut
+        rd_dat_d0 = lut_value_int_dato;
+        lut_value_rreq = rd_req & ~lut_wreq;
+        rd_ack_d0 = lut_value_rack;
+        rd_err_d0 = 1'b0;
+      end
+    default:
+      begin
+        rd_ack_d0 = rd_req;
+        rd_err_d0 = rd_req;
+      end
+    endcase
+  end
+endmodule

--- a/testfiles/features/buserr_mem_int.vhdl
+++ b/testfiles/features/buserr_mem_int.vhdl
@@ -1,0 +1,318 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+use work.cheby_pkg.all;
+
+entity buserr_mem_int is
+  port (
+    aclk                 : in    std_logic;
+    areset_n             : in    std_logic;
+    awvalid              : in    std_logic;
+    awready              : out   std_logic;
+    awaddr               : in    std_logic_vector(7 downto 2);
+    awprot               : in    std_logic_vector(2 downto 0);
+    wvalid               : in    std_logic;
+    wready               : out   std_logic;
+    wdata                : in    std_logic_vector(31 downto 0);
+    wstrb                : in    std_logic_vector(3 downto 0);
+    bvalid               : out   std_logic;
+    bready               : in    std_logic;
+    bresp                : out   std_logic_vector(1 downto 0);
+    arvalid              : in    std_logic;
+    arready              : out   std_logic;
+    araddr               : in    std_logic_vector(7 downto 2);
+    arprot               : in    std_logic_vector(2 downto 0);
+    rvalid               : out   std_logic;
+    rready               : in    std_logic;
+    rdata                : out   std_logic_vector(31 downto 0);
+    rresp                : out   std_logic_vector(1 downto 0);
+
+    -- REG scratch
+    scratch_o            : out   std_logic_vector(31 downto 0);
+
+    -- RAM port for lut
+    lut_adr_i            : in    std_logic_vector(4 downto 0);
+    lut_value_rd_i       : in    std_logic;
+    lut_value_dat_o      : out   std_logic_vector(31 downto 0)
+  );
+end buserr_mem_int;
+
+architecture syn of buserr_mem_int is
+  signal wr_req                         : std_logic;
+  signal wr_ack                         : std_logic;
+  signal wr_err                         : std_logic;
+  signal wr_addr                        : std_logic_vector(7 downto 2);
+  signal wr_data                        : std_logic_vector(31 downto 0);
+  signal wr_sel                         : std_logic_vector(31 downto 0);
+  signal axi_awset                      : std_logic;
+  signal axi_wset                       : std_logic;
+  signal axi_wdone                      : std_logic;
+  signal axi_werr                       : std_logic_vector(1 downto 0);
+  signal rd_req                         : std_logic;
+  signal rd_ack                         : std_logic;
+  signal rd_err                         : std_logic;
+  signal rd_addr                        : std_logic_vector(7 downto 2);
+  signal rd_data                        : std_logic_vector(31 downto 0);
+  signal axi_arset                      : std_logic;
+  signal axi_rdone                      : std_logic;
+  signal axi_rerr                       : std_logic_vector(1 downto 0);
+  signal scratch_reg                    : std_logic_vector(31 downto 0);
+  signal scratch_wreq                   : std_logic;
+  signal scratch_wack                   : std_logic;
+  signal lut_value_int_dato             : std_logic_vector(31 downto 0);
+  signal lut_value_ext_dat              : std_logic_vector(31 downto 0);
+  signal lut_value_rreq                 : std_logic;
+  signal lut_value_rack                 : std_logic;
+  signal lut_value_int_wr               : std_logic;
+  signal rd_ack_d0                      : std_logic;
+  signal rd_err_d0                      : std_logic;
+  signal rd_dat_d0                      : std_logic_vector(31 downto 0);
+  signal wr_req_d0                      : std_logic;
+  signal wr_adr_d0                      : std_logic_vector(7 downto 2);
+  signal wr_dat_d0                      : std_logic_vector(31 downto 0);
+  signal wr_sel_d0                      : std_logic_vector(31 downto 0);
+  signal lut_wr                         : std_logic;
+  signal lut_wreq                       : std_logic;
+  signal lut_adr_int                    : std_logic_vector(4 downto 0);
+  signal lut_sel_int                    : std_logic_vector(3 downto 0);
+begin
+
+  -- AW, W and B channels
+  awready <= not axi_awset;
+  wready <= not axi_wset;
+  bvalid <= axi_wdone or not areset_n;
+  process (aclk) begin
+    if rising_edge(aclk) then
+      if areset_n = '0' then
+        wr_req <= '0';
+        axi_awset <= '0';
+        axi_wset <= '0';
+        -- During reset, return error (BVALID is forced by the reset signal)
+        axi_wdone <= '0';
+        axi_werr <= "10";
+      else
+        wr_req <= '0';
+        if awvalid = '1' and axi_awset = '0' then
+          wr_addr <= awaddr;
+          axi_awset <= '1';
+          wr_req <= axi_wset;
+        end if;
+        if wvalid = '1' and axi_wset = '0' then
+          wr_data <= wdata;
+          wr_sel(7 downto 0) <= (others => wstrb(0));
+          wr_sel(15 downto 8) <= (others => wstrb(1));
+          wr_sel(23 downto 16) <= (others => wstrb(2));
+          wr_sel(31 downto 24) <= (others => wstrb(3));
+          axi_wset <= '1';
+          wr_req <= axi_awset or awvalid;
+        end if;
+        if (axi_wdone and bready) = '1' then
+          axi_wset <= '0';
+          axi_awset <= '0';
+          axi_wdone <= '0';
+        end if;
+        if wr_ack = '1' then
+          axi_wdone <= '1';
+          if wr_err = '0' then
+            axi_werr <= "00";
+          else
+            axi_werr <= "10";
+          end if;
+        end if;
+      end if;
+    end if;
+  end process;
+  bresp <= axi_werr;
+
+  -- AR and R channels
+  arready <= not axi_arset;
+  rvalid <= axi_rdone or not areset_n;
+  process (aclk) begin
+    if rising_edge(aclk) then
+      if areset_n = '0' then
+        rd_req <= '0';
+        axi_arset <= '0';
+        -- During reset, return error (RVALID is forced by the reset signal)
+        axi_rdone <= '0';
+        axi_rerr <= "10";
+        rdata <= (others => '0');
+      else
+        rd_req <= '0';
+        if arvalid = '1' and axi_arset = '0' then
+          rd_addr <= araddr;
+          axi_arset <= '1';
+          rd_req <= '1';
+        end if;
+        if (axi_rdone and rready) = '1' then
+          axi_arset <= '0';
+          axi_rdone <= '0';
+        end if;
+        if rd_ack = '1' then
+          axi_rdone <= '1';
+          rdata <= rd_data;
+          if rd_err = '0' then
+            axi_rerr <= "00";
+          else
+            axi_rerr <= "10";
+          end if;
+        end if;
+      end if;
+    end if;
+  end process;
+  rresp <= axi_rerr;
+
+  -- pipelining for wr-in+rd-out
+  process (aclk) begin
+    if rising_edge(aclk) then
+      if areset_n = '0' then
+        rd_ack <= '0';
+        rd_err <= '0';
+        rd_data <= "00000000000000000000000000000000";
+        wr_req_d0 <= '0';
+        wr_adr_d0 <= "000000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
+        wr_sel_d0 <= "00000000000000000000000000000000";
+      else
+        rd_ack <= rd_ack_d0;
+        rd_err <= rd_err_d0;
+        rd_data <= rd_dat_d0;
+        wr_req_d0 <= wr_req;
+        wr_adr_d0 <= wr_addr;
+        wr_dat_d0 <= wr_data;
+        wr_sel_d0 <= wr_sel;
+      end if;
+    end if;
+  end process;
+
+  -- Register scratch
+  scratch_o <= scratch_reg;
+  scratch_wack <= scratch_wreq;
+  process (aclk) begin
+    if rising_edge(aclk) then
+      if areset_n = '0' then
+        scratch_reg <= "00000000000000000000000000000000";
+      else
+        if scratch_wreq = '1' then
+          scratch_reg <= wr_dat_d0;
+        end if;
+      end if;
+    end if;
+  end process;
+
+  -- Memory lut
+  process (rd_addr, wr_adr_d0, lut_wr) begin
+    if lut_wr = '1' then
+      lut_adr_int <= wr_adr_d0(6 downto 2);
+    else
+      lut_adr_int <= rd_addr(6 downto 2);
+    end if;
+  end process;
+  lut_wreq <= lut_value_int_wr;
+  lut_wr <= lut_wreq;
+  lut_value_raminst: cheby_dpssram
+    generic map (
+      g_data_width         => 32,
+      g_size               => 32,
+      g_addr_width         => 5,
+      g_dual_clock         => '0',
+      g_use_bwsel          => '1'
+    )
+    port map (
+      clk_a_i              => aclk,
+      clk_b_i              => aclk,
+      addr_a_i             => lut_adr_int,
+      bwsel_a_i            => lut_sel_int,
+      data_a_i             => wr_dat_d0,
+      data_a_o             => lut_value_int_dato,
+      rd_a_i               => lut_value_rreq,
+      wr_a_i               => lut_value_int_wr,
+      addr_b_i             => lut_adr_i,
+      bwsel_b_i            => (others => '1'),
+      data_b_i             => lut_value_ext_dat,
+      data_b_o             => lut_value_dat_o,
+      rd_b_i               => lut_value_rd_i,
+      wr_b_i               => '0'
+    );
+  
+  process (wr_sel_d0) begin
+    lut_sel_int <= (others => '0');
+    if not (wr_sel_d0(7 downto 0) = (7 downto 0 => '0')) then
+      lut_sel_int(0) <= '1';
+    end if;
+    if not (wr_sel_d0(15 downto 8) = (7 downto 0 => '0')) then
+      lut_sel_int(1) <= '1';
+    end if;
+    if not (wr_sel_d0(23 downto 16) = (7 downto 0 => '0')) then
+      lut_sel_int(2) <= '1';
+    end if;
+    if not (wr_sel_d0(31 downto 24) = (7 downto 0 => '0')) then
+      lut_sel_int(3) <= '1';
+    end if;
+  end process;
+  process (aclk) begin
+    if rising_edge(aclk) then
+      if areset_n = '0' then
+        lut_value_rack <= '0';
+      else
+        lut_value_rack <= (lut_value_rreq and not lut_wreq) and not lut_value_rack;
+      end if;
+    end if;
+  end process;
+
+  -- Process for write requests.
+  process (wr_adr_d0, wr_req_d0, scratch_wack) begin
+    scratch_wreq <= '0';
+    lut_value_int_wr <= '0';
+    case wr_adr_d0(7 downto 7) is
+    when "0" =>
+      case wr_adr_d0(6 downto 2) is
+      when "00000" =>
+        -- Reg scratch
+        scratch_wreq <= wr_req_d0;
+        wr_ack <= scratch_wack;
+        wr_err <= '0';
+      when others =>
+        wr_ack <= wr_req_d0;
+        wr_err <= wr_req_d0;
+      end case;
+    when "1" =>
+      -- Memory lut
+      lut_value_int_wr <= wr_req_d0;
+      wr_ack <= wr_req_d0;
+      wr_err <= '0';
+    when others =>
+      wr_ack <= wr_req_d0;
+      wr_err <= wr_req_d0;
+    end case;
+  end process;
+
+  -- Process for read requests.
+  process (rd_addr, rd_req, scratch_reg, lut_value_int_dato, lut_wreq,
+           lut_value_rack) begin
+    -- By default ack read requests
+    rd_dat_d0 <= (others => 'X');
+    lut_value_rreq <= '0';
+    case rd_addr(7 downto 7) is
+    when "0" =>
+      case rd_addr(6 downto 2) is
+      when "00000" =>
+        -- Reg scratch
+        rd_ack_d0 <= rd_req;
+        rd_err_d0 <= '0';
+        rd_dat_d0 <= scratch_reg;
+      when others =>
+        rd_ack_d0 <= rd_req;
+        rd_err_d0 <= rd_req;
+      end case;
+    when "1" =>
+      -- Memory lut
+      rd_dat_d0 <= lut_value_int_dato;
+      lut_value_rreq <= rd_req and not lut_wreq;
+      rd_ack_d0 <= lut_value_rack;
+      rd_err_d0 <= '0';
+    when others =>
+      rd_ack_d0 <= rd_req;
+      rd_err_d0 <= rd_req;
+    end case;
+  end process;
+end syn;

--- a/testfiles/features/buserr_mem_sram.cheby
+++ b/testfiles/features/buserr_mem_sram.cheby
@@ -1,0 +1,20 @@
+memory-map:
+  bus: axi4-lite-32
+  name: buserr_mem_sram
+  description: External SRAM-interface memory together with bus-error enabled.  Regression for the memory-decode latch (issue #87) - the SRAM branch of the read/write decode must drive rd_err/wr_err so no latch is inferred.
+  x-hdl:
+    bus-error: True
+  children:
+    - reg:
+        name: scratch
+        width: 32
+        access: rw
+    - memory:
+        name: lut
+        memsize: 128
+        interface: sram
+        children:
+          - reg:
+              name: value
+              width: 32
+              access: rw

--- a/testfiles/features/buserr_mem_sram.sv
+++ b/testfiles/features/buserr_mem_sram.sv
@@ -1,0 +1,286 @@
+
+module buserr_mem_sram
+  (
+    input   wire aclk,
+    input   wire areset_n,
+    input   wire awvalid,
+    output  wire awready,
+    input   wire [7:2] awaddr,
+    input   wire [2:0] awprot,
+    input   wire wvalid,
+    output  wire wready,
+    input   wire [31:0] wdata,
+    input   wire [3:0] wstrb,
+    output  wire bvalid,
+    input   wire bready,
+    output  wire [1:0] bresp,
+    input   wire arvalid,
+    output  wire arready,
+    input   wire [7:2] araddr,
+    input   wire [2:0] arprot,
+    output  wire rvalid,
+    input   wire rready,
+    output  reg [31:0] rdata,
+    output  wire [1:0] rresp,
+
+    // REG scratch
+    output  wire [31:0] scratch_o,
+
+    // SRAM bus lut
+    output  reg [6:2] lut_addr_o,
+    input   wire [31:0] lut_data_i,
+    output  wire [31:0] lut_data_o,
+    output  reg lut_wr_o
+  );
+  reg wr_req;
+  reg wr_ack;
+  reg wr_err;
+  reg [7:2] wr_addr;
+  reg [31:0] wr_data;
+  reg axi_awset;
+  reg axi_wset;
+  reg axi_wdone;
+  reg [1:0] axi_werr;
+  reg rd_req;
+  reg rd_ack;
+  reg rd_err;
+  reg [7:2] rd_addr;
+  reg [31:0] rd_data;
+  reg axi_arset;
+  reg axi_rdone;
+  reg [1:0] axi_rerr;
+  reg [31:0] scratch_reg;
+  reg scratch_wreq;
+  wire scratch_wack;
+  reg lut_rack;
+  reg lut_re;
+  reg rd_ack_d0;
+  reg rd_err_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [7:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+  reg lut_wp;
+  wire lut_we;
+
+  // AW, W and B channels
+  assign awready = ~axi_awset;
+  assign wready = ~axi_wset;
+  assign bvalid = axi_wdone | ~areset_n;
+  always_ff @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        wr_req <= 1'b0;
+        axi_awset <= 1'b0;
+        axi_wset <= 1'b0;
+        // During reset, return error (BVALID is forced by the reset signal)
+        axi_wdone <= 1'b0;
+        axi_werr <= 2'b10;
+      end
+    else
+      begin
+        wr_req <= 1'b0;
+        if (awvalid == 1'b1 & axi_awset == 1'b0)
+          begin
+            wr_addr <= awaddr;
+            axi_awset <= 1'b1;
+            wr_req <= axi_wset;
+          end
+        if (wvalid == 1'b1 & axi_wset == 1'b0)
+          begin
+            wr_data <= wdata;
+            axi_wset <= 1'b1;
+            wr_req <= axi_awset | awvalid;
+          end
+        if ((axi_wdone & bready) == 1'b1)
+          begin
+            axi_wset <= 1'b0;
+            axi_awset <= 1'b0;
+            axi_wdone <= 1'b0;
+          end
+        if (wr_ack == 1'b1)
+          begin
+            axi_wdone <= 1'b1;
+            if (wr_err == 1'b0)
+              axi_werr <= 2'b00;
+            else
+              axi_werr <= 2'b10;
+          end
+      end
+  end
+  assign bresp = axi_werr;
+
+  // AR and R channels
+  assign arready = ~axi_arset;
+  assign rvalid = axi_rdone | ~areset_n;
+  always_ff @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        rd_req <= 1'b0;
+        axi_arset <= 1'b0;
+        // During reset, return error (RVALID is forced by the reset signal)
+        axi_rdone <= 1'b0;
+        axi_rerr <= 2'b10;
+        rdata <= 32'b0;
+      end
+    else
+      begin
+        rd_req <= 1'b0;
+        if (arvalid == 1'b1 & axi_arset == 1'b0)
+          begin
+            rd_addr <= araddr;
+            axi_arset <= 1'b1;
+            rd_req <= 1'b1;
+          end
+        if ((axi_rdone & rready) == 1'b1)
+          begin
+            axi_arset <= 1'b0;
+            axi_rdone <= 1'b0;
+          end
+        if (rd_ack == 1'b1)
+          begin
+            axi_rdone <= 1'b1;
+            rdata <= rd_data;
+            if (rd_err == 1'b0)
+              axi_rerr <= 2'b00;
+            else
+              axi_rerr <= 2'b10;
+          end
+      end
+  end
+  assign rresp = axi_rerr;
+
+  // pipelining for wr-in+rd-out
+  always_ff @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        rd_ack <= 1'b0;
+        rd_err <= 1'b0;
+        rd_data <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 6'b000000;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack <= rd_ack_d0;
+        rd_err <= rd_err_d0;
+        rd_data <= rd_dat_d0;
+        wr_req_d0 <= wr_req;
+        wr_adr_d0 <= wr_addr;
+        wr_dat_d0 <= wr_data;
+      end
+  end
+
+  // Register scratch
+  assign scratch_o = scratch_reg;
+  assign scratch_wack = scratch_wreq;
+  always_ff @(posedge(aclk))
+  begin
+    if (!areset_n)
+      scratch_reg <= 32'b00000000000000000000000000000000;
+    else
+      if (scratch_wreq == 1'b1)
+        scratch_reg <= wr_dat_d0;
+  end
+
+  // Interface lut
+  always_ff @(posedge(aclk))
+  begin
+    if (!areset_n)
+      lut_rack <= 1'b0;
+    else
+      lut_rack <= lut_re & ~lut_rack;
+  end
+  assign lut_data_o = wr_dat_d0;
+  always_ff @(posedge(aclk))
+  begin
+    if (!areset_n)
+      lut_wp <= 1'b0;
+    else
+      lut_wp <= (wr_req_d0 | lut_wp) & rd_req;
+  end
+  assign lut_we = (wr_req_d0 | lut_wp) & ~rd_req;
+  always_comb
+  if (lut_re == 1'b1)
+    lut_addr_o = rd_addr[6:2];
+  else
+    lut_addr_o = wr_adr_d0[6:2];
+
+  // Process for write requests.
+  always_comb
+  begin
+    scratch_wreq = 1'b0;
+    lut_wr_o = 1'b0;
+    case (wr_adr_d0[7:7])
+    1'b0:
+      case (wr_adr_d0[6:2])
+      5'b00000:
+        begin
+          // Reg scratch
+          scratch_wreq = wr_req_d0;
+          wr_ack = scratch_wack;
+          wr_err = 1'b0;
+        end
+      default:
+        begin
+          wr_ack = wr_req_d0;
+          wr_err = wr_req_d0;
+        end
+      endcase
+    1'b1:
+      begin
+        // Memory lut
+        lut_wr_o = lut_we;
+        wr_ack = lut_we;
+        wr_err = 1'b0;
+      end
+    default:
+      begin
+        wr_ack = wr_req_d0;
+        wr_err = wr_req_d0;
+      end
+    endcase
+  end
+
+  // Process for read requests.
+  always_comb
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    lut_re = 1'b0;
+    case (rd_addr[7:7])
+    1'b0:
+      case (rd_addr[6:2])
+      5'b00000:
+        begin
+          // Reg scratch
+          rd_ack_d0 = rd_req;
+          rd_err_d0 = 1'b0;
+          rd_dat_d0 = scratch_reg;
+        end
+      default:
+        begin
+          rd_ack_d0 = rd_req;
+          rd_err_d0 = rd_req;
+        end
+      endcase
+    1'b1:
+      begin
+        // Memory lut
+        rd_dat_d0 = lut_data_i;
+        rd_ack_d0 = lut_rack;
+        lut_re = rd_req;
+        rd_err_d0 = 1'b0;
+      end
+    default:
+      begin
+        rd_ack_d0 = rd_req;
+        rd_err_d0 = rd_req;
+      end
+    endcase
+  end
+endmodule

--- a/testfiles/features/buserr_mem_sram.v
+++ b/testfiles/features/buserr_mem_sram.v
@@ -1,0 +1,286 @@
+
+module buserr_mem_sram
+  (
+    input   wire aclk,
+    input   wire areset_n,
+    input   wire awvalid,
+    output  wire awready,
+    input   wire [7:2] awaddr,
+    input   wire [2:0] awprot,
+    input   wire wvalid,
+    output  wire wready,
+    input   wire [31:0] wdata,
+    input   wire [3:0] wstrb,
+    output  wire bvalid,
+    input   wire bready,
+    output  wire [1:0] bresp,
+    input   wire arvalid,
+    output  wire arready,
+    input   wire [7:2] araddr,
+    input   wire [2:0] arprot,
+    output  wire rvalid,
+    input   wire rready,
+    output  reg [31:0] rdata,
+    output  wire [1:0] rresp,
+
+    // REG scratch
+    output  wire [31:0] scratch_o,
+
+    // SRAM bus lut
+    output  reg [6:2] lut_addr_o,
+    input   wire [31:0] lut_data_i,
+    output  wire [31:0] lut_data_o,
+    output  reg lut_wr_o
+  );
+  reg wr_req;
+  reg wr_ack;
+  reg wr_err;
+  reg [7:2] wr_addr;
+  reg [31:0] wr_data;
+  reg axi_awset;
+  reg axi_wset;
+  reg axi_wdone;
+  reg [1:0] axi_werr;
+  reg rd_req;
+  reg rd_ack;
+  reg rd_err;
+  reg [7:2] rd_addr;
+  reg [31:0] rd_data;
+  reg axi_arset;
+  reg axi_rdone;
+  reg [1:0] axi_rerr;
+  reg [31:0] scratch_reg;
+  reg scratch_wreq;
+  wire scratch_wack;
+  reg lut_rack;
+  reg lut_re;
+  reg rd_ack_d0;
+  reg rd_err_d0;
+  reg [31:0] rd_dat_d0;
+  reg wr_req_d0;
+  reg [7:2] wr_adr_d0;
+  reg [31:0] wr_dat_d0;
+  reg lut_wp;
+  wire lut_we;
+
+  // AW, W and B channels
+  assign awready = ~axi_awset;
+  assign wready = ~axi_wset;
+  assign bvalid = axi_wdone | ~areset_n;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        wr_req <= 1'b0;
+        axi_awset <= 1'b0;
+        axi_wset <= 1'b0;
+        // During reset, return error (BVALID is forced by the reset signal)
+        axi_wdone <= 1'b0;
+        axi_werr <= 2'b10;
+      end
+    else
+      begin
+        wr_req <= 1'b0;
+        if (awvalid == 1'b1 & axi_awset == 1'b0)
+          begin
+            wr_addr <= awaddr;
+            axi_awset <= 1'b1;
+            wr_req <= axi_wset;
+          end
+        if (wvalid == 1'b1 & axi_wset == 1'b0)
+          begin
+            wr_data <= wdata;
+            axi_wset <= 1'b1;
+            wr_req <= axi_awset | awvalid;
+          end
+        if ((axi_wdone & bready) == 1'b1)
+          begin
+            axi_wset <= 1'b0;
+            axi_awset <= 1'b0;
+            axi_wdone <= 1'b0;
+          end
+        if (wr_ack == 1'b1)
+          begin
+            axi_wdone <= 1'b1;
+            if (wr_err == 1'b0)
+              axi_werr <= 2'b00;
+            else
+              axi_werr <= 2'b10;
+          end
+      end
+  end
+  assign bresp = axi_werr;
+
+  // AR and R channels
+  assign arready = ~axi_arset;
+  assign rvalid = axi_rdone | ~areset_n;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        rd_req <= 1'b0;
+        axi_arset <= 1'b0;
+        // During reset, return error (RVALID is forced by the reset signal)
+        axi_rdone <= 1'b0;
+        axi_rerr <= 2'b10;
+        rdata <= 32'b0;
+      end
+    else
+      begin
+        rd_req <= 1'b0;
+        if (arvalid == 1'b1 & axi_arset == 1'b0)
+          begin
+            rd_addr <= araddr;
+            axi_arset <= 1'b1;
+            rd_req <= 1'b1;
+          end
+        if ((axi_rdone & rready) == 1'b1)
+          begin
+            axi_arset <= 1'b0;
+            axi_rdone <= 1'b0;
+          end
+        if (rd_ack == 1'b1)
+          begin
+            axi_rdone <= 1'b1;
+            rdata <= rd_data;
+            if (rd_err == 1'b0)
+              axi_rerr <= 2'b00;
+            else
+              axi_rerr <= 2'b10;
+          end
+      end
+  end
+  assign rresp = axi_rerr;
+
+  // pipelining for wr-in+rd-out
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      begin
+        rd_ack <= 1'b0;
+        rd_err <= 1'b0;
+        rd_data <= 32'b00000000000000000000000000000000;
+        wr_req_d0 <= 1'b0;
+        wr_adr_d0 <= 6'b000000;
+        wr_dat_d0 <= 32'b00000000000000000000000000000000;
+      end
+    else
+      begin
+        rd_ack <= rd_ack_d0;
+        rd_err <= rd_err_d0;
+        rd_data <= rd_dat_d0;
+        wr_req_d0 <= wr_req;
+        wr_adr_d0 <= wr_addr;
+        wr_dat_d0 <= wr_data;
+      end
+  end
+
+  // Register scratch
+  assign scratch_o = scratch_reg;
+  assign scratch_wack = scratch_wreq;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      scratch_reg <= 32'b00000000000000000000000000000000;
+    else
+      if (scratch_wreq == 1'b1)
+        scratch_reg <= wr_dat_d0;
+  end
+
+  // Interface lut
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      lut_rack <= 1'b0;
+    else
+      lut_rack <= lut_re & ~lut_rack;
+  end
+  assign lut_data_o = wr_dat_d0;
+  always @(posedge(aclk))
+  begin
+    if (!areset_n)
+      lut_wp <= 1'b0;
+    else
+      lut_wp <= (wr_req_d0 | lut_wp) & rd_req;
+  end
+  assign lut_we = (wr_req_d0 | lut_wp) & ~rd_req;
+  always @(rd_addr, wr_adr_d0, lut_re)
+  if (lut_re == 1'b1)
+    lut_addr_o = rd_addr[6:2];
+  else
+    lut_addr_o = wr_adr_d0[6:2];
+
+  // Process for write requests.
+  always @(wr_adr_d0, wr_req_d0, scratch_wack, lut_we)
+  begin
+    scratch_wreq = 1'b0;
+    lut_wr_o = 1'b0;
+    case (wr_adr_d0[7:7])
+    1'b0:
+      case (wr_adr_d0[6:2])
+      5'b00000:
+        begin
+          // Reg scratch
+          scratch_wreq = wr_req_d0;
+          wr_ack = scratch_wack;
+          wr_err = 1'b0;
+        end
+      default:
+        begin
+          wr_ack = wr_req_d0;
+          wr_err = wr_req_d0;
+        end
+      endcase
+    1'b1:
+      begin
+        // Memory lut
+        lut_wr_o = lut_we;
+        wr_ack = lut_we;
+        wr_err = 1'b0;
+      end
+    default:
+      begin
+        wr_ack = wr_req_d0;
+        wr_err = wr_req_d0;
+      end
+    endcase
+  end
+
+  // Process for read requests.
+  always @(rd_addr, rd_req, scratch_reg, lut_data_i, lut_rack)
+  begin
+    // By default ack read requests
+    rd_dat_d0 = {32{1'bx}};
+    lut_re = 1'b0;
+    case (rd_addr[7:7])
+    1'b0:
+      case (rd_addr[6:2])
+      5'b00000:
+        begin
+          // Reg scratch
+          rd_ack_d0 = rd_req;
+          rd_err_d0 = 1'b0;
+          rd_dat_d0 = scratch_reg;
+        end
+      default:
+        begin
+          rd_ack_d0 = rd_req;
+          rd_err_d0 = rd_req;
+        end
+      endcase
+    1'b1:
+      begin
+        // Memory lut
+        rd_dat_d0 = lut_data_i;
+        rd_ack_d0 = lut_rack;
+        lut_re = rd_req;
+        rd_err_d0 = 1'b0;
+      end
+    default:
+      begin
+        rd_ack_d0 = rd_req;
+        rd_err_d0 = rd_req;
+      end
+    endcase
+  end
+endmodule

--- a/testfiles/features/buserr_mem_sram.vhdl
+++ b/testfiles/features/buserr_mem_sram.vhdl
@@ -1,0 +1,273 @@
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity buserr_mem_sram is
+  port (
+    aclk                 : in    std_logic;
+    areset_n             : in    std_logic;
+    awvalid              : in    std_logic;
+    awready              : out   std_logic;
+    awaddr               : in    std_logic_vector(7 downto 2);
+    awprot               : in    std_logic_vector(2 downto 0);
+    wvalid               : in    std_logic;
+    wready               : out   std_logic;
+    wdata                : in    std_logic_vector(31 downto 0);
+    wstrb                : in    std_logic_vector(3 downto 0);
+    bvalid               : out   std_logic;
+    bready               : in    std_logic;
+    bresp                : out   std_logic_vector(1 downto 0);
+    arvalid              : in    std_logic;
+    arready              : out   std_logic;
+    araddr               : in    std_logic_vector(7 downto 2);
+    arprot               : in    std_logic_vector(2 downto 0);
+    rvalid               : out   std_logic;
+    rready               : in    std_logic;
+    rdata                : out   std_logic_vector(31 downto 0);
+    rresp                : out   std_logic_vector(1 downto 0);
+
+    -- REG scratch
+    scratch_o            : out   std_logic_vector(31 downto 0);
+
+    -- SRAM bus lut
+    lut_addr_o           : out   std_logic_vector(6 downto 2);
+    lut_data_i           : in    std_logic_vector(31 downto 0);
+    lut_data_o           : out   std_logic_vector(31 downto 0);
+    lut_wr_o             : out   std_logic
+  );
+end buserr_mem_sram;
+
+architecture syn of buserr_mem_sram is
+  signal wr_req                         : std_logic;
+  signal wr_ack                         : std_logic;
+  signal wr_err                         : std_logic;
+  signal wr_addr                        : std_logic_vector(7 downto 2);
+  signal wr_data                        : std_logic_vector(31 downto 0);
+  signal axi_awset                      : std_logic;
+  signal axi_wset                       : std_logic;
+  signal axi_wdone                      : std_logic;
+  signal axi_werr                       : std_logic_vector(1 downto 0);
+  signal rd_req                         : std_logic;
+  signal rd_ack                         : std_logic;
+  signal rd_err                         : std_logic;
+  signal rd_addr                        : std_logic_vector(7 downto 2);
+  signal rd_data                        : std_logic_vector(31 downto 0);
+  signal axi_arset                      : std_logic;
+  signal axi_rdone                      : std_logic;
+  signal axi_rerr                       : std_logic_vector(1 downto 0);
+  signal scratch_reg                    : std_logic_vector(31 downto 0);
+  signal scratch_wreq                   : std_logic;
+  signal scratch_wack                   : std_logic;
+  signal lut_rack                       : std_logic;
+  signal lut_re                         : std_logic;
+  signal rd_ack_d0                      : std_logic;
+  signal rd_err_d0                      : std_logic;
+  signal rd_dat_d0                      : std_logic_vector(31 downto 0);
+  signal wr_req_d0                      : std_logic;
+  signal wr_adr_d0                      : std_logic_vector(7 downto 2);
+  signal wr_dat_d0                      : std_logic_vector(31 downto 0);
+  signal lut_wp                         : std_logic;
+  signal lut_we                         : std_logic;
+begin
+
+  -- AW, W and B channels
+  awready <= not axi_awset;
+  wready <= not axi_wset;
+  bvalid <= axi_wdone or not areset_n;
+  process (aclk) begin
+    if rising_edge(aclk) then
+      if areset_n = '0' then
+        wr_req <= '0';
+        axi_awset <= '0';
+        axi_wset <= '0';
+        -- During reset, return error (BVALID is forced by the reset signal)
+        axi_wdone <= '0';
+        axi_werr <= "10";
+      else
+        wr_req <= '0';
+        if awvalid = '1' and axi_awset = '0' then
+          wr_addr <= awaddr;
+          axi_awset <= '1';
+          wr_req <= axi_wset;
+        end if;
+        if wvalid = '1' and axi_wset = '0' then
+          wr_data <= wdata;
+          axi_wset <= '1';
+          wr_req <= axi_awset or awvalid;
+        end if;
+        if (axi_wdone and bready) = '1' then
+          axi_wset <= '0';
+          axi_awset <= '0';
+          axi_wdone <= '0';
+        end if;
+        if wr_ack = '1' then
+          axi_wdone <= '1';
+          if wr_err = '0' then
+            axi_werr <= "00";
+          else
+            axi_werr <= "10";
+          end if;
+        end if;
+      end if;
+    end if;
+  end process;
+  bresp <= axi_werr;
+
+  -- AR and R channels
+  arready <= not axi_arset;
+  rvalid <= axi_rdone or not areset_n;
+  process (aclk) begin
+    if rising_edge(aclk) then
+      if areset_n = '0' then
+        rd_req <= '0';
+        axi_arset <= '0';
+        -- During reset, return error (RVALID is forced by the reset signal)
+        axi_rdone <= '0';
+        axi_rerr <= "10";
+        rdata <= (others => '0');
+      else
+        rd_req <= '0';
+        if arvalid = '1' and axi_arset = '0' then
+          rd_addr <= araddr;
+          axi_arset <= '1';
+          rd_req <= '1';
+        end if;
+        if (axi_rdone and rready) = '1' then
+          axi_arset <= '0';
+          axi_rdone <= '0';
+        end if;
+        if rd_ack = '1' then
+          axi_rdone <= '1';
+          rdata <= rd_data;
+          if rd_err = '0' then
+            axi_rerr <= "00";
+          else
+            axi_rerr <= "10";
+          end if;
+        end if;
+      end if;
+    end if;
+  end process;
+  rresp <= axi_rerr;
+
+  -- pipelining for wr-in+rd-out
+  process (aclk) begin
+    if rising_edge(aclk) then
+      if areset_n = '0' then
+        rd_ack <= '0';
+        rd_err <= '0';
+        rd_data <= "00000000000000000000000000000000";
+        wr_req_d0 <= '0';
+        wr_adr_d0 <= "000000";
+        wr_dat_d0 <= "00000000000000000000000000000000";
+      else
+        rd_ack <= rd_ack_d0;
+        rd_err <= rd_err_d0;
+        rd_data <= rd_dat_d0;
+        wr_req_d0 <= wr_req;
+        wr_adr_d0 <= wr_addr;
+        wr_dat_d0 <= wr_data;
+      end if;
+    end if;
+  end process;
+
+  -- Register scratch
+  scratch_o <= scratch_reg;
+  scratch_wack <= scratch_wreq;
+  process (aclk) begin
+    if rising_edge(aclk) then
+      if areset_n = '0' then
+        scratch_reg <= "00000000000000000000000000000000";
+      else
+        if scratch_wreq = '1' then
+          scratch_reg <= wr_dat_d0;
+        end if;
+      end if;
+    end if;
+  end process;
+
+  -- Interface lut
+  process (aclk) begin
+    if rising_edge(aclk) then
+      if areset_n = '0' then
+        lut_rack <= '0';
+      else
+        lut_rack <= lut_re and not lut_rack;
+      end if;
+    end if;
+  end process;
+  lut_data_o <= wr_dat_d0;
+  process (aclk) begin
+    if rising_edge(aclk) then
+      if areset_n = '0' then
+        lut_wp <= '0';
+      else
+        lut_wp <= (wr_req_d0 or lut_wp) and rd_req;
+      end if;
+    end if;
+  end process;
+  lut_we <= (wr_req_d0 or lut_wp) and not rd_req;
+  process (rd_addr, wr_adr_d0, lut_re) begin
+    if lut_re = '1' then
+      lut_addr_o <= rd_addr(6 downto 2);
+    else
+      lut_addr_o <= wr_adr_d0(6 downto 2);
+    end if;
+  end process;
+
+  -- Process for write requests.
+  process (wr_adr_d0, wr_req_d0, scratch_wack, lut_we) begin
+    scratch_wreq <= '0';
+    lut_wr_o <= '0';
+    case wr_adr_d0(7 downto 7) is
+    when "0" =>
+      case wr_adr_d0(6 downto 2) is
+      when "00000" =>
+        -- Reg scratch
+        scratch_wreq <= wr_req_d0;
+        wr_ack <= scratch_wack;
+        wr_err <= '0';
+      when others =>
+        wr_ack <= wr_req_d0;
+        wr_err <= wr_req_d0;
+      end case;
+    when "1" =>
+      -- Memory lut
+      lut_wr_o <= lut_we;
+      wr_ack <= lut_we;
+      wr_err <= '0';
+    when others =>
+      wr_ack <= wr_req_d0;
+      wr_err <= wr_req_d0;
+    end case;
+  end process;
+
+  -- Process for read requests.
+  process (rd_addr, rd_req, scratch_reg, lut_data_i, lut_rack) begin
+    -- By default ack read requests
+    rd_dat_d0 <= (others => 'X');
+    lut_re <= '0';
+    case rd_addr(7 downto 7) is
+    when "0" =>
+      case rd_addr(6 downto 2) is
+      when "00000" =>
+        -- Reg scratch
+        rd_ack_d0 <= rd_req;
+        rd_err_d0 <= '0';
+        rd_dat_d0 <= scratch_reg;
+      when others =>
+        rd_ack_d0 <= rd_req;
+        rd_err_d0 <= rd_req;
+      end case;
+    when "1" =>
+      -- Memory lut
+      rd_dat_d0 <= lut_data_i;
+      rd_ack_d0 <= lut_rack;
+      lut_re <= rd_req;
+      rd_err_d0 <= '0';
+    when others =>
+      rd_ack_d0 <= rd_req;
+      rd_err_d0 <= rd_req;
+    end case;
+  end process;
+end syn;


### PR DESCRIPTION
## Summary

Fixes #87.

With `bus-error` enabled, the combinational read/write address decoder drives `rd_err`/`wr_err` in every register branch and in the default (unmapped) branch, but the **memory branch drove only the ack**. The decoder has no default for the error signal, so a `memory:` node left `rd_err`/`wr_err` unassigned in its branch and inferred a **latch** that held the error from the previously decoded access.

A register-only map never showed this, because every register branch already assigns the error — which is why it slipped through.

## Fix

A memory access is always in range, so it never reports an address error: drive the error to `0` explicitly in the memory branch. This covers both memory paths:

- `genmemory.py` — internal (dpssram) memories.
- `srambus.py` — external `interface: sram` memories (both the `read_bus_slave`/`write_bus_slave` active and fallback branches).

## Testing

- `cd proto && python tests.py` — all generation tests pass.
- Added two generation reference tests exercising a `memory:` node with `bus-error` enabled (there were none before — the gap that let this ship):
  - `features/buserr_mem_int` — internal dpssram memory.
  - `features/buserr_mem_sram` — external SRAM-interface memory.
- Mutation-checked: reverting the two generator changes makes `tests.py` fail on these references (the memory branch has no `err` assignment), confirming the tests catch the regression. Both DUTs also analyze cleanly under GHDL.
